### PR TITLE
Fixed #195: prevent redis from saving data to disk

### DIFF
--- a/worker/app/operations/run_redis.py
+++ b/worker/app/operations/run_redis.py
@@ -31,7 +31,7 @@ class RunRedis(Operation):
                         container.remove()
 
                 self.docker.images.pull('redis', tag='latest')
-                self.docker.containers.run('redis', detach=True, name=self.container_name)
+                self.docker.containers.run('redis', command='redis-server --save "" --appendonly no', detach=True, name=self.container_name)
             except docker.errors.APIError:
                 retries -= 1
                 sleep(3)


### PR DESCRIPTION
Simple fix to #195 : passing those args to command line prevent redis from writing to disk.