### PR TITLE
Removed Initializer.create_database_indexes() from main.py

### DIFF
--- a/dispatcher/backend/src/main.py
+++ b/dispatcher/backend/src/main.py
@@ -19,7 +19,6 @@ errors.register_handlers(flask)
 
 
 if __name__ == "__main__":
-    Initializer.create_database_indexes()
     Initializer.create_initial_user()
 
     is_debug = os.getenv('DEBUG', False)


### PR DESCRIPTION
main.py can't start as it is calling a method that has been removed in 8d9c607dc93b

