### PR TITLE
Fixed #206: mwoffliner called without quotes on parameters

### DIFF
--- a/worker/app/operations/run_mwoffliner.py
+++ b/worker/app/operations/run_mwoffliner.py
@@ -51,7 +51,7 @@ class RunMWOffliner(Operation):
                 params.append('--{name}'.format(name=key))
             elif isinstance(value, list):
                 for item in value:
-                    params.append('--{name}={value}'.format(name=key, value=item))
+                    params.append('--{name}="{value}"'.format(name=key, value=item))
             else:
-                params.append('--{name}={value}'.format(name=key, value=value))
+                params.append('--{name}="{value}"'.format(name=key, value=value))
         return 'mwoffliner {}'.format(' '.join(params))


### PR DESCRIPTION
## Rationale

Issue: #206 

## Changes

Added quotes to `=` parameters. Works with all `mwoffiner` params.
