### PR TITLE
task revoked events

### DIFF
--- a/dispatcher/backend/src/common/entities.py
+++ b/dispatcher/backend/src/common/entities.py
@@ -3,11 +3,15 @@ class TaskStatus:
     received = 'received'
     started = 'started'
     succeeded = 'succeeded'
+    container_started = 'container_started'
+    container_finished = 'container_finished'
     failed = 'failed'
+    retried = 'retried'
+    revoked = 'revoked'
 
     @classmethod
     def all(cls):
-        return [cls.sent, cls.received, cls.started, cls.succeeded, cls.failed]
+        return [cls.sent, cls.received, cls.started, cls.succeeded, cls.failed, cls.retried, cls.revoked]
 
 
 class ScheduleCategory:

--- a/dispatcher/monitor/app/entities.py
+++ b/dispatcher/monitor/app/entities.py
@@ -7,3 +7,4 @@ class TaskEvent:
     container_finished = 'container_finished'
     failed = 'failed'
     retried = 'retried'
+    revoked = 'revoked'

--- a/dispatcher/monitor/app/handlers/tasks.py
+++ b/dispatcher/monitor/app/handlers/tasks.py
@@ -173,6 +173,19 @@ class TaskRetriedEventHandler(BaseTaskEventHandler):
                         exception=task.exception, traceback=task.traceback)
 
 
+class TaskRevokedEventHandler(BaseTaskEventHandler):
+    def __call__(self, event):
+        task = super().__call__(event)
+        task_id = self.get_task_id(task)
+
+        terminated = event.get('terminated')
+        signum = event.get('signum')
+
+        logger.info(f'Task Revoked: {task_id}, terminated: {terminated}, signum: {signum}')
+
+        self.save_event(task_id, TaskEvent.revoked, self.get_timestamp(task))
+
+
 class TaskContainerStartedEventHandler(BaseTaskEventHandler):
     def __call__(self, event):
         task_id = self.get_task_id_from_event(event)

--- a/dispatcher/monitor/app/monitor.py
+++ b/dispatcher/monitor/app/monitor.py
@@ -29,6 +29,7 @@ class Monitor:
                 'task-succeeded': task_handlers.TaskSucceededEventHandler(),
                 'task-failed': task_handlers.TaskFailedEventHandler(),
                 'task-retried': task_handlers.TaskRetriedEventHandler(),
+                'task-revoked': task_handlers.TaskRevokedEventHandler(),
                 'task-container_started': task_handlers.TaskContainerStartedEventHandler(),
                 'task-container_finished': task_handlers.TaskContainerFinishedEventHandler(),
                 '*': self.handle_others}


### PR DESCRIPTION
## Rationale

[//]: # (Briefly explain the reason behind this change.)

Save revoked events to mongo and update TaskStatus/Events enum on `backend` and `monitor` container.

<!--
Issue: [Title](link) or #123 for Github issues.
-->

## Changes

- updated TaskStatus enum, the mongo document validator is updated to include extra values as a side effect
- added revoked event support to monitor

[//]: # (Summarize what has changed.)
