### PR TITLE
Worker shutdown and improvements

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -7,6 +7,9 @@ RUN pip3 install -r requirements.txt
 
 COPY app app
 
+RUN adduser --disabled-password --gecos "" celery_runner
+RUN usermod -aG root celery_runner
+
 ENV USERNAME username
 ENV PASSWORD password
 ENV NODE_NAME default_node_name

--- a/worker/app/utils/settings.py
+++ b/worker/app/utils/settings.py
@@ -110,7 +110,8 @@ class Settings:
             'WAREHOUSE_PORT': cls.warehouse_port,
             'WORKING_DIR': cls.working_dir_host,
             'NODE_NAME': cls.node_name,
-            'QUEUES': cls.queues
+            'QUEUES': cls.queues,
+            'CONCURRENCY': cls.concurrency
         }
 
         for name, value in variables.items():

--- a/worker/app/utils/settings.py
+++ b/worker/app/utils/settings.py
@@ -24,7 +24,6 @@ class Settings:
     working_dir_host: str = os.getenv('WORKING_DIR', None)
     working_dir_container: str = '/zim_files'
     private_key: str = '/usr/src/.ssh/id_rsa'
-    redis_name: str = os.getenv('REDIS_NAME', 'zimfarm_redis')
 
     docker_socket: str = '/var/run/docker.sock'
 

--- a/worker/app/worker.py
+++ b/worker/app/worker.py
@@ -65,6 +65,7 @@ class Worker:
         # start celery
         app.worker_main([
             'worker',
+            '--uid', 'celery_runner',
             '--hostname', '{}@{}'.format(Settings.username, Settings.node_name),
             '--queues', Settings.queues,
             '--loglevel', 'info'


### PR DESCRIPTION
## Rationale

This PR is aiming at addressing a few (sometimes annoying) issue of zimfarm worker.

1. Clean up when stopping zimfarm worker container:
the worker container will terminate all outstanding mwoffliner and Redis containers when receive `TERM` signal (sent by docker when using `docker stop`). Note the task will be marked as failed and will not be re-queued to another worker at the moment.  cc @kelson42 

2. Celery is run using a separate user:
No more `Celery is running as root, this is absolutely not recommend` messages.

3. One Redis per MWOffliner
MWOffliners no longer share one single Redis container, now each of them get their own Redis.

4. [Minor] now logs concurrency during start up.


<!--
Issue: [Title](link) or #123 for Github issues.
-->