### PR TITLE
Fixed #76: phet tasks for worker

### DIFF
--- a/dispatcher/backend/src/routes/schedules/validators.py
+++ b/dispatcher/backend/src/routes/schedules/validators.py
@@ -1,6 +1,14 @@
 import trafaret as t
 
 
+class ConfigValidator(t.Dict):
+
+    def check(self, config, *args, **kwargs):
+        super(ConfigValidator, self).check(config, *args, **kwargs)
+        flags_validator = get_flags_validator(config.get("task_name"))
+        return flags_validator.check(config.get("flags"))
+
+
 mwoffliner_flags_validator = t.Dict({
     t.Key('mwUrl'): t.URL,
     t.Key('adminEmail'): t.Email,
@@ -31,15 +39,26 @@ mwoffliner_flags_validator = t.Dict({
     t.Key('getCategories', optional=True): t.Bool,
 })
 
+phet_flags_validator = t.Dict()
 
-config_validator = t.Dict({
-    t.Key('task_name'): t.Enum('offliner.mwoffliner'),
+config_validator = ConfigValidator({
+    t.Key('task_name'): t.Enum('offliner.mwoffliner', 'offliner.phet'),
     t.Key('queue'): t.Enum('small', 'medium', 'large', 'debug'),
     t.Key('warehouse_path'): t.Enum(
-        '/wikipedia', '/other', '/psiram', '/vikidia', '/wikibooks', '/wikinews',
-        '/wikiquote', '/wikisource', '/wikiversity', '/wikivoyage', '/wiktionary'),
+        '/gutenberg', '/other', '/phet', '/psiram', 'stack_exchange',
+        '/ted', '/vikidia', '/wikibooks', '/wikinews', '/wikipedia',
+        '/wikiquote', '/wikisource', '/wikispecies', '/wikiversity',
+        '/wikivoyage', '/wiktionary'),
     t.Key('image'): t.Dict(
-        t.Key('name', trafaret=t.Enum('openzim/mwoffliner')),
+        t.Key('name', trafaret=t.Enum('openzim/mwoffliner', 'openzim/phet')),
         t.Key('tag', trafaret=t.String)),
-    t.Key('flags'): mwoffliner_flags_validator
+    t.Key('flags'): t.Or(mwoffliner_flags_validator, phet_flags_validator),
 })
+
+
+def get_flags_validator(task_name):
+    if task_name == "offliner.phet":
+        return phet_flags_validator
+    if task_name == "offliner.mwoffliner":
+        return mwoffliner_flags_validator
+    return t.Dict()

--- a/dispatcher/backend/src/routes/schedules/validators.py
+++ b/dispatcher/backend/src/routes/schedules/validators.py
@@ -45,7 +45,7 @@ config_validator = ConfigValidator({
     t.Key('task_name'): t.Enum('offliner.mwoffliner', 'offliner.phet'),
     t.Key('queue'): t.Enum('small', 'medium', 'large', 'debug'),
     t.Key('warehouse_path'): t.Enum(
-        '/gutenberg', '/other', '/phet', '/psiram', 'stack_exchange',
+        '/gutenberg', '/other', '/phet', '/psiram', '/stack_exchange',
         '/ted', '/vikidia', '/wikibooks', '/wikinews', '/wikipedia',
         '/wikiquote', '/wikisource', '/wikispecies', '/wikiversity',
         '/wikivoyage', '/wiktionary'),

--- a/worker/app/operations/__init__.py
+++ b/worker/app/operations/__init__.py
@@ -1,3 +1,4 @@
 from .run_redis import RunRedis
 from .run_mwoffliner import RunMWOffliner
+from .run_phet import RunPhet
 from .upload import Upload

--- a/worker/app/operations/run_phet.py
+++ b/worker/app/operations/run_phet.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from docker import DockerClient
+from docker.models.containers import Container
+
+from .base import Operation, ContainerResult
+
+from celery.utils.log import get_task_logger
+logger = get_task_logger(__name__)
+
+class RunPhet(Operation):
+    """Run Phet container with `config`"""
+
+    def __init__(self, docker_client: DockerClient, tag: str, flags: {}, task_id: str, working_dir_host: str):
+        tag = 'latest' if not tag else tag
+        super().__init__()
+        self.docker = docker_client
+        self.command = self._get_command(flags)
+        self.task_id = task_id
+        self.working_dir_host = Path(working_dir_host).joinpath(self.task_id).absolute()
+        self.image_name = 'openzim/phet:{}'.format(tag)
+
+    def execute(self) -> ContainerResult:
+        """Pull and run phet"""
+
+        # pull phet image
+        self.docker.images.pull(self.image_name)
+
+        # run phet
+        volumes = {self.working_dir_host: {'bind': '/phet/dist', 'mode': 'rw'}}
+        container: Container = self.docker.containers.run(
+            image=self.image_name, command=self.command, volumes=volumes, detach=True,
+            name='phet_{}'.format(self.task_id))
+
+        exit_code = container.wait()['StatusCode']
+        stdout = container.logs(stdout=True, stderr=False, tail=100).decode("utf-8")
+        stderr = container.logs(stdout=False, stderr=True).decode("utf-8")
+        result = ContainerResult(self.image_name, self.command, exit_code, stdout, stderr)
+
+        container.remove()
+
+        return result
+
+    @staticmethod
+    def _get_command(flags: {}):
+        return '/bin/bash -c "cd /phet && npm i && npm start"'

--- a/worker/app/tasks/__init__.py
+++ b/worker/app/tasks/__init__.py
@@ -1,1 +1,2 @@
 from .mwoffliner import MWOffliner
+from .phet import Phet

--- a/worker/app/tasks/phet.py
+++ b/worker/app/tasks/phet.py
@@ -1,0 +1,63 @@
+from pathlib import Path
+
+import docker
+import docker.errors
+from celery.utils.log import get_task_logger
+
+from operations import RunPhet, Upload
+from utils import Settings
+from .base import Base
+
+logger = get_task_logger(__name__)
+
+
+class Phet(Base):
+    """Phet zimfarm task. This task have two steps:
+
+    - generate zim files using phet (for all languages at once)
+    - upload generated zim files
+
+    Steps will be executed one after another.
+    """
+
+    name = 'offliner.phet'
+
+    def run(self, flags: dict, image: dict, warehouse_path: str, *args, **kwargs):
+        """Run Phet based offliner tasks.
+
+        :param flags: offliner flags (phet has none)
+        :param image: offliner image name and tag
+        :param warehouse_path: folder to upload files into
+        :return:
+        """
+
+        image_tag = image.get('tag', 'latest')
+        working_dir_container = Path(Settings.working_dir_container).joinpath(self.task_id)
+
+        try:
+            # run phet
+            run_phet = RunPhet(
+                docker_client=docker.from_env(), tag=image_tag, flags=flags,
+                task_id=self.task_id, working_dir_host=Settings.working_dir_host)
+            logger.info(f'Running Phet')
+            logger.debug(f'Running Phet, command: {run_phet.command}')
+            self.send_event('task-container_started', image=image, command=run_phet.command)
+
+            result = run_phet.execute()
+            logger.info(f'Phet finished, exit code: {result.exit_code}')
+            self.send_event('task-container_finished', exit_code=result.exit_code, stdout=result.stdout, stderr=result.stderr)
+
+            if not result.is_successful():
+                raise Exception(str(result))
+
+            # upload files
+            files, files_description = self.get_files(working_dir_container)
+            logger.info(f'Uploading files, {files_description}')
+            upload = Upload(remote_working_dir=warehouse_path, working_dir=working_dir_container)
+            upload.execute()
+
+            return files
+        except docker.errors.APIError as e:
+            raise self.retry(exc=e)
+        except (docker.errors.ContainerError, docker.errors.ImageNotFound) as e:
+            raise Exception from e

--- a/worker/app/worker.py
+++ b/worker/app/worker.py
@@ -35,6 +35,7 @@ class Worker:
 
         # register tasks
         app.register_task(tasks.MWOffliner())
+        app.register_task(tasks.Phet())
 
         # configure queues
         exchange = Exchange('offliner', 'topic')


### PR DESCRIPTION
## Rationale

We need to run additional offliners, starting with phet (#76).
phet is peculiar in that it requires no flags and has no language neither (all languages are built from that same call).

⚠️ the `openzim/phet` container is not working at the moment. For this reason, I've scheduled it in `debug` until this is solved (openzim/phet#48).

Here's the schedule:
```py
{'_id': '5ce29aee874217f83eb2af13',
 'category': 'phet',
 'config': {'flags': {},
            'image': {'name': 'openzim/phet', 'tag': 'latest'},
            'queue': 'debug',
            'task_name': 'offliner.phet',
            'warehouse_path': '/phet'},
 'enabled': True,
 'language': {'code': 'multi',
              'name_en': 'Multiple Languages',
              'name_native': 'Multiple Languages'},
 'most_recent_task': {'_id': '5ce2e8ebf8c0af00205ce80d',
                      'status': 'succeeded',
                      'updated_at': '2019-05-20T17:50:52.784000Z'},
 'name': 'phet_multi',
 'tags': 'multi'}
```

## Changes

Using similar structure as for MWOffliner:
- A task launching a phet container then uploading files
- An operation to pull and start the phet container

Adapted validators as there flags is not tied to mwoffliner anymore.
Added some tests.

Worth nothing that while flags are now validated based on the requested task
all other fields are flexible (image, for instance).
We shall discuss how much we want to enforce rules on config.