### PR TITLE
[API] Additional filtering options for schedules 

### DIFF
--- a/dispatcher/backend/src/routes/schedules/schedule.py
+++ b/dispatcher/backend/src/routes/schedules/schedule.py
@@ -42,8 +42,6 @@ class SchedulesRoute(BaseRoute):
         if name:
             query['name'] = {'$regex': r".*{}.*".format(name), '$options': 'i'}
 
-        print(query)
-
         # get schedules from database
         projection = {
             '_id': 1,

--- a/dispatcher/backend/src/routes/schedules/schedule.py
+++ b/dispatcher/backend/src/routes/schedules/schedule.py
@@ -27,11 +27,22 @@ class SchedulesRoute(BaseRoute):
         skip = 0 if skip < 0 else skip
         limit = 20 if limit <= 0 else limit
         categories = request.args.getlist('category')
+        tags = request.args.getlist('tag')
+        lang = request.args.get('lang')
+        name = request.args.get('name')
 
         # assemble filters
-        filter = {}
+        query = {}
         if categories:
-            filter['category'] = {'$in': categories}
+            query['category'] = {'$in': categories}
+        if lang:
+            query['language.code'] = lang
+        if tags:
+            query['tags'] = {'$all': tags}
+        if name:
+            query['name'] = {'$regex': r".*{}.*".format(name), '$options': 'i'}
+
+        print(query)
 
         # get schedules from database
         projection = {
@@ -44,7 +55,8 @@ class SchedulesRoute(BaseRoute):
             'most_recent_task': 1,
             'tags': 1
         }
-        cursor = Schedules().find(filter, projection).skip(skip).limit(limit)
+        cursor = Schedules().find(query, projection).skip(skip).limit(limit)
+        count = Schedules().count_documents(query)
         schedules = [schedule for schedule in cursor]
 
         # task this month
@@ -61,6 +73,7 @@ class SchedulesRoute(BaseRoute):
             'meta': {
                 'skip': skip,
                 'limit': limit,
+                'count': count,
             },
             'items': schedules
         })

--- a/dispatcher/backend/src/tests/integration/routes/conftest.py
+++ b/dispatcher/backend/src/tests/integration/routes/conftest.py
@@ -93,11 +93,13 @@ def schedules(make_schedule, make_beat_crontab, make_language):
     schedules.append(make_schedule(name="wikipedia_fr_all_maxi"))
     schedules.append(make_schedule(name="wikipedia_fr_all_nopic"))
     schedules.append(make_schedule(name="wikipedia_bm_all_nopic"))
-    schedules.append(make_schedule(language=make_language(code="fr")))
-    schedules.append(make_schedule(language=make_language(code="bm")))
-    schedules.append(make_schedule(category="phet"))
-    schedules.append(make_schedule(category="wikibooks"))
-    schedules.append(make_schedule(tags=["all"]))
-    schedules.append(make_schedule(tags=["all", "mini"]))
-    schedules.append(make_schedule(tags=["mini", "nopic"]))
+    schedules.append(make_schedule(language=make_language(code="fr"),
+                                   name="schedule_43"))
+    schedules.append(make_schedule(language=make_language(code="bm"),
+                                   name="schedule_44"))
+    schedules.append(make_schedule(category="phet", name="schedule_45"))
+    schedules.append(make_schedule(category="wikibooks", name="schedule_46"))
+    schedules.append(make_schedule(tags=["all"], name="schedule_47"))
+    schedules.append(make_schedule(tags=["all", "mini"], name="schedule_48"))
+    schedules.append(make_schedule(tags=["mini", "nopic"], name="schedule_49"))
     return schedules

--- a/dispatcher/backend/src/tests/integration/routes/conftest.py
+++ b/dispatcher/backend/src/tests/integration/routes/conftest.py
@@ -55,15 +55,16 @@ def make_schedule(database, make_beat_crontab, make_language, make_config):
     schedule_ids = []
 
     def _make_schedule(name: str = 'schedule_name', category: str = 'wikipedia',
-                       beat: dict = None, config: dict = None) -> dict:
+                       beat: dict = None, tags: list = ['nopic'],
+                       language: dict = None, config: dict = None) -> dict:
         document = {
             '_id': ObjectId(),
             'name': name,
             'category': category,
             'enabled': True,
             'beat': beat or make_beat_crontab(),
-            'language': make_language(),
-            'tags': ['nopic'],
+            'language': language or make_language(),
+            'tags': tags,
             'config': config or make_config()
         }
         schedule_id = database.schedules.insert_one(document).inserted_id
@@ -81,10 +82,22 @@ def schedule(make_schedule, make_beat_crontab):
 
 
 @pytest.fixture(scope='module')
-def schedules(make_schedule, make_beat_crontab):
+def schedules(make_schedule, make_beat_crontab, make_language):
     schedules = []
-    for index in range(50):
+    for index in range(40):
         name = 'schedule_{}'.format(index)
         schedule = make_schedule(name)
         schedules.append(schedule)
+
+    # custom schedules for query lookup
+    schedules.append(make_schedule(name="wikipedia_fr_all_maxi"))
+    schedules.append(make_schedule(name="wikipedia_fr_all_nopic"))
+    schedules.append(make_schedule(name="wikipedia_bm_all_nopic"))
+    schedules.append(make_schedule(language=make_language(code="fr")))
+    schedules.append(make_schedule(language=make_language(code="bm")))
+    schedules.append(make_schedule(category="phet"))
+    schedules.append(make_schedule(category="wikibooks"))
+    schedules.append(make_schedule(tags=["all"]))
+    schedules.append(make_schedule(tags=["all", "mini"]))
+    schedules.append(make_schedule(tags=["mini", "nopic"]))
     return schedules

--- a/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
+++ b/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
@@ -44,6 +44,30 @@ class TestScheduleList:
         assert 'items' in response_json
         assert len(response_json['items']) == expected
 
+    @pytest.mark.parametrize('params, expected', [
+        ("name=Wikipedia_fr", 2),
+        ("name=Wikipedia", 3),
+        ("name=Wiki.*pic$", 2),
+        ("lang=fr", 1),
+        ("lang=bm", 1),
+        ("category=phet", 1),
+        ("category=wikibooks", 1),
+        ("category=wikipedia", 48),
+        ("category=phet&category=wikipedia", 49),
+        ("tag=all", 2),
+        ("tag=mini", 2),
+        ("tag=all&tag=mini", 1),
+    ])
+    def test_list_schedules_with_filter(self, client, access_token, schedules, params, expected):
+
+        url = '/api/schedules/?{}&limit=50'.format(params)
+        response = client.get(url, headers={'Authorization': access_token})
+        assert response.status_code == 200
+
+        response_json = response.get_json()
+        assert 'items' in response_json
+        assert len(response_json['items']) == expected
+
     def test_unauthorized(self, client):
         url = '/api/schedules/'
         response = client.get(url)


### PR DESCRIPTION
## Rationale

We need additional filtering on the schedules list to improve the U.I

## Changes

* `&lang=<code>` to filter by language code
* `&tag=<atag>&tag=<atag>` to filter via tags. Tags are combinative ($all)
* `&name=<astring>` to filter via schedule name. Accepts regex.

---

* All those filters are combinative: the more you set, the more precise the results.
* Added a `count` parameter to the `meta` key with the total (unbound to `limit`) number of results.
* Added some tests for those filters.

⚠️  `name` from the request is passed to mongo for the regex directly. It seems that mongo is doing a good job at escaping its value. I couln't inject anything this way but let me know if this is OK security wise.