### PR TITLE
Adding code coverage to tests with codecov.io upload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,14 @@ matrix:
       dist: xenial
       python: "3.7"
       services: mongodb
-      install: pip install -r dispatcher/backend/requirements.txt
+      install:
+        - pip install -r dispatcher/backend/requirements.txt
+        - pip install codecov pytest pytest-cov
       before_script:
         - cd dispatcher/backend/src
         - export PYTHONPATH=$PWD
         - export MONGO_HOSTNAME=localhost
         - python prestart.py
-      script: pytest tests/integration
+      script: pytest tests/integration --cov=./
+      after_success:
+        - codecov

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ZIM Farm
 
+backend: [![codecov](https://codecov.io/gh/openzim/zimfarm/branch/master/graph/badge.svg)](https://codecov.io/gh/openzim/zimfarm)
+
 The ZIM farm (zimfarm) is a half-decentralised software solution to
 build [ZIM files](http://www.openzim.org/) efficiently. This means scrapping Web contents,
 packaging them into a ZIM file and uploading the result to an online


### PR DESCRIPTION
## Rationale

Issue: #218 

## Changes

* Added dependencies in `.travis.yml` and pytest now ran with `--cov` (backend)
* `codecov` ran after success to upload coverage details to codecov.io
* codecov badge added to README.
