### PR TITLE
Fixed #221: celery_runner user can now access Docker socket

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -7,8 +7,12 @@ RUN pip3 install -r requirements.txt
 
 COPY app app
 
+RUN groupadd -r docker
 RUN adduser --disabled-password --gecos "" celery_runner
-RUN usermod -aG root celery_runner
+RUN usermod -aG root,docker celery_runner
+
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 ENV USERNAME username
 ENV PASSWORD password
@@ -20,4 +24,4 @@ ENV RABBIT_PORT 5671
 ENV WAREHOUSE_HOST warehouse.farm.openzim.org
 ENV WAREHOUSE_PORT 1522
 
-ENTRYPOINT ["python", "app/main.py"]
+ENTRYPOINT ["/entrypoint.sh"]

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+# checks GID of docker socket on host then change container's docker gid to match it
+# once done, replace pid with worker app
+
+set -x
+
+# configure script to call original entrypoint
+set python app/main.py "$@"
+
+# GID might have been set on host to match container's GID
+if [ "$(id -u)" = "0" ]; then
+  # get gid of docker socket file
+  SOCK_DOCKER_GID=`ls -ng /var/run/docker.sock | cut -f3 -d' '`
+
+  # get group of docker inside container
+  CUR_DOCKER_GID=`getent group docker | cut -f3 -d: || true`
+
+  # if they don't match, adjust
+  if [ ! -z "$SOCK_DOCKER_GID" -a "$SOCK_DOCKER_GID" != "$CUR_DOCKER_GID" ]; then
+    groupmod -g ${SOCK_DOCKER_GID} -o docker
+  fi
+  if ! groups celery_runner | grep -q docker; then
+    usermod -aG docker celery_runner
+  fi
+fi
+
+# replace the current pid 1 with original entrypoint
+exec "$@"


### PR DESCRIPTION
## Rationale

Bug #221 

## Changes

* added a docker group on the container
* added celery_runner into the docker group
* changed entrypoint to a bash script which
  * checks host GID of docker socket
  * edit container's docker group gid to match it
  * runs the actual entrypoint