### PR TITLE
Detecting stuck tasks

### DIFF
--- a/worker/app/operations/run_mwoffliner.py
+++ b/worker/app/operations/run_mwoffliner.py
@@ -1,7 +1,6 @@
 import asyncio
 from pathlib import Path
 
-import aiodocker
 from docker import DockerClient
 from docker.models.containers import Container
 
@@ -47,25 +46,6 @@ class RunMWOffliner(Operation):
         container.remove()
 
         return result
-
-    async def _wait_for_finish(self, container_id: str):
-        docker = aiodocker.Docker()
-        container = await docker.containers.get(container_id)
-
-        tasks = [
-            asyncio.create_task(container.wait()),
-            asyncio.create_task(self.detect_stuck(container))
-        ]
-        finished, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
-        for task in pending:
-            task.cancel()
-
-        try:
-            await asyncio.gather(*pending)
-        except asyncio.CancelledError:
-            pass
-
-        await docker.close()
 
     @staticmethod
     def _get_command(flags: {}):

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -2,3 +2,4 @@ celery==4.3.*
 docker==3.7.*
 paramiko>=2.4.2
 cryptography==2.4.2
+aiodocker==0.14.*


### PR DESCRIPTION
## Rationale

We want to detect when a container generating zim files got stuck and terminate it. As discussed earlier, we define a container stuck as 10 mins without a stdout update.

Also, I am using asyncio here, because I wanted to use this design to add features like live cpu / memory usage, progress update or live container stream. Let me know if it make sense. 

<!--
Issue: [Title](link) or #123 for Github issues.
-->

## Changes

- added stuff to worker to detect container stuck