### PR TITLE
Fixed permission issues when running as celery_runner

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -1,5 +1,9 @@
 FROM python:3.7
 
+RUN apt-get update
+RUN apt-get -y install sudo
+RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
 WORKDIR /usr/src
 
 COPY requirements.txt requirements.txt
@@ -8,11 +12,13 @@ RUN pip3 install -r requirements.txt
 COPY app app
 
 RUN groupadd -r docker
+RUN groupadd -r zim
 RUN adduser --disabled-password --gecos "" celery_runner
-RUN usermod -aG root,docker celery_runner
+RUN usermod -aG root,sudo,docker,zim celery_runner
 
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
+RUN chown -R celery_runner /usr/src
 
 ENV USERNAME username
 ENV PASSWORD password
@@ -23,5 +29,7 @@ ENV DISPATCHER_HOST farm.openzim.org
 ENV RABBIT_PORT 5671
 ENV WAREHOUSE_HOST warehouse.farm.openzim.org
 ENV WAREHOUSE_PORT 1522
+
+USER celery_runner
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/worker/README.md
+++ b/worker/README.md
@@ -73,11 +73,13 @@ Please make sure the RSA public key is uploaded to dispatcher using the public A
 
 ## Example
 
+__note__: your local `PATH_WORKING_DIR` must be group writable (chgrp rwx PATH_WORKING_DIR)
+
 ```bash
 docker run \
-    -v /var/run/docker.sock:/var/run/docker.sock \
-    -v PATH_SSH_KEY:/usr/src/.ssh/id_rsa \
-    -v PATH_WORKING_DIR:/zim_files \
+    -v /var/run/docker.sock:/var/run/docker.sock:rw \
+    -v PATH_SSH_KEY:/usr/src/.ssh/id_rsa:ro \
+    -v PATH_WORKING_DIR:/zim_files:rw \
     --env USERNAME='username' \
     --env PASSWORD='password' \
     --env WORKING_DIR='PATH_WORKING_DIR' \

--- a/worker/app/main.py
+++ b/worker/app/main.py
@@ -5,7 +5,7 @@ from worker import Worker
 
 if __name__ == '__main__':
     # setting up logging
-    log_path = os.getenv('LOG_PATH', '/worker.log')
+    log_path = os.getenv('LOG_PATH', '/usr/src/worker.log')
     logging.basicConfig(level=logging.INFO,
                         format='[%(asctime)s: %(levelname)s] %(message)s',
                         handlers=[logging.StreamHandler(),

--- a/worker/app/worker.py
+++ b/worker/app/worker.py
@@ -66,7 +66,6 @@ class Worker:
         # start celery
         app.worker_main([
             'worker',
-            '--uid', 'celery_runner',
             '--hostname', '{}@{}'.format(Settings.username, Settings.node_name),
             '--queues', Settings.queues,
             '--loglevel', 'info'

--- a/worker/entrypoint.sh
+++ b/worker/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/sh
 # checks GID of docker socket on host then change container's docker gid to match it
+# checks UID of SSH key on host then change user's uid to match it
+# check GID of /zim_files folder on host then change zim group gid to match it
+# ensure /zim_files is writable (or die)
 # once done, replace pid with worker app
 
 set -x
@@ -7,21 +10,55 @@ set -x
 # configure script to call original entrypoint
 set python app/main.py "$@"
 
-# GID might have been set on host to match container's GID
-if [ "$(id -u)" = "0" ]; then
-  # get gid of docker socket file
-  SOCK_DOCKER_GID=`ls -ng /var/run/docker.sock | cut -f3 -d' '`
+# get gid of docker socket file
+SOCK_DOCKER_GID=`ls -ng /var/run/docker.sock | cut -f3 -d' '`
 
-  # get group of docker inside container
-  CUR_DOCKER_GID=`getent group docker | cut -f3 -d: || true`
+# get gid of docker group inside container
+CUR_DOCKER_GID=`getent group docker | cut -f3 -d: || true`
 
-  # if they don't match, adjust
-  if [ ! -z "$SOCK_DOCKER_GID" -a "$SOCK_DOCKER_GID" != "$CUR_DOCKER_GID" ]; then
-    groupmod -g ${SOCK_DOCKER_GID} -o docker
-  fi
-  if ! groups celery_runner | grep -q docker; then
-    usermod -aG docker celery_runner
-  fi
+# if they don't match, adjust
+if [ ! -z "$SOCK_DOCKER_GID" -a "$SOCK_DOCKER_GID" != "$CUR_DOCKER_GID" ]; then
+    sudo groupmod -g ${SOCK_DOCKER_GID} -o docker
+fi
+
+# if docker socket not writable, fail.
+if [ ! -w /var/run/docker.sock ] ; then
+	echo "docker socket (/var/run/docker.sock in container) is not writable."
+	exit 1
+fi
+
+
+# get uid of ssh key
+SSH_KEY_UID=`ls -n /usr/src/.ssh/id_rsa | cut -f4 -d' '`
+# get uid of celery_runner user inside container
+CUR_CELERY_UID=`id -u celery_runner`
+
+# if they don't match, adjust
+if [ ! -z "$SSH_KEY_UID" -a "$SSH_KEY_UID" != "$CUR_CELERY_UID" ]; then
+    sudo usermod -u ${SSH_KEY_UID} -o celery_runner
+fi
+
+# if ssh key not readable, fail.
+if [ ! -r /usr/src/.ssh/id_rsa ] ; then
+	echo "ssh key (/usr/src/.ssh/id_rsa in container) is not readable."
+	exit 1
+fi
+
+# get gid of output folder
+ZIM_FOLDER_GID=`ls -ndg /zim_files | cut -f3 -d' '`
+
+# get gid of zim group inside container
+CUR_FOLDER_GID=`getent group zim | cut -f3 -d: || true`
+
+# if they don't match, adjust
+if [ ! -z "$ZIM_FOLDER_GID" -a "$ZIM_FOLDER_GID" != "$CUR_FOLDER_GID" ]; then
+    sudo groupmod -g ${ZIM_FOLDER_GID} -o zim
+fi
+
+# if zim folder not group-writable, fail.
+if [ ! -w /zim_files ] ; then
+	echo "zim output folder (/zim_files in container) is not writable."
+	exit 1
 fi
 
 # replace the current pid 1 with original entrypoint


### PR DESCRIPTION
## Rationale

#223 was fixed for docker socket but ssh key and zim output folder (used at the end of the process) were affected as well.

## Changes

Dockerfile:

* added sudo
* made `celery_runner` sudoer without pass
* added group zim (for `/zim_files`)
* added celery_runner to groups `sudo` and `zim`
* changed /usr/src ownership to `celery_runner`
* run container as `celery_runner`

Worker

* worker log to be written to /usr/src/worker.log (was /worker.log)
* removed `--uid` flag on Celery (parent process already running as `celery_runner`)
* additional startup tweaks:
  * celery_runner's uid changed to match the one of the ssh key
  * zim group gid changed to match the one of the /zim_files volume
  * die early if permission issue on docker, ssh key or zim folder

Reason for changing `uid` for the ssh key is that for security reason, it is expected that user's keys are only user-readable (`0600`).