### PR TITLE
mwoffliner-redis connection via socket

### DIFF
--- a/worker/app/operations/__init__.py
+++ b/worker/app/operations/__init__.py
@@ -1,3 +1,4 @@
+from .run_socket import RunSocket
 from .run_redis import RunRedis
 from .run_mwoffliner import RunMWOffliner
 from .run_phet import RunPhet

--- a/worker/app/utils/settings.py
+++ b/worker/app/utils/settings.py
@@ -27,6 +27,9 @@ class Settings:
 
     docker_socket: str = '/var/run/docker.sock'
 
+    sockets_dir_host: str = os.getenv('SOCKETS_DIR', '/tmp/sockets')
+    sockets_dir_container: str = '/tmp/sockets'
+
     @classmethod
     def sanity_check(cls):
         # check mandatory env variables exist


### PR DESCRIPTION
## Rationale

Request in #233 to improve perf/latency/reliability of mwoffliner-redis communication.

## Changes

- uses a busybox container to _host_ the socket (ran per task)
- socket is postfixed with task_id to prevent conflict on host mapping
