### PR TITLE
Implement a DNS Cache to save on requests round trips

### DIFF
--- a/dnscache/Dockerfile
+++ b/dnscache/Dockerfile
@@ -1,0 +1,22 @@
+FROM alpine:edge
+
+RUN apk update && apk --no-cache add dnsmasq
+
+# prepare our revolf file
+RUN echo -e "# CloudFlare\nnameserver 1.1.1.1\n# Google DNS\nnameserver 8.8.8.8\nnameserver 2001:4860:4860::8888\n# OpenDNS\n# nameserver 208.67.222.222\n# nameserver 208.67.220.220" > /etc/resolv.dnsmasq
+
+# --no-daemon and --keep-in-foreground are similar
+# but no-deamon has debug enabled (and thus starts with useful output)
+
+ENTRYPOINT ["dnsmasq", \
+			"--no-daemon", \
+			"--user=root", \
+			"--conf-file=/etc/dnsmasq.conf", \
+			"--resolv-file=/etc/resolv.dnsmasq", \
+			"--domain-needed", \
+			"--bogus-priv", \
+			"--no-hosts", \
+			"--min-cache-ttl=86400", \
+			"--cache-size=1000", \
+			"--neg-ttl=3600", \
+			"--no-poll"]

--- a/dnscache/README.md
+++ b/dnscache/README.md
@@ -1,0 +1,34 @@
+DNS Cache
+===
+
+Simple `dnsmasq` container to cache DNS requests for openzim's scrappers.
+
+## Usage
+
+At the moment, this container has a static config of **caching every domain for 1day** (86400s).
+
+``` sh
+docker run --name dnscache openzim/dnscache
+```
+
+To use your DNS cache container, you need to run your scrapper(s) with the `--dns=` option. This option **only accepts** IPv4 and IPv6 values (no alias).
+
+### Find out the IP of your `dnscache` container:
+
+```sh
+docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' dnscache
+```
+
+### Start a scrapper without knowing the IP
+
+You can save the extra step and set the `--dns` to output of the previous command:
+
+``` sh
+docker run --dns=$(docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' dnscache) openzim/mwoffliner
+```
+
+You can also retrieve the first IPaddress (what you want unless you're using networks) in python:
+
+``` py
+client.inspect_container("dnscache")["NetworkSettings"]["IPAddress"]
+```

--- a/worker/app/operations/run_dnscache.py
+++ b/worker/app/operations/run_dnscache.py
@@ -7,15 +7,15 @@ from .base import Operation
 from utils.docker import remove_existing_container
 
 
-class RunRedis(Operation):
+class RunDNSCache(Operation):
     def __init__(self, docker_client: DockerClient, task_id: str):
         super().__init__()
         self.docker = docker_client
-        self._container_name = f'redis_{task_id}'
+        self._container_name = f'dnscache_{task_id}'
         self._container: Optional[Container] = None
 
     def execute(self) -> Container:
-        """Run a redis container detached.
+        """Run a dnscache container detached.
 
         :raise: docker.errors.ImageNotFound
         :raise: docker.errors.APIError
@@ -26,15 +26,17 @@ class RunRedis(Operation):
 
         remove_existing_container(self.docker, name=self._container_name)
 
-        image = self.docker.images.pull('redis', tag='latest')
-        self._container = self.docker.containers.run(
-            image, command='redis-server --save "" --appendonly no', detach=True, name=self._container_name)
+        image = self.docker.images.pull('openzim/dnscache', tag='latest')
+        self._container = self.docker.containers.run(image, detach=True, name=self._container_name)
         return self._container
+
+    def stop(self):
+        if self._container:
+            self._container.stop()
+            self._container.remove()
 
     def __enter__(self):
         return self.execute()
 
     def __exit__(self, exc_type, exc_val, exc_tb):
-        if self._container:
-            self._container.stop()
-            self._container.remove()
+        self.stop()

--- a/worker/app/operations/run_phet.py
+++ b/worker/app/operations/run_phet.py
@@ -11,7 +11,7 @@ logger = get_task_logger(__name__)
 class RunPhet(Operation):
     """Run Phet container with `config`"""
 
-    def __init__(self, docker_client: DockerClient, tag: str, flags: {}, task_id: str, working_dir_host: str):
+    def __init__(self, docker_client: DockerClient, tag: str, flags: {}, task_id: str, working_dir_host: str, dns: str):
         tag = 'latest' if not tag else tag
         super().__init__()
         self.docker = docker_client
@@ -19,6 +19,7 @@ class RunPhet(Operation):
         self.task_id = task_id
         self.working_dir_host = Path(working_dir_host).joinpath(self.task_id).absolute()
         self.image_name = 'openzim/phet:{}'.format(tag)
+        self.dns = dns
 
     def execute(self) -> ContainerResult:
         """Pull and run phet"""
@@ -30,7 +31,7 @@ class RunPhet(Operation):
         volumes = {self.working_dir_host: {'bind': '/phet/dist', 'mode': 'rw'}}
         container: Container = self.docker.containers.run(
             image=self.image_name, command=self.command, volumes=volumes, detach=True,
-            name='phet_{}'.format(self.task_id))
+            name=f'phet_{self.task_id}', dns=self.dns)
 
         exit_code = container.wait()['StatusCode']
         stdout = container.logs(stdout=True, stderr=False, tail=100).decode("utf-8")

--- a/worker/app/tasks/base.py
+++ b/worker/app/tasks/base.py
@@ -1,10 +1,13 @@
 import shutil
 from pathlib import Path
 
+import docker
 from celery.task import Task
 from celery.utils.log import get_task_logger
 
 from utils import Settings
+from utils.docker import get_ip_address
+from operations.run_dnscache import RunDNSCache
 
 logger = get_task_logger(__name__)
 
@@ -23,7 +26,31 @@ class Base(Task):
     def __init__(self):
         super().__init__()
 
+    def set_up(self):
+        # start a dnscache instance
+        try:
+            self.run_dnscache = RunDNSCache(docker_client=docker.from_env(),
+                                            task_id=self.task_id)
+            self.run_dnscache.execute()
+            logger.info(f'Running DNSCache at {self.get_dns()[-1]}')
+        except docker.errors.APIError as e:
+            raise self.retry(exc=e)
+        except (docker.errors.ContainerError, docker.errors.ImageNotFound) as e:
+            raise Exception from e
+
+    def get_dns(self):
+        """list of DNS IPs to feed `dns` on scrappers with: [<dnscache_ip>]"""
+        if not hasattr(self, 'run_dnscache'):
+            self.set_up()
+
+        return [get_ip_address(docker.from_env(), self.run_dnscache._container_name)]
+
     def clean_up(self):
+        # ensure dnscache is stopped
+        if self.run_dnscache:
+            self.run_dnscache.stop()
+
+        # remove working_dir
         working_dir = Path(Settings.working_dir_container).joinpath(self.task_id)
         shutil.rmtree(working_dir)
 

--- a/worker/app/tasks/mwoffliner.py
+++ b/worker/app/tasks/mwoffliner.py
@@ -41,9 +41,9 @@ class MWOffliner(Base):
                 run_mwoffliner = RunMWOffliner(
                     docker_client=docker.from_env(), tag=image_tag, flags=flags,
                     task_id=self.task_id, working_dir_host=Settings.working_dir_host,
-                    redis_container=redis_container)
+                    redis_container=redis_container, dns=self.get_dns())
                 logger.info(f'Running MWOffliner, mwUrl: {flags["mwUrl"]}')
-                logger.debug(f'Running MWOffliner, command: {run_mwoffliner.command}')
+                logger.debug(f'Running MWOffliner, dns={run_mwoffliner.dns}, command: {run_mwoffliner.command}')
 
                 self.send_event('task-container_started', image=image, command=run_mwoffliner.command)
                 result = run_mwoffliner.execute()

--- a/worker/app/tasks/phet.py
+++ b/worker/app/tasks/phet.py
@@ -38,9 +38,10 @@ class Phet(Base):
             # run phet
             run_phet = RunPhet(
                 docker_client=docker.from_env(), tag=image_tag, flags=flags,
-                task_id=self.task_id, working_dir_host=Settings.working_dir_host)
+                task_id=self.task_id, working_dir_host=Settings.working_dir_host,
+                dns=self.get_dns())
             logger.info(f'Running Phet')
-            logger.debug(f'Running Phet, command: {run_phet.command}')
+            logger.debug(f'Running Phet, dns={run_phet.dns}, command: {run_phet.command}')
             self.send_event('task-container_started', image=image, command=run_phet.command)
 
             result = run_phet.execute()

--- a/worker/app/utils/docker.py
+++ b/worker/app/utils/docker.py
@@ -1,0 +1,12 @@
+
+
+def remove_existing_container(docker_client, name):
+    """remove container matching its name, if exists"""
+    for container in docker_client.containers.list(all=True, filters={'name': name}):
+        container.stop()
+        container.remove()
+
+
+def get_ip_address(docker_client, name):
+    """IP Address (first) of a named container"""
+    return docker_client.api.inspect_container(name)["NetworkSettings"]["IPAddress"]

--- a/worker/app/worker.py
+++ b/worker/app/worker.py
@@ -18,7 +18,8 @@ def worker_shutting_down_clean_up(*args, **kwargs):
     logger.info('Shutting Down...')
 
     client = docker.from_env()
-    containers = client.containers.list(filters={'name': 'mwoffliner'})
+    containers = client.containers.list(
+        filters={'name': 'mwoffliner|redis|socket|phet|dnscache'})
     for container in containers:
         logger.info(f'Terminating container: {container.name}')
         container.stop(timeout=0)


### PR DESCRIPTION
## Rationale

Following openzim/mwoffliner/issues/789

Scrappers make tons of requests, mostly to the same domain, potentially for days. Even though DNS is fast, it's a huge waste of resource to not cache does requests. Additionaly, @kelson42 mentioned a case when he faced DNS throttling in the past.

It is understood that scrappers could and *should* implement DNS caching on their own containers to provide a worry-free experience but since we control the zimfarm environment, we can also implement it and make sure we're saving on those requests.

FYI, `nscd` could be used on containers as it caches `gethostbyname()` calls but it might not get all requests (only those going through that libc function) and is reportedly buggy (couldn't find how).

`dnsmasq` itself is quite easy to integrate to a container as well but since docker maps `/etc/resolv.conf` inside the container to a copy of the host's one (`/var/lib/docker/<cid>/resolv.conf`), it is advised not to modify it. The only other way is to pass the `--dns` argument to docker which only accept IP addresses. It means that running a local `dnsmasq` would still require `--dns=127.0.0.1`.

## Changes

* created an [openzim/dnscache](https://hub.docker.com/openzim/dnscache) container based on dnsmasq
  * not zimfarm specific but currently cache domains for 1day
* a dnscache instance is created for each task (see #234 discussion)
* dnscache IP is retrieved
* scrappers (mwoffliner and phet ATM) are passed `dns=[<ip>]` on startup

* also fixed `worker_shutting_down_clean_up()` which only looked-for mwoffliner