### PR TITLE
mwoffliner-redis connection via socket (simple volume version)

### DIFF
--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -16,6 +16,5 @@ ENV DISPATCHER_HOST farm.openzim.org
 ENV RABBIT_PORT 5671
 ENV WAREHOUSE_HOST warehouse.farm.openzim.org
 ENV WAREHOUSE_PORT 1522
-ENV SOCKETS_DIR /tmp/sockets
 
 ENTRYPOINT ["python", "app/main.py"]

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -16,5 +16,6 @@ ENV DISPATCHER_HOST farm.openzim.org
 ENV RABBIT_PORT 5671
 ENV WAREHOUSE_HOST warehouse.farm.openzim.org
 ENV WAREHOUSE_PORT 1522
+ENV SOCKETS_DIR /tmp/sockets
 
 ENTRYPOINT ["python", "app/main.py"]

--- a/worker/app/operations/run_mwoffliner.py
+++ b/worker/app/operations/run_mwoffliner.py
@@ -18,6 +18,7 @@ class RunMWOffliner(Operation):
         super().__init__()
         self.docker = docker_client
         self.working_dir_host = Path(working_dir_host).joinpath(task_id).absolute()
+        self.sockets_dir_host = Path(working_dir_host).joinpath('sockets').absolute()
         self.redis_container = redis_container
         self.image_name = 'openzim/mwoffliner:{}'.format(tag)
         self.image_tag = tag
@@ -34,8 +35,8 @@ class RunMWOffliner(Operation):
 
         # run mwoffliner
         volumes = {self.working_dir_host: {'bind': '/output', 'mode': 'rw'},
-                   Settings.sockets_dir_host: {'bind': Settings.sockets_dir_container,
-                                               'mode': 'rw'}}
+                   self.sockets_dir_host: {'bind': Settings.sockets_dir_container,
+                                           'mode': 'rw'}}
         container: Container = self.docker.containers.run(
             image=self.image_name, command=self.command, volumes=volumes, detach=True,
             name=self.container_name, dns=self.dns)

--- a/worker/app/operations/run_redis.py
+++ b/worker/app/operations/run_redis.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import Path
 from typing import Optional
 
 from docker import DockerClient
@@ -10,12 +11,13 @@ from utils.settings import Settings
 
 
 class RunRedis(Operation):
-    def __init__(self, docker_client: DockerClient, task_id: str):
+    def __init__(self, docker_client: DockerClient, task_id: str, working_dir_host: str):
         super().__init__()
         self.docker = docker_client
         self._container_name = f'redis_{task_id}'
         self._container: Optional[Container] = None
         self.redis_socket_name = f'redis_{task_id}.sock'
+        self.sockets_dir_host = Path(working_dir_host).joinpath('sockets').absolute()
 
     def execute(self) -> Container:
         """Run a redis container detached.
@@ -30,8 +32,8 @@ class RunRedis(Operation):
         remove_existing_container(self.docker, name=self._container_name)
 
         image = self.docker.images.pull('redis', tag='latest')
-        volumes = {Settings.sockets_dir_host: {'bind': Settings.sockets_dir_container,
-                                               'mode': 'rw'}}
+        volumes = {self.sockets_dir_host: {'bind': Settings.sockets_dir_container,
+                                           'mode': 'rw'}}
         self._container = self.docker.containers.run(
             image, command=self._get_command(), detach=True, name=self._container_name, volumes=volumes)
         return self._container

--- a/worker/app/tasks/mwoffliner.py
+++ b/worker/app/tasks/mwoffliner.py
@@ -37,7 +37,7 @@ class MWOffliner(Base):
 
         try:
             # run mwoffliner
-            with RunRedis(docker_client=docker.from_env(), task_id=self.task_id) as redis_container:
+            with RunRedis(docker_client=docker.from_env(), task_id=self.task_id, working_dir_host=Settings.working_dir_host) as redis_container:
                 run_mwoffliner = RunMWOffliner(
                     docker_client=docker.from_env(), tag=image_tag, flags=flags,
                     task_id=self.task_id, working_dir_host=Settings.working_dir_host,

--- a/worker/app/utils/settings.py
+++ b/worker/app/utils/settings.py
@@ -23,12 +23,10 @@ class Settings:
 
     working_dir_host: str = os.getenv('WORKING_DIR', None)
     working_dir_container: str = '/zim_files'
+    sockets_dir_container: str = '/tmp/sockets'
     private_key: str = '/usr/src/.ssh/id_rsa'
 
     docker_socket: str = '/var/run/docker.sock'
-
-    sockets_dir_host: str = os.getenv('SOCKETS_DIR', '/tmp/sockets')
-    sockets_dir_container: str = '/tmp/sockets'
 
     @classmethod
     def sanity_check(cls):

--- a/worker/app/utils/settings.py
+++ b/worker/app/utils/settings.py
@@ -27,6 +27,9 @@ class Settings:
 
     docker_socket: str = '/var/run/docker.sock'
 
+    sockets_dir_host: str = os.getenv('SOCKETS_DIR', '/tmp/sockets')
+    sockets_dir_container: str = '/tmp/sockets'
+
     @classmethod
     def sanity_check(cls):
         # check mandatory env variables exist


### PR DESCRIPTION
## Rationale

Request in #233 to improve perf/latency/reliability of mwoffliner-redis communication.

## Changes

- mount a shared `/tmp/sockets` on both `mwoffliner_xxx` and `redis_xxx` containers
- redis starts with a socket inside this volume
- socket is postfixed with task_id to prevent conflict on host mapping