### PR TITLE
Fixed X962 error in worker startup

### DIFF
--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -1,5 +1,5 @@
-celery==4.3.*
-docker==3.7.*
-paramiko>=2.4.2
-cryptography==2.4.2
-aiodocker==0.14.*
+celery==4.3.0
+docker==4.0.1
+paramiko==2.5.0
+cryptography==2.7
+aiodocker==0.14.0


### PR DESCRIPTION
## Rationale

Worker can't start anymore due to a cryptic X962 error.

Due to an update of paramiko without one for cryptography.

## Changes

* updated all worker requirements to latest versions
* using fixed (`==`) versions to avoid this kind of issue.