### PR TITLE
Check sockets folder permission on start to avoid in-task issue

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -73,12 +73,7 @@ Please make sure the RSA public key is uploaded to dispatcher using the public A
 
 ## Example
 
-__note__: your local `PATH_WORKING_DIR` must be group writable and `PATH_WORKING_DIR/sockets` must be world writable:
-
-```
-chmod g+rwx PATH_WORKING_DIR
-mkdir -p -m 0777 PATH_WORKING_DIR/sockets
-```
+__note__: your local `PATH_WORKING_DIR` must be group writable (chgrp rwx PATH_WORKING_DIR)
 
 ```bash
 docker run \

--- a/worker/README.md
+++ b/worker/README.md
@@ -73,7 +73,12 @@ Please make sure the RSA public key is uploaded to dispatcher using the public A
 
 ## Example
 
-__note__: your local `PATH_WORKING_DIR` must be group writable (chgrp rwx PATH_WORKING_DIR)
+__note__: your local `PATH_WORKING_DIR` must be group writable and `PATH_WORKING_DIR/sockets` must be world writable:
+
+```
+chmod g+rwx PATH_WORKING_DIR
+mkdir -p -m 0777 PATH_WORKING_DIR/sockets
+```
 
 ```bash
 docker run \

--- a/worker/app/utils/settings.py
+++ b/worker/app/utils/settings.py
@@ -78,6 +78,14 @@ class Settings:
             logger.error('Docker socket mapping did not found inside container at {}.'.format(cls.private_key))
             sys.exit(1)
 
+        # check sockets folder permission (redis is ran as user)
+        sockets_dir_from_worker = Path(cls.working_dir_container).joinpath('sockets')
+        sockets_dir_host = Path(cls.working_dir_host).joinpath('sockets')
+        if not oct(sockets_dir_from_worker.stat().st_mode & 0o777)[-3:] == '777':
+            logger.error('Sockets placeholder at {} need to be world-writable'
+                         .format(sockets_dir_host))
+            sys.exit(1)
+
     @classmethod
     def ensure_correct_typing(cls):
         try:


### PR DESCRIPTION
## Rationale

`sockets` subfolder needs to be world writable (`0777`) for redis to create the socket (redis runs as a user)

## Changes

* updated doc to mention the required step
* added check in `sanity_check()` so the worker fails upon start if not correct
