### PR TITLE
change the path for nginx conf

### DIFF
--- a/dispatcher/backend/Dockerfile
+++ b/dispatcher/backend/Dockerfile
@@ -3,7 +3,7 @@ FROM tiangolo/uwsgi-nginx:python3.6
 COPY requirements.txt /usr/src/
 RUN pip install -r /usr/src/requirements.txt
 
-COPY nginx.conf /etc/nginx/conf.d/
+COPY nginx.conf /etc/nginx/conf.d/custom.conf
 
 COPY src /usr/src/flask
 COPY static /usr/src/static


### PR DESCRIPTION
## Rationale

[//]: # (Briefly explain the reason behind this change.)

For some reason the default behavior for `uwsgi-nginx` changed on `nginx.conf`. It now overwrite our own nginx conf. Which caused the static stuff to all return 404, since a default nginx conf is used.

Upon further reading of the docs, it suggested to store customizations in `custom.conf`

Docs: https://hub.docker.com/r/tiangolo/uwsgi-nginx/

## Changes

changed the path for nginx conf file
