### PR TITLE
Cancel started Task

### DIFF
--- a/dispatcher/backend/src/common/entities.py
+++ b/dispatcher/backend/src/common/entities.py
@@ -11,6 +11,10 @@ class TaskStatus:
     revoked = 'revoked'
 
     @classmethod
+    def incomplete(cls):
+        return [cls.sent, cls.received, cls.started, cls.container_started, cls.retried]
+
+    @classmethod
     def all(cls):
         return [cls.sent, cls.received, cls.started, cls.succeeded, cls.failed, cls.retried, cls.revoked]
 

--- a/dispatcher/backend/src/routes/auth/rabbitmq.py
+++ b/dispatcher/backend/src/routes/auth/rabbitmq.py
@@ -29,6 +29,8 @@ def auth(intention: str):
             return Response('allow')
         else:
             user = Users().find_one({'username': username}, {'_id': 0, 'password_hash': 1, 'scope.rabbitmq': 1})
+            if user is None:
+                return Response('deny')
             password_hash = user.get('password_hash', '')
             tags = user.get('scope', {}).get('rabbitmq', [])
             if user is not None and check_password_hash(password_hash, password):

--- a/dispatcher/backend/src/routes/auth/rabbitmq.py
+++ b/dispatcher/backend/src/routes/auth/rabbitmq.py
@@ -33,7 +33,7 @@ def auth(intention: str):
                 return Response('deny')
             password_hash = user.get('password_hash', '')
             tags = user.get('scope', {}).get('rabbitmq', [])
-            if user is not None and check_password_hash(password_hash, password):
+            if check_password_hash(password_hash, password):
                 tags = ['allow'] + tags
                 return Response(' '.join(tags))
             else:

--- a/dispatcher/backend/src/routes/tasks/__init__.py
+++ b/dispatcher/backend/src/routes/tasks/__init__.py
@@ -1,5 +1,5 @@
 from routes.base import BaseBlueprint
-from routes.tasks.task import TasksRoute, TaskRoute
+from routes.tasks.task import TasksRoute, TaskRoute, TaskCancelRoute
 
 
 class Blueprint(BaseBlueprint):
@@ -8,3 +8,4 @@ class Blueprint(BaseBlueprint):
 
         self.register_route(TasksRoute())
         self.register_route(TaskRoute())
+        self.register_route(TaskCancelRoute())


### PR DESCRIPTION
## Rationale

Fixes #220

## Changes

* Added a `POST /tasks/<tid>/cancel` endpoint
* Added tests for endpoint
* endpoint calls `revoke()` on task which kills the task process in the worker (if started) or dismisses it if not started.
* Added a general handler in worker to remove dnscache container on revoke.