### PR TITLE
Upload redis log

### DIFF
--- a/worker/app/operations/run_redis.py
+++ b/worker/app/operations/run_redis.py
@@ -5,6 +5,7 @@ from typing import Optional
 from docker import DockerClient
 from docker.models.containers import Container
 
+from .upload import Upload
 from .base import Operation
 from utils.docker import remove_existing_container
 from utils.settings import Settings
@@ -44,6 +45,8 @@ class RunRedis(Operation):
     def __exit__(self, exc_type, exc_val, exc_tb):
         if self._container:
             self._container.stop()
+            # TODO: remove this ultimately (upload redis log to warehouse)
+            Upload.upload_log(self._container)
             self._container.remove()
 
     def _get_command(self):


### PR DESCRIPTION
## Rationale

In order to debug some very long mwoffliner tasks, we'll upload redis logs as well.
This is a temporary measure.

## Changes

- logs are uploaded and link will be “guessed” by user (replace `mwoffliner` by `redis` in link)
- logs are very short
