### PR TITLE
Fixed DNS Cache tear down/set up issue

### DIFF
--- a/worker/app/operations/run_dnscache.py
+++ b/worker/app/operations/run_dnscache.py
@@ -1,17 +1,18 @@
 from typing import Optional
 
+import docker
 from docker import DockerClient
 from docker.models.containers import Container
 
 from .base import Operation
-from utils.docker import remove_existing_container
+from utils.docker import get_ip_address, remove_existing_container
 
 
 class RunDNSCache(Operation):
     def __init__(self, docker_client: DockerClient, task_id: str):
         super().__init__()
         self.docker = docker_client
-        self._container_name = f'dnscache_{task_id}'
+        self.container_name = f'dnscache_{task_id}'
         self._container: Optional[Container] = None
 
     def execute(self) -> Container:
@@ -24,14 +25,22 @@ class RunDNSCache(Operation):
         if self._container:
             return self._container
 
-        remove_existing_container(self.docker, name=self._container_name)
+        remove_existing_container(self.docker, name=self.container_name)
 
         image = self.docker.images.pull('openzim/dnscache', tag='latest')
-        self._container = self.docker.containers.run(image, detach=True, name=self._container_name)
+        self._container = self.docker.containers.run(image, detach=True, name=self.container_name)
         return self._container
 
+    def get_ip_addresses(self):
+        return [get_ip_address(docker.from_env(), self.container_name)]
+
+    @property
+    def ip_address(self):
+        addresses = self.get_ip_addresses()
+        return addresses[-1] if len(addresses) else None
+
     def stop(self):
-        remove_existing_container(self.docker, name=self._container_name)
+        remove_existing_container(self.docker, name=self.container_name)
 
     def __enter__(self):
         return self.execute()

--- a/worker/app/operations/run_dnscache.py
+++ b/worker/app/operations/run_dnscache.py
@@ -31,9 +31,7 @@ class RunDNSCache(Operation):
         return self._container
 
     def stop(self):
-        if self._container:
-            self._container.stop()
-            self._container.remove()
+        remove_existing_container(self.docker, name=self._container_name)
 
     def __enter__(self):
         return self.execute()

--- a/worker/app/tasks/base.py
+++ b/worker/app/tasks/base.py
@@ -43,7 +43,7 @@ class Base(Task):
 
     def get_dns(self):
         """list of DNS IPs to feed `dns` on scrappers with: [<dnscache_ip>]"""
-        if not hasattr(self, 'run_dnscache'):
+        if not hasattr(self, 'run_dnscache') or self.task_id not in self.run_dnscache._container_name:
             self.set_up()
 
         return [get_ip_address(docker.from_env(), self.run_dnscache._container_name)]


### PR DESCRIPTION
## Rationale

mwoffliner tasks have difficulties running one after another as the property might point to the wrong `dnscache_xxx` container.

## Changes

* simplified `stop()` on dnscache to reuse existing code which is also safer (prevents `.stop()` on non-existing container).
* check the `task_id` of the attached `run_dnscache` property and change if required.
