### PR TITLE
Added `noLocalParserFallback` mwoffliner option to validator

### DIFF
--- a/dispatcher/backend/src/routes/schedules/validators.py
+++ b/dispatcher/backend/src/routes/schedules/validators.py
@@ -40,6 +40,7 @@ mwoffliner_flags_validator = t.Dict({
     t.Key('withoutZimFullTextIndex', optional=True): t.Bool,
     t.Key('addNamespaces', optional=True): t.String,
     t.Key('getCategories', optional=True): t.Bool,
+    t.Key('noLocalParserFallback', optional=True): t.Bool,
 })
 
 phet_flags_validator = t.Dict()

--- a/dispatcher/backend/src/tests/unit/routes/test_schedules_validators.py
+++ b/dispatcher/backend/src/tests/unit/routes/test_schedules_validators.py
@@ -83,6 +83,7 @@ class TestMWOfflinerFlagsValidator:
                  'withoutZimFullTextIndex': False,
                  'addNamespaces': "100,200",
                  'getCategories': False,
+                 'noLocalParserFallback': True,
                  }
         mwoffliner_flags_validator.check(flags)
 
@@ -131,6 +132,7 @@ class TestMWOfflinerFlagsValidator:
         {'withoutZimFullTextIndex': 'False'},
         {'addNamespaces': 123},
         {'getCategories': 'False'},
+        {'noLocalParserFallback': 'False'},
 
     ])
     def test_invalid_field(self, data):


### PR DESCRIPTION
## Rationale

A new `noLocalParserFallback` option has been added to mwoffliner. We need to support it as a number of wikis need it. Without it in the validator, we can't update their configs.

## Changes

* Added key to validator
* Added tests.