### PR TITLE
Fixed #267 #261: custom ENV for IDLE_TIMEOUT and container-killed event

### DIFF
--- a/dispatcher/backend/src/common/entities.py
+++ b/dispatcher/backend/src/common/entities.py
@@ -6,6 +6,7 @@ class TaskStatus:
     succeeded = 'succeeded'
     container_started = 'container_started'
     container_finished = 'container_finished'
+    container_killed = 'container_killed'
     failed = 'failed'
     retried = 'retried'
     revoked = 'revoked'
@@ -16,7 +17,9 @@ class TaskStatus:
 
     @classmethod
     def all(cls):
-        return [cls.sent, cls.received, cls.started, cls.succeeded, cls.failed, cls.retried, cls.revoked]
+        return [cls.sent, cls.received, cls.started, cls.succeeded,
+                cls.container_started, cls.container_finished, cls.container_killed,
+                cls.failed, cls.retried, cls.revoked]
 
 
 class ScheduleCategory:

--- a/dispatcher/monitor/app/entities.py
+++ b/dispatcher/monitor/app/entities.py
@@ -5,6 +5,7 @@ class TaskEvent:
     succeeded = 'succeeded'
     container_started = 'container_started'
     container_finished = 'container_finished'
+    container_killed = 'container_killed'
     failed = 'failed'
     retried = 'retried'
     revoked = 'revoked'

--- a/dispatcher/monitor/app/monitor.py
+++ b/dispatcher/monitor/app/monitor.py
@@ -32,6 +32,7 @@ class Monitor:
                 'task-revoked': task_handlers.TaskRevokedEventHandler(),
                 'task-container_started': task_handlers.TaskContainerStartedEventHandler(),
                 'task-container_finished': task_handlers.TaskContainerFinishedEventHandler(),
+                'task-container_killed': task_handlers.TaskContainerKilledEventHandler(),
                 '*': self.handle_others}
             receiver = self.celery.events.Receiver(connection, handlers=handlers)
             receiver.capture(limit=None, timeout=None, wakeup=True)

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -11,6 +11,7 @@ ENV USERNAME username
 ENV PASSWORD password
 ENV NODE_NAME default_node_name
 ENV QUEUES celery
+ENV IDLE_TIMEOUT 600
 
 ENV DISPATCHER_HOST farm.openzim.org
 ENV RABBIT_PORT 5671

--- a/worker/Dockerfile
+++ b/worker/Dockerfile
@@ -11,6 +11,7 @@ ENV USERNAME username
 ENV PASSWORD password
 ENV NODE_NAME default_node_name
 ENV QUEUES celery
+ENV CONCURRENCY 1
 ENV IDLE_TIMEOUT 600
 
 ENV DISPATCHER_HOST farm.openzim.org

--- a/worker/README.md
+++ b/worker/README.md
@@ -23,6 +23,7 @@ Any Linux or Unix based system that has Docker installed. Windows are not suppor
 - WORKING_DIR: path of a working directory in host system
 - NODE_NAME: name of the celery node
 - CONCURRENCY: max number of concurrent tasks, default to number of CPU cores
+- IDLE_TIMEOUT: max number of seconds without new log entry before failing (default: 600)
 - QUEUES: comma separated queue names
   - default
   - small

--- a/worker/app/operations/base.py
+++ b/worker/app/operations/base.py
@@ -6,6 +6,8 @@ from typing import Optional
 from aiodocker.containers import DockerContainer
 from celery.utils.log import get_task_logger
 
+from utils.settings import Settings
+
 logger = get_task_logger(__name__)
 
 
@@ -38,9 +40,10 @@ class Operation:
         await docker.close()
 
     @staticmethod
-    async def _detect_stuck(container: DockerContainer, max_wait: int = 600):
+    async def _detect_stuck(container: DockerContainer, max_wait: int = None):
         histories = []
         interval = 60
+        max_wait = max_wait or Settings.idle_timeout
         while True:
             latest = await container.log(stdout=True, stderr=False, tail=100)
             histories.append(latest)

--- a/worker/app/tasks/mwoffliner.py
+++ b/worker/app/tasks/mwoffliner.py
@@ -41,7 +41,7 @@ class MWOffliner(Base):
                 run_mwoffliner = RunMWOffliner(
                     docker_client=docker.from_env(), tag=image_tag, flags=flags,
                     task_id=self.task_id, working_dir_host=Settings.working_dir_host,
-                    redis_container=redis_container, dns=self.get_dns())
+                    redis_container=redis_container, dns=self.get_dns(), on_kill_cb=self.on_container_killed)
                 logger.info(f'Running MWOffliner, mwUrl: {flags["mwUrl"]}')
                 logger.debug(f'Running MWOffliner, dns={run_mwoffliner.dns}, command: {run_mwoffliner.command}')
 
@@ -65,3 +65,6 @@ class MWOffliner(Base):
         except docker.errors.ContainerError as e:
             self.clean_up()
             raise Exception from e
+
+    def on_container_killed(self, timeout):
+        self.send_event('task-container_killed', timeout)

--- a/worker/app/utils/settings.py
+++ b/worker/app/utils/settings.py
@@ -33,19 +33,19 @@ class Settings:
     def sanity_check(cls):
         # check mandatory env variables exist
         if cls.username is None or cls.username == '':
-            logger.error('{} environmental variable is required.'.format('USERNAME'))
+            logger.error('{} environment variable is required.'.format('USERNAME'))
             sys.exit(1)
         if cls.password is None or cls.password == '':
-            logger.error('{} environmental variable is required.'.format('PASSWORD'))
+            logger.error('{} environment variable is required.'.format('PASSWORD'))
             sys.exit(1)
         if cls.working_dir_host is None or cls.working_dir_host == '':
-            logger.error('{} environmental variable is required.'.format('WORKING_DIR'))
+            logger.error('{} environment variable is required.'.format('WORKING_DIR'))
             sys.exit(1)
         if cls.node_name is None or cls.node_name == '' or cls.node_name == 'default_node_name':
-            logger.error('{} environmental variable is required.'.format('NODE_NAME'))
+            logger.error('{} environment variable is required.'.format('NODE_NAME'))
             sys.exit(1)
         if cls.queues is None or cls.queues == '':
-            logger.error('{} environmental variable is required.'.format('QUEUES'))
+            logger.error('{} environment variable is required.'.format('QUEUES'))
             sys.exit(1)
 
         # check working directory mapping inside container
@@ -100,13 +100,13 @@ class Settings:
     @classmethod
     def ensure_correct_typing(cls):
         try:
-            if cls.concurrency is not None:
+            if not isinstance(cls.concurrency, int):
                 cls.concurrency = int(cls.concurrency)
                 if cls.concurrency < 1:
-                    logger.error('CONCURRENCY environmental variable cannot be less than one.')
+                    logger.error('CONCURRENCY environment variable cannot be less than one.')
                     sys.exit(1)
         except ValueError:
-            logger.error('CONCURRENCY environmental variable is not an integer.')
+            logger.error('CONCURRENCY environment variable is not an integer.')
             sys.exit(1)
         try:
             if not isinstance(cls.idle_timeout, int):
@@ -120,12 +120,12 @@ class Settings:
         try:
             cls.rabbit_port = int(cls.rabbit_port)
         except ValueError:
-            logger.error('RABBIT_PORT environmental variable is not an integer.')
+            logger.error('RABBIT_PORT environment variable is not an integer.')
             sys.exit(1)
         try:
             cls.warehouse_port = int(cls.warehouse_port)
         except ValueError:
-            logger.error('WAREHOUSE_PORT environmental variable is not an integer.')
+            logger.error('WAREHOUSE_PORT environment variable is not an integer.')
             sys.exit(1)
 
     @classmethod

--- a/worker/app/utils/settings.py
+++ b/worker/app/utils/settings.py
@@ -15,6 +15,7 @@ class Settings:
     node_name: str = os.getenv('NODE_NAME', None)
     queues: str = os.getenv('QUEUES', None)
     concurrency: int = os.getenv('CONCURRENCY', None)
+    idle_timeout: int = os.getenv('IDLE_TIMEOUT', None)
 
     dispatcher_hostname: str = os.getenv('DISPATCHER_HOST', 'farm.openzim.org')
     rabbit_port: int = os.getenv('RABBIT_PORT', 5671)
@@ -108,6 +109,15 @@ class Settings:
             logger.error('CONCURRENCY environmental variable is not an integer.')
             sys.exit(1)
         try:
+            if not isinstance(cls.idle_timeout, int):
+                cls.idle_timeout = int(cls.idle_timeout)
+                if cls.idle_timeout < 1:
+                    logger.error('IDLE_TIMEOUT environment variable cannot be less than one.')
+                    sys.exit(1)
+        except ValueError:
+            logger.error('IDLE_TIMEOUT environment variable is not an integer.')
+            sys.exit(1)
+        try:
             cls.rabbit_port = int(cls.rabbit_port)
         except ValueError:
             logger.error('RABBIT_PORT environmental variable is not an integer.')
@@ -129,7 +139,8 @@ class Settings:
             'WORKING_DIR': cls.working_dir_host,
             'NODE_NAME': cls.node_name,
             'QUEUES': cls.queues,
-            'CONCURRENCY': cls.concurrency
+            'CONCURRENCY': cls.concurrency,
+            'IDLE_TIMEOUT': cls.idle_timeout,
         }
 
         for name, value in variables.items():


### PR DESCRIPTION
## Rationale

* Fixes #267
* Fixes #261 

Here's a combination (for review/merge sake) of two fixes: the customization of the idle timeout via an `ENV` and the report of a killed container to the zimfarm.

Currently, the idle timeout is a fixed 10mn hard-coded.

Also, there is no trace of a container being killed except a single line in the worker log (not accessible then). We used to guess a killed due to the mwoffliner exit_code but that's neither wanted nor reliable.

## Changes

__#267__
* Added an `ENV` to Dockerfile, int-casting and no value handling.
* Used the opportunity to fix a typo in log messages on settings
* harmonized `ENV` usage for concurrency as it's similar.

_Note_: not using default parameter in `_detect_stuck` definition as it is parsed at import time.

__#261__
chose to go with a _dumb_ `container-killed` event instead of changing the `container-finished` one to keep it simple. It's just an extra event letting us know that container was killed.

* Added `container_killed` in `TaskEvent` and `TaskStatus` (backend)
* Added a monitor handler for `task-container_killed` event: saves event to mongo (with the passed `timeout`)
* `on_container_killed(timeout)` in `MWOffliner` Task that emits the event.

_note_: not displaying the timeout in the UI. Seems unnecessary (can be retrieved via API).