### PR TITLE
Fixed #239: added ulimit config details to README

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -6,15 +6,15 @@ After successfully established a secure connection with dispatcher,
 worker will receive and execute tasks to generate zim files. Each task
 contains roughly three stages:
 
-- prepare: run helper docker containers, pull images, etc
-- generate: generate zim files using a offliner docker container
+- prepare: run helper Docker containers, pull images, etc
+- generate: generate zim files using a offliner Docker container
 - upload: upload the zim files back to zimfarm warehouse
 
-To run containers, zimfarm worker need to have access to a docker socket on the host system.
+To run containers, zimfarm worker need to have access to a Docker socket on the host system.
 
 ## Requirements:
 
-Any Linux or Unix based system that has docker installed. Windows are not supported.
+Any Linux or Unix based system that has Docker installed. Windows are not supported.
 
 ## Environmental Variables
 
@@ -31,8 +31,8 @@ Any Linux or Unix based system that has docker installed. Windows are not suppor
 
 ## Docker Volumes
 
-- docker socket `/var/run/docker.sock:/var/run/docker.sock`
-- rsa private key `PATH:/usr/src/.ssh/id_rsa`
+- Docker socket `/var/run/docker.sock:/var/run/docker.sock`
+- RSA private key `PATH:/usr/src/.ssh/id_rsa`
 - working dir `PATH:/zim_files`
 
 ## Upload Your RSA Key
@@ -92,14 +92,14 @@ openzim/zimfarm-worker:latest
 
 ## Optimization
 
-Workers (containers and sub-containers) inherits resources limits from the docker daemon which is usually launched as root.
+Workers (containers and sub-containers) inherits resources limits from the Docker daemon which is usually launched as root.
 
 For workers' purposes, it is interesting to have the most available number of files open (`nofile`/`-n`) and the largest `stack`/`-s`).
 
-You can check docker's limits via:
+You can check Docker's limits via:
 
 ``` sh
-cat /proc/$(ps -ef | grep dockerd | head -n 1 |awk '{ print $2 }')/limits
+cat /proc/$(ps -ef | grep dockerd | grep -v grep | head -n 1 | awk '{ print $2 }')/limits
 ```
 
 Look for `Max stack size` and `Max open files`.
@@ -111,15 +111,15 @@ Look for `Max stack size` and `Max open files`.
 * Change System and User values in systemd
 
 ``` sh
-echo "DefaultLimitNOFILE=1048576" |sudo tee /etc/systemd/system.conf /etc/systemd/user.conf
+echo "DefaultLimitNOFILE=infinity" |sudo tee /etc/systemd/system.conf /etc/systemd/user.conf
 echo "DefaultLimitSTACK=infinity" |sudo tee /etc/systemd/system.conf /etc/systemd/user.conf
 sudo systemctl daemon-reexec
 ```
-* Add overrides to `docker` service definition
+* Add overrides to `docker` service definition (to secure that Docker does not have lower limits)
 
 ``` sh
 sudo mkdir -p /etc/systemd/system/docker.service.d/
-echo -e "[Service]\nLimitNOFILE=1048576\nLimitSTACK=infinity" |sudo tee /etc/systemd/system/docker.service.d/override.conf
+echo -e "[Service]\nLimitNOFILE=infinity\nLimitSTACK=infinity" | sudo tee /etc/systemd/system/docker.service.d/override.conf
 sudo systemctl daemon-reload
 sudo systemctl restart docker
 ```
@@ -127,7 +127,7 @@ sudo systemctl restart docker
 Verify that new values applied (reboot might help):
 
 ``` sh
-cat /proc/$(ps -ef | grep dockerd | head -n 1 |awk '{ print $2 }')/limits
+cat /proc/$(ps -ef | grep dockerd | grep -v grep | head -n 1 | awk '{ print $2 }')/limits
 ```
 
 _Note_: `/etc/security/limits.conf` is not used anymore on systemd-based distro.


### PR DESCRIPTION
## Rationale

#239 

## Changes

* Updated README
* Applied it to all WMF workers

```
reg@mwoffliner5:~$ cat /proc/$(ps -ef | grep dockerd | head -n 1 |awk '{ print $2 }')/limits
Limit                     Soft Limit           Hard Limit           Units
Max cpu time              unlimited            unlimited            seconds
Max file size             unlimited            unlimited            bytes
Max data size             unlimited            unlimited            bytes
Max stack size            unlimited            unlimited            bytes
Max core file size        unlimited            unlimited            bytes
Max resident set          unlimited            unlimited            bytes
Max processes             unlimited            unlimited            processes
Max open files            1048576              1048576              files
Max locked memory         65536                65536                bytes
Max address space         unlimited            unlimited            bytes
Max file locks            unlimited            unlimited            locks
Max pending signals       64113                64113                signals
Max msgqueue size         819200               819200               bytes
Max nice priority         0                    0
Max realtime priority     0                    0
Max realtime timeout      unlimited            unlimited            us
```
