### PR TITLE
Fixed #232: Added support for Gutenberg offliner

### DIFF
--- a/dispatcher/backend/src/routes/schedules/validators.py
+++ b/dispatcher/backend/src/routes/schedules/validators.py
@@ -44,21 +44,24 @@ mwoffliner_flags_validator = t.Dict({
 })
 
 phet_flags_validator = t.Dict()
+gutenberg_flags_validator = t.Dict()
 
 config_validator = ConfigValidator({
-    t.Key('task_name'): t.Enum('offliner.mwoffliner', 'offliner.phet'),
+    t.Key('task_name'): t.Enum('offliner.mwoffliner', 'offliner.phet', 'offliner.gutenberg'),
     t.Key('queue'): t.Enum(*ScheduleQueue.all()),
     t.Key('warehouse_path'): t.Enum(*ScheduleCategory.all_warehouse_paths()),
     t.Key('image'): t.Dict(
-        t.Key('name', trafaret=t.Enum('openzim/mwoffliner', 'openzim/phet')),
+        t.Key('name', trafaret=t.Enum('openzim/mwoffliner', 'openzim/phet', 'openzim/gutenberg')),
         t.Key('tag', trafaret=t.String)),
-    t.Key('flags'): t.Or(mwoffliner_flags_validator, phet_flags_validator),
+    t.Key('flags'): t.Or(mwoffliner_flags_validator, phet_flags_validator, gutenberg_flags_validator),
 })
 
 
 def get_flags_validator(task_name):
     if task_name == "offliner.phet":
         return phet_flags_validator
+    if task_name == "offliner.gutenberg":
+        return gutenberg_flags_validator
     if task_name == "offliner.mwoffliner":
         return mwoffliner_flags_validator
     return t.Dict()

--- a/dispatcher/backend/src/tests/integration/routes/conftest.py
+++ b/dispatcher/backend/src/tests/integration/routes/conftest.py
@@ -77,6 +77,7 @@ def schedules(make_schedule, make_config, make_language):
     schedules.append(make_schedule(name="wikipedia_fr_all_maxi"))
     schedules.append(make_schedule(name="wikipedia_fr_all_nopic"))
     schedules.append(make_schedule(name="wikipedia_bm_all_nopic"))
+    schedules.append(make_schedule(name="schedule_42", category="gutenberg"))
     schedules.append(make_schedule(language=make_language(code="fr"),
                                    name="schedule_43"))
     schedules.append(make_schedule(language=make_language(code="bm"),

--- a/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
+++ b/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
@@ -26,6 +26,13 @@ good_patch_updates = [
         'flags': {},
         'image': {'name': 'openzim/phet', 'tag': 'latest'},
     }},
+    {'config': {
+        'task_name': 'offliner.gutenberg',
+        'queue': 'large',
+        'warehouse_path': '/gutenberg',
+        'flags': {},
+        'image': {'name': 'openzim/gutenberg', 'tag': 'latest'},
+    }},
     {'name': 'new_name'},
 ]
 
@@ -76,6 +83,13 @@ bad_patch_updates = [
         'warehouse_path': '/phet',
         'flags': {},
         'image': {'name': 'openzim/youtube', 'tag': 'latest'},
+    }},
+    {'config': {
+        'task_name': 'offliner.gutenberg',
+        'queue': 'small',
+        'warehouse_path': '/gutenberg',
+        'flags': {},
+        'image': {'name': 'openzim/youtube', 'tag': 'latest'},
     }}
 ]
 
@@ -102,7 +116,7 @@ class TestScheduleList:
             assert isinstance(item['tags'], list)
 
     @pytest.mark.parametrize('skip, limit, expected', [
-        (0, 30, 30), (10, 15, 15), (40, 25, 10), (100, 100, 0), ('', 10, 10), (5, 'abc', 20)
+        (0, 30, 30), (10, 15, 15), (40, 25, 11), (100, 100, 0), ('', 10, 10), (5, 'abc', 20)
     ])
     def test_list_schedules_with_param(self, client, access_token, schedules, skip, limit, expected):
 
@@ -122,14 +136,16 @@ class TestScheduleList:
         ("lang=bm", 1),
         ("lang=bm&lang=fr", 3),
         ("category=phet", 1),
+        ("category=gutenberg", 1),
         ("category=wikibooks", 1),
         ("category=wikipedia", 47),
         ("category=phet&category=wikipedia", 48),
+        ("category=gutenberg&category=phet&category=wikipedia", 49),
         ("tag=all", 2),
         ("tag=mini", 2),
         ("tag=all&tag=mini", 1),
         ("queue=small", 2),
-        ("queue=offliner_default", 48),
+        ("queue=offliner_default", 49),
         ("queue=offliner_default&queue=small", 50),
         ("name=youtube&lang=fr&category=other&tag=nopic&tag=novid&queue=small", 1),
     ])
@@ -152,8 +168,8 @@ class TestScheduleList:
 
 class TestSchedulePost:
 
-    def test_create_schedule(self, database, client, access_token):
-        schedule = {
+    @pytest.mark.parametrize('document', [
+        {
             "name": "wikipedia_bm_test",
             "category": "wikipedia",
             "enabled": False,
@@ -170,22 +186,41 @@ class TestSchedulePost:
                 "flags": {},
                 "image": {"name": "openzim/phet", "tag": "latest"},
             },
-        }
+        },
+        {
+            "name": "gutenberg_multi",
+            "category": "gutenberg",
+            "enabled": True,
+            "tags": ["full", "multi"],
+            "language": {
+                "code": "multi",
+                "name_en": "Multiple Languages",
+                "name_native": "Multiple Languages",
+            },
+            "config": {
+                "task_name": "offliner.gutenberg",
+                "queue": "debug",
+                "warehouse_path": "/gutenberg",
+                "flags": {},
+                "image": {"name": "openzim/gutenberg", "tag": "latest"},
+            },
+        }])
+    def test_create_schedule(self, database, client, access_token, document):
 
         url = '/api/schedules/'
-        response = client.post(url, json=schedule, headers={'Authorization': access_token})
+        response = client.post(url, json=document, headers={'Authorization': access_token})
         assert response.status_code == 201
 
-        url = '/api/schedules/{}'.format(schedule['name'])
+        url = '/api/schedules/{}'.format(document['name'])
         response = client.get(url, headers={'Authorization': access_token})
         assert response.status_code == 200
 
         response_json = response.get_json()
-        schedule['_id'] = response_json['_id']
-        assert response.get_json() == schedule
+        document['_id'] = response_json['_id']
+        assert response.get_json() == document
 
         # remove from DB to prevent count mismatch on other tests
-        database.schedules.delete_one({'_id': ObjectId(schedule['_id'])})
+        database.schedules.delete_one({'_id': ObjectId(document['_id'])})
 
     @pytest.mark.parametrize('key', ['name', 'category', 'enabled', 'tags', 'language', 'config'])
     def test_create_schedule_missing_keys(self, client, access_token, key):

--- a/worker/app/operations/__init__.py
+++ b/worker/app/operations/__init__.py
@@ -1,4 +1,5 @@
 from .run_redis import RunRedis
 from .run_mwoffliner import RunMWOffliner
 from .run_phet import RunPhet
+from .run_gutenberg import RunGutenberg
 from .upload import Upload

--- a/worker/app/operations/run_gutenberg.py
+++ b/worker/app/operations/run_gutenberg.py
@@ -1,0 +1,51 @@
+from pathlib import Path
+
+from docker import DockerClient
+from docker.models.containers import Container
+
+from .base import Operation, ContainerResult
+from .upload import Upload
+
+from celery.utils.log import get_task_logger
+logger = get_task_logger(__name__)
+
+class RunGutenberg(Operation):
+    """Run Gutenberg container with `config`"""
+
+    def __init__(self, docker_client: DockerClient, tag: str, flags: {}, task_id: str, working_dir_host: str, dns: str):
+        tag = 'latest' if not tag else tag
+        super().__init__()
+        self.docker = docker_client
+        self.command = self._get_command(flags)
+        self.task_id = task_id
+        self.working_dir_host = Path(working_dir_host).joinpath(self.task_id).absolute()
+        self.image_name = 'openzim/gutenberg:{}'.format(tag)
+        self.dns = dns
+
+    def execute(self) -> ContainerResult:
+        """Pull and run gutenberg"""
+
+        # pull gutenberg image
+        self.docker.images.pull(self.image_name)
+
+        # run gutenberg
+        volumes = {self.working_dir_host: {'bind': '/output', 'mode': 'rw'}}
+        container: Container = self.docker.containers.run(
+            image=self.image_name, command=self.command, volumes=volumes, detach=True,
+            name=f'gutenberg_{self.task_id}', dns=self.dns)
+
+        exit_code = container.wait()['StatusCode']
+
+        container_log = Upload.upload_log(container)
+
+        stdout = container.logs(stdout=True, stderr=False, tail=100).decode("utf-8")
+        stderr = container.logs(stdout=False, stderr=True).decode("utf-8")
+        result = ContainerResult(self.image_name, self.command, exit_code, stdout, stderr, container_log)
+
+        container.remove()
+
+        return result
+
+    @staticmethod
+    def _get_command(flags: {}):
+        return 'gutenberg2zim --complete --formats all --one-language-one-zim /output'

--- a/worker/app/tasks/__init__.py
+++ b/worker/app/tasks/__init__.py
@@ -1,2 +1,3 @@
 from .mwoffliner import MWOffliner
 from .phet import Phet
+from .gutenberg import Gutenberg

--- a/worker/app/tasks/gutenberg.py
+++ b/worker/app/tasks/gutenberg.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import docker
+import docker.errors
+from celery.utils.log import get_task_logger
+
+from operations import RunGutenberg
+from utils import Settings
+from .base import Base
+
+logger = get_task_logger(__name__)
+
+
+class Gutenberg(Base):
+    """Gutenberg zimfarm task. This task have two steps:
+
+    - generate zim files using gutenberg (for all languages at once)
+    - upload generated zim files
+
+    Steps will be executed one after another.
+    """
+
+    name = 'offliner.gutenberg'
+
+    def run(self, flags: dict, image: dict, warehouse_path: str, *args, **kwargs):
+        """Run Gutenberg based offliner tasks.
+
+        :param flags: offliner flags (phet has none)
+        :param image: offliner image name and tag
+        :param warehouse_path: folder to upload files into
+        :return:
+        """
+
+        image_tag = image.get('tag', 'latest')
+        working_dir_container = Path(Settings.working_dir_container).joinpath(self.task_id)
+
+        try:
+            # run gutenberg
+            run_gutenberg = RunGutenberg(
+                docker_client=docker.from_env(), tag=image_tag, flags=flags,
+                task_id=self.task_id, working_dir_host=Settings.working_dir_host,
+                dns=self.get_dns())
+            logger.info(f'Running Gutenberg')
+            logger.debug(f'Running Gutenberg, dns={run_gutenberg.dns}, command: {run_gutenberg.command}')
+            self.send_event('task-container_started', image=image, command=run_gutenberg.command)
+
+            result = run_gutenberg.execute()
+            logger.info(f'Gutenberg finished, exit code: {result.exit_code}')
+            self.send_event('task-container_finished', exit_code=result.exit_code, stdout=result.stdout, stderr=result.stderr)
+
+            if not result.is_successful():
+                raise Exception(str(result))
+
+            # upload files
+            files = self.upload_zims(remote_working_dir=warehouse_path, directory=working_dir_container)
+
+            return files
+        except docker.errors.APIError as e:
+            raise self.retry(exc=e)
+        except (docker.errors.ContainerError, docker.errors.ImageNotFound) as e:
+            raise Exception from e

--- a/worker/app/worker.py
+++ b/worker/app/worker.py
@@ -47,6 +47,7 @@ class Worker:
         # register tasks
         app.register_task(tasks.MWOffliner())
         app.register_task(tasks.Phet())
+        app.register_task(tasks.Gutenberg())
 
         # configure queues
         exchange = Exchange('offliner', 'topic')


### PR DESCRIPTION
## Rationale

#232 

## Changes

Simple offliner without flags (builds all languages ZIM at once), similar to PhET.

* validators changes: blank validator, offliner name, image name
* `RunGutenberg` operation
* `Gutenberg` task
