### PR TITLE
Add option to use public DNS or not

### DIFF
--- a/dnscache/Dockerfile
+++ b/dnscache/Dockerfile
@@ -2,17 +2,15 @@ FROM alpine:edge
 
 RUN apk update && apk --no-cache add dnsmasq
 
+RUN echo -e "# CloudFlare\nnameserver 1.1.1.1\n# Google DNS\nnameserver 8.8.8.8\n# OpenDNS\n# nameserver 208.67.222.222\n# nameserver 208.67.220.220" > /etc/resolv.dnsmasq.public
+RUN ln -sf /etc/resolv.conf /etc/resolv.dnsmasq
+
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 # --no-daemon and --keep-in-foreground are similar
 # but no-deamon has debug enabled (and thus starts with useful output)
 
-ENTRYPOINT ["dnsmasq", \
-			"--no-daemon", \
-			"--user=root", \
-			"--conf-file=/etc/dnsmasq.conf", \
-			"--domain-needed", \
-			"--bogus-priv", \
-			"--no-hosts", \
-			"--min-cache-ttl=86400", \
-			"--cache-size=1000", \
-			"--neg-ttl=3600", \
-			"--no-poll"]
+ENTRYPOINT ["entrypoint.sh"]
+
+CMD ["dnsmasq", "--no-daemon", "--user=root", "--conf-file=/etc/dnsmasq.conf", "--resolv-file=/etc/resolv.dnsmasq", "--domain-needed", "--bogus-priv", "--no-hosts", "--min-cache-ttl=86400", "--cache-size=1000", "--neg-ttl=3600", "--no-poll"]

--- a/dnscache/README.md
+++ b/dnscache/README.md
@@ -11,6 +11,12 @@ At the moment, this container has a static config of **caching every domain for 
 docker run --name dnscache openzim/dnscache
 ```
 
+It uses the host's DNS configuration (`/etc/resolv.conf`) or a mix of public DNS (CloudFare, Google, OpenDNS – all IPv4) if `USE_PUBLIC_DNS=yes`.
+
+``` sh
+docker run --name dnscache --env USE_PUBLIC_DNS=yes openzim/dnscache
+```
+
 To use your DNS cache container, you need to run your scrapper(s) with the `--dns=` option. This option **only accepts** IPv4 and IPv6 values (no alias).
 
 ### Find out the IP of your `dnscache` container:

--- a/dnscache/entrypoint.sh
+++ b/dnscache/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+if [ "$USE_PUBLIC_DNS" = "yes" ]; then
+	echo "starting dnscache with Public DNS"
+	ln -sf /etc/resolv.dnsmasq.public /etc/resolv.dnsmasq
+else
+	echo "starting dnscache with inherited DNS"
+	ln -sf /etc/resolv.conf /etc/resolv.dnsmasq
+fi
+
+exec "$@"

--- a/worker/README.md
+++ b/worker/README.md
@@ -18,17 +18,18 @@ Any Linux or Unix based system that has Docker installed. Windows are not suppor
 
 ## Environmental Variables
 
-- USERNAME
-- PASSWORD
-- WORKING_DIR: path of a working directory in host system
-- NODE_NAME: name of the celery node
-- CONCURRENCY: max number of concurrent tasks, default to number of CPU cores
-- IDLE_TIMEOUT: max number of seconds without new log entry before failing (default: 600)
-- QUEUES: comma separated queue names
-  - default
-  - small
-  - medium
-  - large
+- `USERNAME`
+- `PASSWORD`
+- `WORKING_DIR`: path of a working directory in host system
+- `NODE_NAME`: name of the celery node
+- `CONCURRENCY`: max number of concurrent tasks, default to number of CPU cores
+- `IDLE_TIMEOUT`: max number of seconds without new log entry before failing (default: 600)
+- `QUEUES`: comma separated queue names
+  - `default`
+  - `small`
+  - `medium`
+  - `large`
+- `USE_PUBLIC_DNS`: set to `yes` to use Public DNS services in `dnscache` container (attached to all scraper containers). Otherwise inherits DNS config from host.
 
 ## Docker Volumes
 
@@ -138,6 +139,7 @@ _Note_: `/etc/security/limits.conf` is not used anymore on systemd-based distro.
 We recommend to clean periodicaly and automatically unused Docker
 layers. Here is a script example (with execution
 permission) to be executed on a daily basis on the host system:
+
 ```bash
 cat /etc/cron.daily/docker-clean
 #!/bin/bash

--- a/worker/app/operations/run_dnscache.py
+++ b/worker/app/operations/run_dnscache.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 
 import docker
@@ -27,8 +28,9 @@ class RunDNSCache(Operation):
 
         remove_existing_container(self.docker, name=self.container_name)
 
+        environment = {"USE_PUBLIC_DNS": os.getenv("USE_PUBLIC_DNS", "no")}
         image = self.docker.images.pull('openzim/dnscache', tag='latest')
-        self._container = self.docker.containers.run(image, detach=True, name=self.container_name)
+        self._container = self.docker.containers.run(image, detach=True, name=self.container_name, environment=environment)
         return self._container
 
     def get_ip_addresses(self):


### PR DESCRIPTION
## Rationale

On athena18 worker, we can't use the host's DNS as we don't manage the host and it's using a local cache.

To be able to support this use case and the classic one, we add support for inherited or public DNS conf via a `USE_PUBLIC_DNS=yes` environment variable.

## Changes

* restored public name servers in dnscache container (only IPv4 though)
* added an entrypoint to switch from inherited to public on runtime
* edited dnscache README
* added environment config to `RunDNSCache` (just forwarding worker's env)
* edited worker README
