### PR TITLE
Upload files using new uploader container

### DIFF
--- a/worker/app/operations/upload.py
+++ b/worker/app/operations/upload.py
@@ -1,14 +1,13 @@
+import os
 import re
 import lzma
-import tempfile
 import logging
 from pathlib import Path
 
-from paramiko.ssh_exception import SSHException
+import docker
 
-from utils.settings import Settings
-from utils.sftp import SFTPClient
 from .base import Operation, UploadError
+from utils.settings import Settings
 
 MAX_UPLOAD_LOG_LINES = 10 ** 6
 logger = logging.getLogger(__name__)
@@ -31,24 +30,72 @@ class Upload(Operation):
         self.remote_working_dir = remote_working_dir
         self.files = files
         self.delete = delete
+        self.image_name = 'openzim/uploader'
+
+    def get_private_key_host_path(self):
+        """ private key path on host by inspecting current container """
+        container_id = os.getenv("HOSTNAME", "zimfarm_worker")
+        api_client = docker.APIClient(base_url=f'unix://{Settings.docker_socket}')
+        try:
+            for mount in api_client.inspect_container(container_id)["Mounts"]:
+                if mount["Destination"] == str(Settings.private_key):
+                    return mount["Source"]
+        except Exception as exc:
+            logger.exception(exc)
+            raise ValueError("unable to find RSA private key path on host")
 
     def execute(self):
-        hostname = Settings.warehouse_hostname
-        port = Settings.warehouse_port
-        username = Settings.username
-        private_key = Settings.private_key
+        docker_client = docker.from_env()
+        docker_client.images.pull(self.image_name)
 
-        try:
-            with SFTPClient(hostname, port, username, private_key) as client:
-                for file in self.files:
-                    if file.is_dir():
-                        continue
-                    client.upload_file(self.remote_working_dir, file)
+        working_dir_host = Path(Settings.working_dir_host)
+        working_dir_container = Path(Settings.working_dir_container)
+        working_dir_target = Path("/output")  # working-dir mount point in target
+        private_key = self.get_private_key_host_path()  # private key path on host
 
-                    if self.delete:
-                        file.unlink()
-        except SSHException as e:
-            raise UploadError(code='paramiko.Error', message=str(e))
+        # mount working-dir and private key to uploader
+        volumes = {working_dir_host: {'bind': str(working_dir_target), 'mode': 'rw'},
+                   private_key: {'bind': '/etc/ssh/keys/id_rsa', 'mode': 'ro'}}
+        # prepare non-file-specific uploader args
+        base_args = ['uploader', '--username', Settings.username,
+                     '--upload-uri', f'sftp://{Settings.warehouse_hostname}:{Settings.warehouse_port}/{self.remote_working_dir}/']
+        if self.delete:
+            base_args += ["--delete"]
+
+        for file in self.files:
+            if file.is_dir():
+                continue
+
+            if working_dir_container not in file.parents:
+                raise ValueError(f"can't upload file from outside host volume: {file}")
+
+            # replace local path (mounted volume) to target (in uploader mounted volume)
+            target_path = re.sub(
+                r"^({working_dir})".format(working_dir=working_dir_container),
+                str(working_dir_target),
+                str(file), 1)
+            # add file path to uploader args
+            args = base_args + ['--file', target_path]
+
+            logger.debug(args)
+
+            try:
+                container_log = docker_client.containers.run(
+                    image=self.image_name, remove=True,
+                    command=args, volumes=volumes)
+            except docker.errors.ContainerError as exc:
+                try:
+                    logger.error(container_log)
+                except Exception:
+                    pass
+                raise UploadError(code=exc.exit_status,
+                                  msg=f'failed to upload {file.name}. uploader exited with `{exc.exit_status}`')
+            except (docker.errors.APIError, docker.errors.ImageNotFound) as exc:
+                logger.exception(exc)
+                raise UploadError(code='docker',
+                                  msg=f'Docker error while uploading: {exc}')
+            else:
+                logger.info(f'successfuly uploaded {file.name}')
 
     @staticmethod
     def upload_files(remote_working_dir: str, files: list = None, delete: bool = False):
@@ -76,7 +123,8 @@ class Upload(Operation):
         """fetch, compress and upload the container's stdout to the warehouse"""
 
         # compress log output (using a 1M lines buffer to prevent swap)
-        archive = Path(tempfile.gettempdir()).joinpath(container.name + '.log.xz')
+        archive = Path(Settings.working_dir_container).joinpath(
+            container.name + '.log.xz')
         with lzma.open(archive, 'wb') as f:
             buff, count = (b'', 0)
             for line in container.logs(stdout=True, stderr=True, stream=True):


### PR DESCRIPTION
## Rationale

* testing uploader and validating its robustness while we re-org the rest of the worker

## Changes

* Upload method code changed to prepare and start an uploader container
  * find private key on host and mount
  * mount working dir
  * replace local path with in-uploader one
  * fire the container and report error if any

_Note_: uploader containers don't have task-specific names (docker generated)