### PR TITLE
warehouse: setting fixed paramiko version and generating RSA key in PEM

### DIFF
--- a/warehouse/Dockerfile
+++ b/warehouse/Dockerfile
@@ -6,7 +6,7 @@ COPY ./app/requirements.txt /usr/src/app/requirements.txt
 
 RUN pip3 install -r ./app/requirements.txt
 RUN mkdir /files
-RUN ssh-keygen -t rsa -N "" -f server.key
+RUN ssh-keygen -t RSA -m PEM -N "" -f server.key
 
 ENV RSA_KEY server.key
 ENV PORT 22

--- a/warehouse/app/requirements.txt
+++ b/warehouse/app/requirements.txt
@@ -1,1 +1,1 @@
-paramiko>=2.4
+paramiko==2.6.0


### PR DESCRIPTION

## Rationale

* updated paramiko requires RSA private key in PEM format.
* was auto updated as not using fixed version

## Changes

* fixed version
* using PEM
