### PR TITLE
using python:3.8-buster for most images

### DIFF
--- a/dispatcher/backend/Dockerfile
+++ b/dispatcher/backend/Dockerfile
@@ -1,9 +1,4 @@
-FROM python:3.8-slim-buster
-
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends build-essential && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+FROM python:3.8-buster
 
 RUN ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 RUN echo "UTC" > /etc/timezone

--- a/dispatcher/relay/Dockerfile
+++ b/dispatcher/relay/Dockerfile
@@ -1,9 +1,4 @@
-FROM python:3.8-slim-buster
-
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends build-essential && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+FROM python:3.8-buster
 
 RUN ln -sf /usr/share/zoneinfo/UTC /etc/localtime
 RUN echo "UTC" > /etc/timezone

--- a/workers/manager-Dockerfile
+++ b/workers/manager-Dockerfile
@@ -1,9 +1,4 @@
-FROM python:3.8-slim-buster
-
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends build-essential && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+FROM python:3.8-buster
 
 WORKDIR /usr/src
 

--- a/workers/task-Dockerfile
+++ b/workers/task-Dockerfile
@@ -1,9 +1,4 @@
-FROM python:3.8-slim-buster
-
-RUN apt-get update -y && \
-    apt-get install -y --no-install-recommends build-essential && \
-    apt-get clean && \
-    rm -rf /var/lib/apt/lists/*
+FROM python:3.8-buster
 
 WORKDIR /usr/src
 


### PR DESCRIPTION
## Rationale

* we need build-essentials on all and openssh on some which are not in slim
* good  to harmonize across images

## Changes

docker base image off buster and not buster-slim