### PR TITLE
removing timezone stmts in dockerfiles

### DIFF
--- a/dispatcher/backend/Dockerfile
+++ b/dispatcher/backend/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:3.8-buster
 
-RUN ln -sf /usr/share/zoneinfo/UTC /etc/localtime
-RUN echo "UTC" > /etc/timezone
-
 RUN pip install -U pip
 RUN pip install uwsgi==2.0.18
 

--- a/dispatcher/relay/Dockerfile
+++ b/dispatcher/relay/Dockerfile
@@ -1,8 +1,5 @@
 FROM python:3.8-buster
 
-RUN ln -sf /usr/share/zoneinfo/UTC /etc/localtime
-RUN echo "UTC" > /etc/timezone
-
 RUN pip install -U pip zmq
 
 COPY relay.py /usr/local/bin/zimfarm-relay

--- a/uploader/Dockerfile
+++ b/uploader/Dockerfile
@@ -1,7 +1,5 @@
 FROM debian:bullseye-slim
 
-RUN ln -sf /usr/share/zoneinfo/UTC /etc/localtime
-RUN echo "UTC" > /etc/timezone
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends ssh curl python3 && \
     apt-get clean && \

--- a/workers/app/common/constants.py
+++ b/workers/app/common/constants.py
@@ -16,7 +16,7 @@ WORKER_MANAGER = "worker-manager"
 TASK_WORKER = "task-worker"
 
 # images
-TASK_WORKER_IMAGE = os.getenv("TASK_WORKER_IMAGE", "openzim/task_worker:latest")
+TASK_WORKER_IMAGE = os.getenv("TASK_WORKER_IMAGE", "openzim/zimfarm-task-worker:latest")
 
 # paths
 DEFAULT_WORKDIR = os.getenv("WORKDIR", "/data")  # in-container workdir for manager

--- a/workers/manager-Dockerfile
+++ b/workers/manager-Dockerfile
@@ -5,9 +5,6 @@ WORKDIR /usr/src
 COPY manager-requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 
-RUN ln -sf /usr/share/zoneinfo/UTC /etc/localtime
-RUN echo "UTC" > /etc/timezone
-
 COPY app app
 RUN ln -s /usr/src/app/worker_manager.py /usr/local/bin/worker-manager
 RUN chmod +x /usr/local/bin/worker-manager

--- a/workers/task-Dockerfile
+++ b/workers/task-Dockerfile
@@ -5,9 +5,6 @@ WORKDIR /usr/src
 COPY task-requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 
-RUN ln -sf /usr/share/zoneinfo/UTC /etc/localtime
-RUN echo "UTC" > /etc/timezone
-
 COPY app app
 RUN ln -s /usr/src/app/task_worker.py /usr/local/bin/task-worker
 RUN chmod +x /usr/local/bin/task-worker


### PR DESCRIPTION
## Rationale

* not clear how this is supposed to help
* suspect this is the reason our logs are f*ck'd up on sloppy

## Changes

* removed lines hardcoding timezone at build time on dockerfiles.

We should probably have reconfigured tzdata after setting it but I believe no-setting is good enough or we should be able to achieve anything with just setting `--env TZ=xxx` on run.
