### PR TITLE
better OFFLINERS= env: use only valid values

### DIFF
--- a/workers/app/common/constants.py
+++ b/workers/app/common/constants.py
@@ -89,4 +89,10 @@ ALL_OFFLINERS = [
     OFFLINER_PHET,
     OFFLINER_GUTENBERG,
 ]
-SUPPORTED_OFFLINERS = os.getenv("OFFLINERS", "").split(",") or ALL_OFFLINERS
+SUPPORTED_OFFLINERS = [
+    offliner
+    for offliner in (
+        list(filter(bool, os.getenv("OFFLINERS", "").split(","))) or ALL_OFFLINERS
+    )
+    if offliner in ALL_OFFLINERS
+]


### PR DESCRIPTION
if `OFFLINERS` not supplied: use `ALL_OFFLINERS`
if supplied, use only values from splitted (`,`) string that match a valid offliner.