### PR TITLE
restore selfish mode

### DIFF
--- a/dispatcher/backend/src/common/schemas/parameters.py
+++ b/dispatcher/backend/src/common/schemas/parameters.py
@@ -146,6 +146,7 @@ class UserUpdateSchema(Schema):
 # workers checkin
 class WorkerCheckInSchema(Schema):
     username = username_field
+    selfish = fields.Boolean(required=False, missing=False)
     cpu = fields.Integer(required=True, validate=validate_cpu)
     memory = fields.Integer(required=True, validate=validate_memory)
     disk = fields.Integer(required=True, validate=validate_disk)

--- a/dispatcher/backend/src/routes/workers/worker.py
+++ b/dispatcher/backend/src/routes/workers/worker.py
@@ -81,6 +81,7 @@ class WorkerCheckinRoute(BaseRoute):
         document = {
             "name": name,
             "username": request_json["username"],
+            "selfish": request_json["selfish"],
             "resources": {
                 "cpu": request_json["cpu"],
                 "memory": request_json["memory"],

--- a/dispatcher/backend/src/utils/scheduling.py
+++ b/dispatcher/backend/src/utils/scheduling.py
@@ -214,7 +214,11 @@ def get_reqs_doable_by(worker):
     query = {}
     for res_key in ("cpu", "memory", "disk"):
         query[f"config.resources.{res_key}"] = {"$lte": worker["resources"][res_key]}
+
     query["config.task_name"] = {"$in": worker["offliners"]}
+
+    if worker.get("selfish", False):
+        query["worker"] = worker["name"]
 
     projection = {
         "_id": 1,
@@ -308,7 +312,7 @@ def find_requested_task_for(username, worker_name, avail_cpu, avail_memory, avai
     # get total resources for that worker
     worker = Workers().find_one(
         {"username": username, "name": worker_name},
-        {"resources": 1, "offliners": 1, "last_seen": 1, "name": 1},
+        {"resources": 1, "offliners": 1, "last_seen": 1, "name": 1, "selfish": 1},
     )
 
     # worker is not checked-in

--- a/workers/app/manager/worker.py
+++ b/workers/app/manager/worker.py
@@ -136,6 +136,7 @@ class WorkerManager(BaseWorker):
             f"/workers/{self.worker_name}/check-in",
             payload={
                 "username": self.username,
+                "selfish": self.selfish,
                 "cpu": host_stats["cpu"]["total"],
                 "memory": host_stats["memory"]["total"],
                 "disk": host_stats["disk"]["total"],


### PR DESCRIPTION
selfish mode used to work by filtering-out tasks on the worker itself.
the backend was not aware of the selfishness of a worker.

when switching to advanced scheduling, we started returning a single, pre-selected
task for each poll. this rendered selfish useless.

this restores selfish mode by informing the API of the selfishness on check-in.
we shall now be able to distinguish selfish workers in the UI (not impl here).
scheduler now assigns tasks according to selfish mode.