### PR TITLE
race condition on log upload container removal 

### DIFF
--- a/workers/app/common/docker.py
+++ b/workers/app/common/docker.py
@@ -96,6 +96,11 @@ def remove_container(docker_client, *args, **kwargs):
     return retried_docker_call(docker_client.api.remove_container, *args, **kwargs)
 
 
+def prune_containers(docker_client, *args, **kwargs):
+    """ filters={} """
+    return retried_docker_call(docker_client.api.prune_containers, *args, **kwargs)
+
+
 def stop_container(docker_client, *args, **kwargs):
     """ container="", timeout=None """
     return retried_docker_call(docker_client.api.stop, *args, **kwargs)
@@ -373,6 +378,7 @@ def start_uploader(
     # remove container should it exists (should not)
     try:
         remove_container(docker_client, container_name)
+        prune_containers(docker_client, {"label": [f"filename={filename}"]})
     except docker.errors.NotFound:
         pass
 

--- a/workers/manager-requirements.txt
+++ b/workers/manager-requirements.txt
@@ -1,6 +1,6 @@
 zmq
 requests==2.22.0
-docker==4.1.0
+docker==4.2.0
 psutil==5.6.3
 humanfriendly==4.18
 PyJWT==1.7.1

--- a/workers/task-requirements.txt
+++ b/workers/task-requirements.txt
@@ -1,5 +1,5 @@
 requests==2.22.0
-docker==4.1.0
+docker==4.2.0
 psutil==5.6.3
 humanfriendly==4.18
 PyJWT==1.7.1


### PR DESCRIPTION
when uploading scraper log, setting the container name based on the log filename
we encounter a Conflict trying to remove the container ; docker replying
that it's already removing the container

now trying to refresh/retest for status=removing before removing
then should remove not encounter a Conflict, awaiting "removed" status

also pruning container based on filename= label