### PR TITLE
better reporting of gone tasks

### DIFF
--- a/dispatcher/backend/src/common/schemas/parameters.py
+++ b/dispatcher/backend/src/common/schemas/parameters.py
@@ -24,6 +24,7 @@ from common.schemas.fields import (
     validate_status,
     validate_event,
     validate_worker_name,
+    TaskIdsListOrNone,
 )
 from common.schemas.models import LanguageSchema, DockerImageSchema, ResourcesSchema
 
@@ -57,6 +58,7 @@ class RequestedTaskSchema(Schema):
 # requested-tasks for worker
 class WorkerRequestedTaskSchema(Schema):
     worker = fields.String(required=True, validate=validate_worker_name)
+    running_task_ids = TaskIdsListOrNone(required=False, missing=None)
     avail_cpu = fields.Integer(required=True, validate=validate_cpu)
     avail_memory = fields.Integer(required=True, validate=validate_memory)
     avail_disk = fields.Integer(required=True, validate=validate_disk)

--- a/dispatcher/backend/src/routes/requested_tasks/requested_task.py
+++ b/dispatcher/backend/src/routes/requested_tasks/requested_task.py
@@ -20,6 +20,7 @@ from common.schemas.parameters import (
     WorkerRequestedTaskSchema,
 )
 from utils.scheduling import request_a_schedule, find_requested_task_for
+from common.utils import sync_running_and_expected_tasks
 
 logger = logging.getLogger(__name__)
 
@@ -172,6 +173,11 @@ class RequestedTasksForWorkers(BaseRoute):
             )
 
         request_args = WorkerRequestedTaskSchema().load(request_args)
+
+        # sync tasks actually being run with tasks expected to be running
+        running_task_ids = request_args.get("running_task_ids")
+        if worker_name and running_task_ids is not None:
+            sync_running_and_expected_tasks(worker_name, running_task_ids)
 
         task = find_requested_task_for(
             token.username,


### PR DESCRIPTION
while worker-manager was already syncing its running tasks with its registry of tasks
the backend was not aware of any abandoned task:

because task-worker is independent, the absence of a task container could be anything
    - a sucessfull completion
    - a reported failure
    - a gone container
polling now supply an additional parameter listing the task IDs currently being run
with this information, the backend can compare the affected tasks to worker with that
list and missing ones can be marked as failed due to gone container

this will prevent dangling task in workers dashboard and resources miscalculations
due to ghost tasks

also removed useless block for filtering selfish results