### PR TITLE
Issues #356 #411: more retries on docker API

### DIFF
--- a/workers/app/common/docker.py
+++ b/workers/app/common/docker.py
@@ -29,22 +29,22 @@ from common.utils import short_id, as_pos_int, format_size
 
 RUNNING_STATUSES = ("created", "running", "restarting", "paused", "removing")
 STOPPED_STATUSES = ("exited", "dead")
-RETRIES = 3  # retry attempts in case of API error
+DOCKER_API_RETRIES = 10  # retry attempts in case of API error
 RESOURCES_DISK_LABEL = "resources_disk"
 
 
 def retried_docker_call(docker_method, *args, **kwargs):
     attempt = 0
     while True:
+        attempt += 1
         try:
-            attempt += 1
             return docker_method(*args, **kwargs)
         except docker.errors.APIError as exc:
-            if exc.is_server_error() and attempt <= RETRIES:
+            if exc.is_server_error() and attempt <= DOCKER_API_RETRIES:
                 logger.debug(
                     f"Docker API Error for {docker_method} (attempt {attempt})"
                 )
-                time.sleep(2)
+                time.sleep(10 * attempt)
                 continue
             raise exc
 


### PR DESCRIPTION
increased number of retries on the docker API which also applies to docker hub.
retries are incrementaly longer (10s * attempt) covering a larger range of scenarios
With this, a docker API and or docker Hub issue would be attempted up to 9mn.
That should get us through all hickups and fail only due to more serious problems
