### PR TITLE
consider ZIMFARM_DISK as reserved disk space

### DIFF
--- a/workers/README.md
+++ b/workers/README.md
@@ -23,9 +23,9 @@ host:
 * `ZIMFARM_MAX_RAM` sets the max amount of RAM the worker will assign
   to its tasks.
 
-* `ZIMFARM_DISK` sets the max amount of disk you'd want the worker to
-  use. It is used to decide whether you can run tasks or not but _is
-  not enforced_. If a [Zimfarm](https://farm.openzim.org/recipes)
+* `ZIMFARM_DISK` sets the amount of disk you want to dedicate to the worker.
+  It is used to decide whether you can run tasks or not but _is
+  not enforced_: if a [Zimfarm](https://farm.openzim.org/recipes)
   recipe indicates that a task uses `2GB` of disk but actually uses
   `10GB`, it will try to use those `10GB` on your disk.
 

--- a/workers/app/common/docker.py
+++ b/workers/app/common/docker.py
@@ -140,7 +140,6 @@ def query_host_stats(docker_client, workdir):
     workir_fs_stats = os.statvfs(workdir)
     disk_used = stats["disk"]
     disk_free = workir_fs_stats.f_bavail * workir_fs_stats.f_frsize
-    disk_avail = as_pos_int(min([ZIMFARM_DISK_SPACE - stats["disk"], disk_free]))
 
     # CPU cores
     cpu_used = stats["cpu_shares"] // DEFAULT_CPU_SHARE
@@ -155,7 +154,7 @@ def query_host_stats(docker_client, workdir):
         "disk": {
             "total": ZIMFARM_DISK_SPACE,
             "used": disk_used,
-            "available": disk_avail,
+            "available": disk_free,
         },
         "memory": {"total": ZIMFARM_MEMORY, "used": mem_used, "available": mem_avail},
     }

--- a/workers/contrib/zimfarm.config
+++ b/workers/contrib/zimfarm.config
@@ -24,8 +24,8 @@ ZIMFARM_DEBUG="y"
 # Maximum amount of RAM you want your worker to use
 ZIMFARM_MAX_RAM="1G"
 
-# Maximum amount of storage you want your worker to use (/!\ not
-# enforced)
+# Disk space you are dedicating to the worker. worker needs this space avail to work
+# /!\ disk usage is not enforced (might exceed this limit)
 ZIMFARM_DISK="1G"
 
 # Artificial number to configure the level of CPU load you want to


### PR DESCRIPTION
`ZIMFARM_DISK` config variable was used to set a maximum amount of disk space that
the worker could use: ie. scheduler would use this value to select doable task for it.

Because non-dedicated workers might consume disk space outside the zimfarm, we are
now considering the `ZIMFARM_DISK` variable to represent a dedicated amount of disk
storage for the zimfarm.

Because it's now supposed to be dedicated, should the available disk space not match it
the worker would exit, providing the reason (and the sizes concerned).

Config file comment and README have been updated accordingly.
