### PR TITLE
Issue #404: added support for UI-hidden flags

### DIFF
--- a/dispatcher/backend/src/common/schemas/offliners/mwoffliner.py
+++ b/dispatcher/backend/src/common/schemas/offliners/mwoffliner.py
@@ -1,6 +1,6 @@
 from marshmallow import fields, validate
 
-from common.schemas import SerializableSchema, ListOfStringEnum
+from common.schemas import SerializableSchema, ListOfStringEnum, StringEnum
 from common.schemas.fields import validate_output
 
 
@@ -87,6 +87,21 @@ class MWOfflinerFlagsSchema(SerializableSchema):
             "label": "Flavours",
             "description": "Which flavours to build, as `<flavour>:<custom-suffix>`. Empty option is full without suffix.",
         },
+    )
+    customFlavour = StringEnum(
+        metadata={
+            "label": "Custom Flavour",
+            "description": "Custom processor to filter and process articles (see extensions/*.js)",
+        },
+        validate=validate.OneOf(["/tmp/mwoffliner/wiktionary_fr.js"]),
+    )
+
+    optimisationCacheUrl = fields.Url(
+        metadata={
+            "label": "Optmiziation Cache URL",
+            "description": "S3 Storage URL including credentials and bucket",
+            "secret": True,
+        }
     )
 
     addNamespaces = fields.String(

--- a/dispatcher/backend/src/common/schemas/offliners/mwoffliner.py
+++ b/dispatcher/backend/src/common/schemas/offliners/mwoffliner.py
@@ -93,7 +93,7 @@ class MWOfflinerFlagsSchema(SerializableSchema):
             "label": "Custom Flavour",
             "description": "Custom processor to filter and process articles (see extensions/*.js)",
         },
-        validate=validate.OneOf(["/tmp/mwoffliner/wiktionary_fr.js"]),
+        validate=validate.OneOf(["/tmp/mwoffliner/wiktionary_fr.js"]),  # nosec
     )
 
     optimisationCacheUrl = fields.Url(

--- a/dispatcher/frontend-ui/src/components/FlagsList.vue
+++ b/dispatcher/frontend-ui/src/components/FlagsList.vue
@@ -2,13 +2,17 @@
   <table class="table table-sm table-striped" :class="{'table-responsive': shrink}">
     <tbody>
       <tr v-for="(value, name) in flags" :key="name">
-        <td><code>{{ name }}</code></td><td>{{ value }}</td>
+        <td><code>{{ name }}</code></td>
+        <td v-if="is_protected_key(name)" v-tooltip="'Actual content hidden'">{{ secret_replacement }}</td>
+        <td v-else>{{ value }}</td>
       </tr>
     </tbody>
   </table>
 </template>
 
 <script type="text/javascript">
+  import Constants from '../constants.js'
+
   export default {
     name: 'FlagsList',
     props: {
@@ -16,7 +20,14 @@
       shrink: {
         type: Boolean,
         default: false
-      }
+      },
+      secret_fields: Array,
+    },
+    computed: {
+      secret_replacement() { return Constants.secret_replacement; }
+    },
+    methods: {
+      is_protected_key(key) { return this.secret_fields.indexOf(key) != -1; },
     },
   }
 </script>

--- a/dispatcher/frontend-ui/src/constants.js
+++ b/dispatcher/frontend-ui/src/constants.js
@@ -169,7 +169,7 @@ function secret_fields_for(offliner_def) {
   if (offliner_def === null)
     return null;
   return offliner_def
-    .filter(function (item) { return item.hasOwnProperty("secret") && item.secret === true; })
+    .filter(function (item) { return "secret" in item && item.secret === true; })
     .map(function (item) { return item.key});
 }
 

--- a/dispatcher/frontend-ui/src/constants.js
+++ b/dispatcher/frontend-ui/src/constants.js
@@ -35,12 +35,32 @@ function image_human(config) {
   return config.image.name + ":" + config.image.tag;
 }
 
-function build_docker_command(name, config) {
+function build_command_without(config, secret_fields) {
+  if (secret_fields == null)
+    return "<missing defs>";
+  if (secret_fields.length == 0)
+    return config.str_command;
+
+  function should_keep(line) {
+    let keep = true;
+    secret_fields.forEach(function (field_name) {
+      if (line.indexOf("--" + field_name) == 0)
+        keep = false;
+    });
+    return keep;
+  }
+
+  return config.command.map(function (line) {
+      return should_keep(line) ? line : line.split("=")[0] + '="' + secret_replacement + '"';
+  }).join(" ");
+}
+
+function build_docker_command(name, config, secret_fields) {
   let mounts = ["-v", "/my-path:" + config.mount_point + ":rw"];
   let mem_params = ["--memory-swappiness", "0", "--memory", config.resources.memory];
   let cpu_params = ["--cpu-shares", config.resources.cpu * DEFAULT_CPU_SHARE];
   let docker_base = ["docker", "run"].concat(mounts).concat(["--name", config.task_name + "_" + name, "--detach"]).concat(cpu_params).concat(mem_params);
-  let scraper_command = config.str_command;
+  let scraper_command = build_command_without(config, secret_fields);
   let args = docker_base.concat([image_human(config)]).concat([scraper_command]);
   return args.join(" ");
 }
@@ -145,12 +165,21 @@ function schedule_durations_dict(duration) {
   return multiple_durations(min_value, max_value, duration.workers);
 }
 
+function secret_fields_for(offliner_def) {
+  if (offliner_def === null)
+    return null;
+  return offliner_def
+    .filter(function (item) { return item.hasOwnProperty("secret") && item.secret === true; })
+    .map(function (item) { return item.key});
+}
+
 var DEFAULT_CPU_SHARE = 1024;
 
 var ZIMFARM_WEBAPI = window.environ.ZIMFARM_WEBAPI || process.env.ZIMFARM_WEBAPI || "https://api.farm.openzim.org/v1";
 var ZIMFARM_LOGS_URL = window.environ.ZIMFARM_LOGS_URL || process.env.ZIMFARM_LOGS_URL || "https://logs.warehouse.farm.openzim.org";
 var cancelable_statuses = ["reserved", "started", "scraper_started", "scraper_completed", "scraper_killed"];
 var running_statuses = cancelable_statuses.concat(["cancel_requested"]);
+var secret_replacement = "**********";
 
 export default {
   isProduction() {
@@ -332,4 +361,6 @@ export default {
   filesize: filesize2,
   duplicate: duplicate,
   schedule_durations_dict: schedule_durations_dict,
+  secret_fields_for: secret_fields_for,
+  secret_replacement: secret_replacement,
 };

--- a/dispatcher/frontend-ui/src/views/ScheduleView.vue
+++ b/dispatcher/frontend-ui/src/views/ScheduleView.vue
@@ -128,7 +128,7 @@
               <ResourceBadge kind="disk" :value="config.resources.disk" />
             </td>
           </tr>
-          <tr><th>Config</th><td><FlagsList :flags="config.flags" /></td></tr>
+          <tr><th>Config</th><td><FlagsList :flags="config.flags" :secret_fields="secret_fields" /></td></tr>
           <tr><th>Command <button class="btn btn-light btn-sm" @click.prevent="copyCommand"><font-awesome-icon icon="copy" size="sm" /> Copy</button></th><td><code class="command">{{ command }}</code></td></tr>
         </table>
       </div>
@@ -190,9 +190,11 @@
       last_run() { return this.schedule.most_recent_task; },
       config() { return this.schedule.config; },
       offliner() { return this.config.task_name; },
+      offliner_def() { return this.$store.getters.offliners_defs[this.offliner] || null; },
+      secret_fields() { return Constants.secret_fields_for(this.offliner_def); },
       image_human() { return Constants.image_human(this.config); },
       warehouse_path() { return this.config.warehouse_path; },
-      command() { return Constants.build_docker_command(this.name, this.config); },
+      command() { return Constants.build_docker_command(this.name, this.config, this.secret_fields); },
       trimmed_command() { return Constants.trim_command(this.command); },
       requested_id() { return (this.requested) ? this.requested._id : null; },
       duration_dict() { return Constants.schedule_durations_dict(this.schedule.duration); }


### PR DESCRIPTION
Offliner flag with an extra `secret` property set to `true` would be considered
a text string which value should not be displayed on Recipe config.

In both the config table and the sample docker command, the value will be replaced
with ****.

Note that the API still returns actual value, as well as executed command from the
Debug tab and potentially logs.
