### PR TITLE
Fixes #386: recipes list now shows whether schedule has a requested task

### DIFF
--- a/dispatcher/backend/docs/openapi_v1.yaml
+++ b/dispatcher/backend/docs/openapi_v1.yaml
@@ -460,6 +460,14 @@ paths:
       - $ref: '#/components/parameters/LimitParameter'
       - $ref: '#/components/parameters/ScheduleNameQueryParameter'
       - in: query
+        required: false
+        name: schedule_name
+        description: filter by schedule_name
+        schema:
+          type: array
+          items:
+            $ref: '#/components/schemas/ScheduleName'
+      - in: query
         name: matching_cpu
         required: false
         schema:

--- a/dispatcher/backend/src/common/schemas/parameters.py
+++ b/dispatcher/backend/src/common/schemas/parameters.py
@@ -52,7 +52,7 @@ class RequestedTaskSchema(Schema):
 
     worker = worker_field
     priority = priority_field
-    schedule_name = schedule_name_field
+    schedule_name = fields.List(schedule_name_field, required=False)
 
     matching_cpu = fields.Integer(required=False, validate=validate_cpu)
     matching_memory = fields.Integer(required=False, validate=validate_memory)

--- a/dispatcher/backend/src/routes/requested_tasks/requested_task.py
+++ b/dispatcher/backend/src/routes/requested_tasks/requested_task.py
@@ -38,17 +38,18 @@ def list_of_requested_tasks(token: AccessToken.Payload = None):
         )
 
     request_args["matching_offliners"] = request.args.getlist("matching_offliners")
+    request_args["schedule_name"] = request.args.getlist("schedule_name")
     request_args = RequestedTaskSchema().load(request_args)
 
     # unpack query parameter
     skip, limit = request_args["skip"], request_args["limit"]
-    schedule_name = request_args.get("schedule_name")
+    schedule_names = request_args["schedule_name"]
     priority = request_args.get("priority")
 
     # get requested tasks from database
     query = {}
-    if schedule_name:
-        query["schedule_name"] = schedule_name
+    if schedule_names:
+        query["schedule_name"] = {"$in": schedule_names}
 
     if priority:
         query["priority"] = {"$gte": priority}

--- a/dispatcher/frontend-ui/src/main.js
+++ b/dispatcher/frontend-ui/src/main.js
@@ -27,7 +27,7 @@ import { faSpinner, faUser, faUserCircle, faKey, faTimes, faTimesCircle,
          faCalendarAlt, faStopCircle, faTrashAlt, faPlug,
          faSkullCrossbones, faAsterisk, faCheck, faPlusCircle,
          faExclamationTriangle, faServer, faSortAmountUp,
-         faExternalLinkAlt } from '@fortawesome/free-solid-svg-icons'
+         faExternalLinkAlt, faClock } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 library.add(faKey);
 library.add(faHdd);
@@ -35,6 +35,7 @@ library.add(faUser);
 library.add(faPlug);
 library.add(faFire);
 library.add(faCopy);
+library.add(faClock);
 library.add(faCheck);
 library.add(faServer);
 library.add(faTimes);


### PR DESCRIPTION
This is to fix #386 but using a different approach.

I disagree with the issue's diagnostic that the _Last Task_ information is incorrect. It is correct and reflect the information of the _Last Task_.

I understand the need to know whether a new task has been requested or not but merging that with the _Last Task_ info would only make it less clear and loose some information.

Instead, this keeps the _Last Task_ info as it was but adds a new small column displaying whether the schedule has a requested task or not.