### PR TITLE
Fix Recipe Trailing Space Issue

### DIFF
--- a/dispatcher/backend/src/routes/schedules/schedule.py
+++ b/dispatcher/backend/src/routes/schedules/schedule.py
@@ -73,6 +73,7 @@ class SchedulesRoute(BaseRoute):
 
         try:
             document = ScheduleSchema().load(request.get_json())
+            document["name"] = document["name"].strip()
         except ValidationError as e:
             raise InvalidRequestJSON(e.messages)
 


### PR DESCRIPTION
## Rationale

Recipes with trailing space are not reachable from the UI

Fixes  #458

## Changes

Modified `dispatcher.backend.src.routes.schedules.schedule`. Stripped away spaces from document name when creating a schedule through a GET request on ScheduleRoute.
