### PR TITLE
Fixed #474: updated schemas for youtube and sotoki 

### DIFF
--- a/dispatcher/backend/src/common/schemas/offliners/sotoki.py
+++ b/dispatcher/backend/src/common/schemas/offliners/sotoki.py
@@ -86,3 +86,12 @@ class SotokiFlagsSchema(SerializableSchema):
             "description": "Don't include user profiles",
         },
     )
+
+    optimization_cache = fields.Url(
+        metadata={
+            "label": "Optimization Cache URL",
+            "description": "S3 Storage URL including credentials and bucket",
+            "secret": True,
+        },
+        data_key="optimization-cache",
+    )

--- a/dispatcher/backend/src/common/schemas/offliners/youtube.py
+++ b/dispatcher/backend/src/common/schemas/offliners/youtube.py
@@ -64,6 +64,30 @@ class YoutubeFlagsSchema(SerializableSchema):
         },
     )
 
+    dateafter = fields.String(
+        metadata={
+            "label": "Only after date",
+            "description": "Custom filter to download videos uploaded on or after specified date. Format: YYYYMMDD or (now|today)[+-][0-9](day|week|month|year)(s)?",
+        }
+    )
+
+    optimization_cache = fields.Url(
+        metadata={
+            "label": "Optimization Cache URL",
+            "description": "S3 Storage URL including credentials and bucket",
+            "secret": True,
+        },
+        data_key="optimization-cache",
+    )
+
+    use_any_optimized_version = fields.Boolean(
+        metadata={
+            "label": "Use any optimized version",
+            "description": "Use the cached files if present, whatever the version",
+        },
+        data_key="use-any-optimized-version",
+    )
+
     all_subtitles = fields.Boolean(
         truthy=[True],
         falsy=[False],

--- a/dispatcher/frontend-ui/src/constants.js
+++ b/dispatcher/frontend-ui/src/constants.js
@@ -167,10 +167,10 @@ function schedule_durations_dict(duration) {
 
 function secret_fields_for(offliner_def) {
   if (offliner_def === null)
-    return null;
+    return [];
   return offliner_def
     .filter(function (item) { return "secret" in item && item.secret === true; })
-    .map(function (item) { return item.key});
+    .map(function (item) { return item.data_key});
 }
 
 var DEFAULT_CPU_SHARE = 1024;


### PR DESCRIPTION
Added missing params definitions for sotoki and youtube.
`--optimization-cache` for both
`--dateafter` and `--use-any-optimized-version` for youtube

Also fixed flag secrecy hiding: flag value hiding was not working for flags which key is different than the data key.