### PR TITLE
Fixed task-worker loop on files-upload

### DIFF
--- a/workers/app/task/worker.py
+++ b/workers/app/task/worker.py
@@ -459,6 +459,7 @@ class TaskWorker(BaseWorker):
                 self.sleep()
                 continue
 
+            last_check = now
             self.upload_files()
 
         # scraper is done. check files so upload can continue
@@ -475,6 +476,7 @@ class TaskWorker(BaseWorker):
                 self.sleep()
                 continue
 
+            last_check = now
             self.upload_files()
 
         self.upload_files()  # make sure we submit upload status for last one


### PR DESCRIPTION
main task-worker loop (`run()`) is basically doing nothing while the scraper is running.
It must still wait for the scraper to exit and upload ZIM files as those are created.
The ZIM creation detection (`.upload_files()`) is called every minute to do so.

As reported by Kevin McMurtrie in #zimfarm, the `last_check` variable used to calculate
than a minute has passed was actually never updated.
This resulted in a no-delay loop to `upload_files()`.

Fixing this might improve performances a bit as `upload_files()` does two things all the time:

1. list files on the target folder
2. query the status of the scraper container

## Rationale

[//]: # (Briefly explain the reason behind this change.)

<!--
Issue: [Title](link) or #123 for Github issues.
-->

## Changes

[//]: # (Summarize what has changed.)
