### PR TITLE
Add more flexible gutenberg support

### DIFF
--- a/dispatcher/backend/src/common/schemas/offliners/__init__.py
+++ b/dispatcher/backend/src/common/schemas/offliners/__init__.py
@@ -4,13 +4,10 @@ from common.schemas.offliners.youtube import YoutubeFlagsSchema
 from common.schemas.offliners.sotoki import SotokiFlagsSchema
 from common.schemas.offliners.nautilus import NautilusFlagsSchema
 from common.schemas.offliners.ted import TedFlagsSchema
+from common.schemas.offliners.gutenberg import GutenbergFlagsSchema
 
 
 class PhetFlagsSchema(SerializableSchema):
     class Meta:
         ordered = True
 
-
-class GutenbergFlagsSchema(SerializableSchema):
-    class Meta:
-        ordered = True

--- a/dispatcher/backend/src/common/schemas/offliners/__init__.py
+++ b/dispatcher/backend/src/common/schemas/offliners/__init__.py
@@ -10,4 +10,3 @@ from common.schemas.offliners.gutenberg import GutenbergFlagsSchema
 class PhetFlagsSchema(SerializableSchema):
     class Meta:
         ordered = True
-

--- a/dispatcher/backend/src/common/schemas/offliners/gutenberg.py
+++ b/dispatcher/backend/src/common/schemas/offliners/gutenberg.py
@@ -1,0 +1,114 @@
+from marshmallow import fields
+
+from common.schemas import SerializableSchema
+
+
+class GutenbergFlagsSchema(SerializableSchema):
+    class Meta:
+        ordered = True
+
+    languages = fields.String(
+        metadata={
+            "label": "Languages",
+            "description": "Comma-separated list of lang codes to filter export to (preferably ISO 639-1, else ISO 639-3) Defaults to all",
+        },
+    )
+
+    formats = fields.String(
+        metadata={
+            "label": "Formats",
+            "description": "Comma-separated list of formats to filter export to (epub, html, pdf, all) Defaults to all",
+        },
+    )
+
+    zim_title = fields.String(
+        metadata={
+            "label": "Title",
+            "description": "Custom title for your project and ZIM.",
+        },
+        data_key="zim-title",
+    )
+
+    zim_desc = fields.String(
+        metadata={"label": "Description", "description": "Description for ZIM"},
+        data_key="zim-desc",
+    )
+
+    books = fields.String(
+        metadata={
+            "label": "Books",
+            "description": "Filter to only specific books ; separated by commas, or dashes for intervals. Defaults to all",
+        },
+    )
+
+    concurrency = fields.Integer(
+        metadata={
+            "label": "Concurrency",
+            "description": "Number of concurrent threads to use",
+        },
+    )
+
+    dlc = fields.Integer(
+        metadata={
+            "label": "Download Concurrency",
+            "description": "Number of parallel downloads to run (overrides concurrency)",
+        },
+        data_key="dlc",
+    )
+
+    # /!\ we are using a boolean flag for this while the actual option
+    # expect an output folder for the ZIM files.
+    # Given we can't set the output dir for regular mode, we're using this
+    # flag to switch between the two and the path is set to the mount point
+    # in command_for() (offliners.py)
+    one_language_one_zim = fields.Boolean(
+        truthy=[True, "/output"],
+        falsy=[False],
+        metadata={
+            "label": "Multiple ZIMs",
+            "description": "Create one ZIM per language",
+        },
+        data_key="one-language-one-zim",
+    )
+
+    no_index = fields.Boolean(
+        truthy=[True],
+        falsy=[False],
+        metadata={
+            "label": "No Index",
+            "description": "Do not create full-text index within ZIM file",
+        },
+        data_key="no-index",
+    )
+
+    title_search = fields.Boolean(
+        truthy=[True],
+        falsy=[False],
+        metadata={
+            "label": "Title search",
+            "description": "Search by title feature (⚠️ does not scale)",
+        },
+        data_key="title-search",
+    )
+
+    bookshelves = fields.Boolean(
+        truthy=[True],
+        falsy=[False],
+        metadata={
+            "label": "Bookshelves",
+            "description": "Browse by bookshelves feature",
+        },
+    )
+
+    optimization_cache = fields.Url(
+        metadata={
+            "label": "Optimization Cache URL",
+            "description": "S3 Storage URL including credentials and bucket",
+            "secret": True,
+        },
+        data_key="optimization-cache",
+    )
+
+    use_any_optimized_version = fields.Boolean(
+        truthy=[True], falsy=[False], data_key="--use-any-optimized-version"
+    )

--- a/dispatcher/backend/src/utils/offliners.py
+++ b/dispatcher/backend/src/utils/offliners.py
@@ -24,14 +24,13 @@ def command_for(offliner, flags, mount_point):
     if offliner == Offliner.phet:
         return ["/bin/bash", "-c", "'cd /phet && npm i && npm start'"]
     if offliner == Offliner.gutenberg:
-        return [
-            "gutenberg2zim",
-            "--complete",
-            "--formats",
-            "all",
-            "--one-language-one-zim",
-            str(mount_point),
-        ]
+        cmd = "gutenberg2zim"
+        # multiple ZIM expects a directory
+        if flags.get("one-language-one-zim"):
+            flags["one-language-one-zim"] = str(mount_point)
+        if flags.get("one-language-one-zim") is False:
+            del flags["one-language-one-zim"]
+        # when not using multiple ZIM, scraper uses cwd as output (/output)
     if offliner == Offliner.sotoki:
         command_flags = copy.deepcopy(flags)
         domain = command_flags.pop("domain")

--- a/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
+++ b/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
@@ -360,7 +360,7 @@
                 if (typeof obj[k] == "object" && obj[k] !== null)
                   recursivelyCleanup(obj[k]);
                 else {
-                  if (!Object.isArray(obj) && obj[k] == "") {
+                  if (!Object.isArray(obj) && obj[k] === "") {
                     delete obj[k];
                   }
                 }


### PR DESCRIPTION
Now that gutenberg supports S3 cache, we need to be able to configure it from zimfarm
Also, new features like bokshelves and title search might lead to additional recipes
zimfarm now supports all gutenberg options, allowing custom recipes along out main one