### PR TITLE
Sort languages on english name

### DIFF
--- a/dispatcher/backend/src/routes/languages/language.py
+++ b/dispatcher/backend/src/routes/languages/language.py
@@ -36,7 +36,7 @@ class LanguagesRoute(BaseRoute):
         else:
             pipeline = [
                 group,
-                {"$sort": {"_id": 1}},
+                {"$sort": {"name_en": 1}},
                 {"$skip": skip},
                 {"$limit": limit},
             ]


### PR DESCRIPTION
This shall fix #502 by sorting the languages on the basis of their English names instead of the iso-639-3 codes