### PR TITLE
Add support for openedx

### DIFF
--- a/dispatcher/backend/src/common/enum.py
+++ b/dispatcher/backend/src/common/enum.py
@@ -73,6 +73,7 @@ class ScheduleCategory:
     psiram = "psiram"
     stack_exchange = "stack_exchange"
     ted = "ted"
+    openedx = "openedx"
     vikidia = "vikidia"
     wikibooks = "wikibooks"
     wikinews = "wikinews"
@@ -93,6 +94,7 @@ class ScheduleCategory:
             cls.psiram,
             cls.stack_exchange,
             cls.ted,
+            cls.openedx,
             cls.vikidia,
             cls.wikibooks,
             cls.wikinews,
@@ -122,6 +124,7 @@ class DockerImageName:
     sotoki = "openzim/sotoki"
     nautilus = "openzim/nautilus"
     ted = "openzim/ted"
+    openedx = "openzim/openedx"
 
     @classmethod
     def all(cls) -> set:
@@ -133,6 +136,7 @@ class DockerImageName:
             cls.sotoki,
             cls.nautilus,
             cls.ted,
+            cls.openedx,
         }
 
 
@@ -144,6 +148,7 @@ class Offliner:
     sotoki = "sotoki"
     nautilus = "nautilus"
     ted = "ted"
+    openedx = "openedx"
 
     @classmethod
     def all(cls):
@@ -155,6 +160,7 @@ class Offliner:
             cls.sotoki,
             cls.nautilus,
             cls.ted,
+            cls.openedx,
         ]
 
 

--- a/dispatcher/backend/src/common/schemas/models.py
+++ b/dispatcher/backend/src/common/schemas/models.py
@@ -24,6 +24,7 @@ from common.schemas.offliners import (
     SotokiFlagsSchema,
     NautilusFlagsSchema,
     TedFlagsSchema,
+    OpenedxFlagsSchema,
 )
 
 
@@ -72,6 +73,7 @@ class ScheduleConfigSchema(SerializableSchema):
             Offliner.sotoki: SotokiFlagsSchema,
             Offliner.nautilus: NautilusFlagsSchema,
             Offliner.ted: TedFlagsSchema,
+            Offliner.openedx: OpenedxFlagsSchema,
         }.get(offliner, Schema)
 
     @validates_schema

--- a/dispatcher/backend/src/common/schemas/offliners/__init__.py
+++ b/dispatcher/backend/src/common/schemas/offliners/__init__.py
@@ -4,6 +4,7 @@ from common.schemas.offliners.youtube import YoutubeFlagsSchema
 from common.schemas.offliners.sotoki import SotokiFlagsSchema
 from common.schemas.offliners.nautilus import NautilusFlagsSchema
 from common.schemas.offliners.ted import TedFlagsSchema
+from common.schemas.offliners.openedx import OpenedxFlagsSchema
 from common.schemas.offliners.gutenberg import GutenbergFlagsSchema
 
 

--- a/dispatcher/backend/src/common/schemas/offliners/openedx.py
+++ b/dispatcher/backend/src/common/schemas/offliners/openedx.py
@@ -1,0 +1,184 @@
+from marshmallow import fields, validate
+
+from common.schemas import SerializableSchema, StringEnum
+from common.schemas.fields import validate_output
+
+
+class OpenedxFlagsSchema(SerializableSchema):
+    class Meta:
+        ordered = True
+
+    course_url = fields.Url(
+        metadata={
+            "label": "Course URL",
+            "description": "URL of the course you wnat to scrape",
+        },
+        data_key="course-url",
+        required=True,
+    )
+
+    email = fields.String(
+        metadata={
+            "label": "Registered e-mail",
+            "description": "The registered e-mail ID on the openedx instance",
+        },
+        data_key="email",
+        required=True,
+    )
+
+    password = fields.String(
+        metadata={
+            "label": "Password",
+            "description": "Password to the account registered on the openedx instance",
+            "secret": True,
+        },
+        data_key="password",
+        required=True,
+    )
+
+    ignore_missing_xblocks = fields.Boolean(
+        truthy=[True],
+        falsy=[False],
+        metadata={
+            "label": "Ignore unsupported xblocks",
+            "description": "Ignore unsupported content (xblock(s))",
+        },
+        data_key="ignore-missing-xblocks",
+    )
+
+    add_wiki = fields.Boolean(
+        truthy=[True],
+        falsy=[False],
+        metadata={
+            "label": "Include wiki",
+            "description": "Add wiki (if available) to the ZIM",
+        },
+        data_key="add-wiki",
+    )
+
+    add_forum = fields.Boolean(
+        truthy=[True],
+        falsy=[False],
+        metadata={
+            "label": "Include forum",
+            "description": "Add forum/discussion (if available) to the ZIM",
+        },
+        data_key="add-forum",
+    )
+
+    video_format = StringEnum(
+        metadata={
+            "label": "Video format",
+            "description": "Format to download/transcode video to. webm is smaller",
+        },
+        validate=validate.OneOf(["webm", "mp4"]),
+        data_key="format",
+    )
+
+    low_quality = fields.Boolean(
+        truthy=[True],
+        falsy=[False],
+        metadata={
+            "label": "Low Quality",
+            "description": "Re-encode video using stronger compression",
+        },
+        data_key="low-quality",
+    )
+
+    name = fields.String(
+        metadata={
+            "label": "Name",
+            "description": "ZIM name. Used as identifier and filename (date will be appended)",
+            "placeholder": "topic_eng",
+        },
+        data_key="name",
+        required=True,
+    )
+
+    title = fields.String(
+        metadata={
+            "label": "Title",
+            "description": "Custom title for your ZIM. Based on MOOC otherwise",
+        },
+        data_key="title",
+    )
+
+    description = fields.String(
+        metadata={
+            "label": "Description",
+            "description": "Custom description for your ZIM. Based on MOOC otherwise",
+        },
+        data_key="description",
+    )
+
+    creator = fields.String(
+        metadata={
+            "label": "Content Creator",
+            "description": "Name of content creator. Defaults to edX",
+        },
+        data_key="creator",
+    )
+
+    tags = fields.String(
+        metadata={
+            "label": "ZIM Tags",
+            "description": "List of comma-separated Tags for the ZIM file. category:openedx, and openedx added automatically",
+        },
+        data_key="tags",
+    )
+
+    optimization_cache = fields.Url(
+        metadata={
+            "label": "Optimization Cache URL",
+            "description": "URL with credentials and bucket name to S3 Optimization Cache",
+            "secret": True,
+        },
+        data_key="optimization-cache",
+    )
+
+    use_any_optimized_version = fields.Boolean(
+        truthy=[True],
+        falsy=[False],
+        metadata={
+            "label": "Use any optimized version",
+            "description": "Use the cached files if present, whatever the version",
+        },
+        data_key="use-any-optimized-version",
+    )
+
+    output = fields.String(
+        metadata={
+            "label": "Output folder",
+            "placeholder": "/output",
+            "description": "Output folder for ZIM file(s). Leave it as `/output`",
+        },
+        missing="/output",
+        default="/output",
+        validate=validate_output,
+        data_key="output",
+    )
+
+    tmp_dir = fields.String(
+        metadata={
+            "label": "Temp folder",
+            "description": "Where to create temporay build folder. Leave it as `/output`",
+        },
+        missing="/output",
+        default="/output",
+        validate=validate_output,
+        data_key="tmp-dir",
+    )
+
+    zim_file = fields.String(
+        metadata={
+            "label": "ZIM filename",
+            "description": "ZIM file name (based on ZIM name if not provided)",
+        },
+        data_key="zim-file",
+    )
+
+    debug = fields.Boolean(
+        truthy=[True],
+        falsy=[False],
+        metadata={"label": "Debug", "description": "Enable verbose output"},
+    )

--- a/dispatcher/backend/src/utils/offliners.py
+++ b/dispatcher/backend/src/utils/offliners.py
@@ -60,6 +60,8 @@ def compute_flags(flags, use_equals=True):
     for key, value in flags.items():
         if value is True:
             params.append(f"--{key}")
+        if value is False:
+            continue
         elif isinstance(value, list):
             for item in value:
                 if use_equals:

--- a/dispatcher/backend/src/utils/offliners.py
+++ b/dispatcher/backend/src/utils/offliners.py
@@ -45,6 +45,9 @@ def command_for(offliner, flags, mount_point):
     if offliner == Offliner.ted:
         cmd = "ted2zim-multi"
         flags["output"] = str(mount_point)
+    if offliner == Offliner.openedx:
+        cmd = "openedx2zim"
+        flags["output"] = str(mount_point)
     if offliner == Offliner.nautilus:
         cmd = "nautiluszim"
         flags["output"] = str(mount_point)

--- a/dispatcher/frontend-ui/src/constants.js
+++ b/dispatcher/frontend-ui/src/constants.js
@@ -203,14 +203,14 @@ export default {
   running_statuses: running_statuses,
   contact_email: "contact@kiwix.org",
   categories: ["gutenberg", "other", "phet", "psiram", "stack_exchange",
-               "ted", "vikidia", "wikibooks", "wikinews", "wikipedia",
+               "ted", "openedx", "vikidia", "wikibooks", "wikinews", "wikipedia",
                "wikiquote", "wikisource", "wikispecies", "wikiversity",
                "wikivoyage", "wiktionary"],  // list of categories for fileering
   warehouse_paths: ["/gutenberg", "/other", "/phet", "/psiram", "/stack_exchange",
-                    "/ted", "/vikidia", "/wikibooks", "/wikinews", "/wikipedia",
+                    "/ted", "/openedx", "/vikidia", "/wikibooks", "/wikinews", "/wikipedia",
                     "/wikiquote", "/wikisource", "/wikispecies", "/wikiversity",
                     "/wikivoyage", "/wiktionary", "/.hidden/dev", "/.hidden/endless"],
-  offliners: ["mwoffliner", "youtube", "phet", "gutenberg", "sotoki", "nautilus", "ted"],
+  offliners: ["mwoffliner", "youtube", "phet", "gutenberg", "sotoki", "nautilus", "ted", "openedx"],
   periodicities: ["manually", "monthly", "quarterly", "biannualy", "annually"],
   memory_values: [536870912, // 512MiB
                   1073741824,  // 1GiB

--- a/workers/app/common/constants.py
+++ b/workers/app/common/constants.py
@@ -78,6 +78,7 @@ UPLOAD_URI = os.getenv("UPLOAD_URI", "sftp://uploader@warehouse.farm.openzim.org
 OFFLINER_MWOFFLINER = "mwoffliner"
 OFFLINER_YOUTUBE = "youtube"
 OFFLINER_TED = "ted"
+OFFLINER_OPENEDX = "openedx"
 OFFLINER_PHET = "phet"
 OFFLINER_GUTENBERG = "gutenberg"
 OFFLINER_SOTOKI = "sotoki"
@@ -91,6 +92,7 @@ ALL_OFFLINERS = [
     OFFLINER_SOTOKI,
     OFFLINER_NAUTILUS,
     OFFLINER_TED,
+    OFFLINER_OPENEDX,
 ]
 SUPPORTED_OFFLINERS = [
     offliner

--- a/workers/contrib/zimfarm.config
+++ b/workers/contrib/zimfarm.config
@@ -36,7 +36,7 @@ ZIMFARM_CPU="3"
 # Comma-separated list of offliners to run or `""` for all of them. If
 # you want to run `youtube` tasks, you need to be whitelisted, contact
 # us.
-ZIMFARM_OFFLINERS="mwoffliner,sotoki,gutenberg,phet,nautilus,ted"
+ZIMFARM_OFFLINERS="mwoffliner,sotoki,gutenberg,phet,nautilus,ted,openedx"
 
 # Set to `"y"` to only run task specifically assigned to this worker
 # (`""` otherwise)


### PR DESCRIPTION
This fixes #473 by adding support for the newer openedx scraper (which is still in development). This includes support for the optimization cache too and thus depends on  https://github.com/openzim/openedx/pull/55 and will remain as a draft until it gets merged.
