### PR TITLE
added duration rounding to taskView

### DIFF
--- a/dispatcher/frontend-ui/src/constants.js
+++ b/dispatcher/frontend-ui/src/constants.js
@@ -18,6 +18,11 @@ function format_duration_between(start, end) { // display a duration between two
   return format_duration(diff);
 }
 
+function duration_between(start,end) {
+  let diff = moment(end).diff(start);
+  return diff;
+}
+
 function from_now(value) {
   let mom = moment(value);
   return mom.isValid() ? mom.fromNow() : value;
@@ -370,6 +375,7 @@ export default {
   },
   format_dt: format_dt,
   format_duration: format_duration,
+  duration_between:duration_between,
   format_duration_between: format_duration_between,
   params_serializer:params_serializer,
   now: now,

--- a/dispatcher/frontend-ui/src/views/TaskView.vue
+++ b/dispatcher/frontend-ui/src/views/TaskView.vue
@@ -157,6 +157,16 @@
         if (this.is_running) {
           return Constants.format_duration_between(first, Constants.now());
         }
+        var dur=0;
+        if(this.task.files&&Object.keys(this.task.files).length>0)
+        {
+            for (var file in this.task.files)
+            {
+              dur=dur+Constants.duration_between(this.task.timestamp.scraper_started, this.task.files[file].created_timestamp);
+            }
+            
+            return Constants.format_duration(dur);
+        }
 
         // if task is not running, it's started to last status
         let last = this.task.updated_at;


### PR DESCRIPTION
## Rationale
@rgaudin This solves  #487 
I have made changes in `task_duration` function in TaskView.vue and I have made a new function in constants.js to calculate duration between two timestamps and have added the durations as required 
<!--
Issue: [Title](link) or #123 for Github issues.
-->

## Changes
Added a new function `duration_between` in constants.js and modified `task_duration` in TaskView.vue
