### PR TITLE
added output for empty edit flags

### DIFF
--- a/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
+++ b/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
@@ -229,6 +229,7 @@
       </tr>
     </tbody>
     </table>
+    <p v-if="!edit_flags_fields.length">No Command Flags</p>
 
   <b-row>
       <b-col>

--- a/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
+++ b/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
@@ -190,7 +190,7 @@
 
     <hr />
 
-    <b-row v-if="edit_flags_fields.length>0"><b-col><h2><code>{{ edit_task_name}}</code> command flags</h2></b-col></b-row>
+    <b-row v-if="edit_flags_fields.length > 0"><b-col><h2><code>{{ edit_task_name}}</code> command flags</h2></b-col></b-row>
 
     <table class="table table-striped table-hover table-sm table-responsive-md">
       <tbody>

--- a/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
+++ b/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
@@ -190,7 +190,7 @@
 
     <hr />
 
-    <b-row><b-col><h2><code>{{ edit_task_name}}</code> command flags</h2></b-col></b-row>
+    <b-row v-if="edit_flags_fields.length>0"><b-col><h2><code>{{ edit_task_name}}</code> command flags</h2></b-col></b-row>
 
     <table class="table table-striped table-hover table-sm table-responsive-md">
       <tbody>
@@ -229,7 +229,6 @@
       </tr>
     </tbody>
     </table>
-    <p v-if="!edit_flags_fields.length">No Command Flags</p>
 
   <b-row>
       <b-col>


### PR DESCRIPTION
## Rationale
This resolves #427 

<!--
Issue: [Title](link) or #123 for Github issues.
--> 
#427 
## Changes
Added a condition to check whether edit flag options are not available then print no command flags
