### PR TITLE
tasks ids are too similar

### DIFF
--- a/dispatcher/backend/src/utils/scheduling.py
+++ b/dispatcher/backend/src/utils/scheduling.py
@@ -10,6 +10,7 @@ import pymongo
 from bson.son import SON
 
 from common import getnow
+from bson.objectid import ObjectId
 from common.constants import PERIODICITIES
 from common.enum import TaskStatus, SchedulePeriodicity, Platform
 from utils.offliners import expanded_config
@@ -115,6 +116,7 @@ def request_a_schedule(
         "priority": priority,
         "worker": worker,
         "config": config,
+        "_id": ObjectId(str(ObjectId())[::-1])
     }
 
     if worker:

--- a/dispatcher/backend/src/utils/scheduling.py
+++ b/dispatcher/backend/src/utils/scheduling.py
@@ -117,7 +117,7 @@ def request_a_schedule(
         "worker": worker,
         "config": config,
         # reverse ObjectId to randomize task ids
-        "_id": ObjectId(str(ObjectId())[::-1])
+        "_id": ObjectId(str(ObjectId())[::-1]),
     }
 
     if worker:

--- a/dispatcher/backend/src/utils/scheduling.py
+++ b/dispatcher/backend/src/utils/scheduling.py
@@ -116,6 +116,7 @@ def request_a_schedule(
         "priority": priority,
         "worker": worker,
         "config": config,
+        # reverse ObjectId to randomize task ids
         "_id": ObjectId(str(ObjectId())[::-1])
     }
 

--- a/dispatcher/frontend-ui/src/constants.js
+++ b/dispatcher/frontend-ui/src/constants.js
@@ -153,7 +153,7 @@ function trim_command(command, columns=79) {  // trim a string to espaced versio
 }
 
 function short_id(id) {  // short id of tasks (last chars)
-  return id.substr(id.length - 5);
+  return id.substr(0,5);
 }
 
 function filesize2(value) {

--- a/dispatcher/frontend-ui/src/constants.js
+++ b/dispatcher/frontend-ui/src/constants.js
@@ -153,7 +153,7 @@ function trim_command(command, columns=79) {  // trim a string to espaced versio
 }
 
 function short_id(id) {  // short id of tasks (last chars)
-  return id.substr(0,5);
+  return id.substr(0, 5);
 }
 
 function filesize2(value) {

--- a/workers/app/common/utils.py
+++ b/workers/app/common/utils.py
@@ -7,7 +7,7 @@ import humanfriendly
 
 def short_id(task_id):
     """ stripped version of task_id for containers/display """
-    return task_id[-5:]
+    return task_id[:5]
 
 
 def as_pos_int(value):


### PR DESCRIPTION
## Rationale

[//]: # (Briefly explain the reason behind this change.)
Task ids were too similar hence difficult to differentiate
<!--
Issue: [Title](link) or #123 for Github issues.
-->
#304 
## Changes
I have reversed the task ids as suggested and the made the first five characters as short id which makes it more convinient

