### PR TITLE
web recipe filters added in url

### DIFF
--- a/dispatcher/frontend-ui/src/components/SchedulesList.vue
+++ b/dispatcher/frontend-ui/src/components/SchedulesList.vue
@@ -98,12 +98,10 @@
 
 <script type="text/javascript">
   import Multiselect from 'vue-multiselect'
-
   import Constants from '../constants.js'
   import ZimfarmMixins from '../components/Mixins.js'
   import RequestSelectionButton from '../components/RequestSelectionButton.vue'
   import TaskLink from '../components/TaskLink.vue'
-
   export default {
     name: 'SchedulesList',
     mixins: [ZimfarmMixins],
@@ -120,12 +118,7 @@
       selectedLanguagesOptions: {  // multiple-select value for selected languages to filter on (union)
         set(selectedLanguagesOptions) {
           this.$store.commit('SET_SELECTED_LANGUAGES_OPTIONS', selectedLanguagesOptions);
-          if (this.selectedName.length > 0) {
-            this.$router.replace({ name:"schedules-list" ,query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags, name:this.selectedName }});
-          }
-          else {
-            this.$router.replace({ name:"schedules-list" ,query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags }});
-          }
+          this.update_url();
         },
         get() {
           return this.$store.state.selectedLanguagesOptions;
@@ -134,12 +127,7 @@
       selectedCategoriesOptions: {  // multiple-select value for selected languages to filter on (union)
         set(selectedCategoriesOptions) {
           this.$store.commit('SET_SELECTED_CATEGORIES_OPTIONS', selectedCategoriesOptions);
-          if (this.selectedName.length > 0) {
-            this.$router.replace({ name:"schedules-list" ,query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags, name:this.selectedName} });
-          }
-          else {
-            this.$router.replace({ name:"schedules-list" ,query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags }});
-          }
+          this.update_url();
         },
         get() {
           return this.$store.state.selectedCategoriesOptions;
@@ -148,12 +136,7 @@
       selectedTagsOptions: {  // multiple-select value for selected tags to filter on (intersection)
         set(selectedTagsOptions) {
           this.$store.commit('SET_SELECTED_TAGS_OPTIONS', selectedTagsOptions);
-          if (this.selectedName.length > 0) {
-            this.$router.replace({ name:"schedules-list" ,query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags, name:this.selectedName }});
-          }
-          else {
-            this.$router.replace({ name:"schedules-list" ,query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags }});
-          }
+          this.update_url();
         },
         get() {
           return this.$store.state.selectedTagsOptions;
@@ -162,12 +145,7 @@
       selectedName: {  // entered regexp to match schedule names on
         set(selectedName) {
           this.$store.commit('SET_SELECTED_NAME', selectedName);
-          if (this.selectedName.length > 0 ) {
-            this.$router.replace({ name:"schedules-list", query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags, name:this.selectedName }});
-          }
-          else {
-            this.$router.replace({ name:"schedules-list" ,query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags }});
-          }
+          this.update_url();
         },
         get() {
           return this.$store.state.selectedName;
@@ -215,64 +193,48 @@
         this.saveLimitPreference(this.selectedLimit);
         this.loadSchedules();
       },
+      update_url(){
+         // updating url on reloading page
+         if (this.selectedName.length > 0 ) {
+            this.$router.replace({ name:"schedules-list", query:{ Categories:this.selectedCategories, Languages:this.selectedLanguages, Tags:this.selectedTags, name:this.selectedName }});
+          }
+          else {
+            this.$router.replace({ name:"schedules-list" ,query:{ Categories:this.selectedCategories, Languages:this.selectedLanguages, Tags:this.selectedTags }});
+          }
+      },
       loadSchedules() {  // load filtered schedules from API
         let parent = this;
         this.toggleLoader("fetching recipes…");
         let params = {limit: parent.selectedLimit};
-        // prepare params for filering
-        if (this.$route.query.language) {
-          params.lang = this.$route.query.language;
-          if (this.selectedLanguagesOptions.length == 0) {
-            if (typeof this.$route.query.language === "string") {
-              this.selectedLanguagesOptions.push({ name:this.$route.query.language, value:this.$route.query.language })
-            }
-            else {
-              for(var i=0; i<this.$route.query.language.length; i++) {
-                this.selectedLanguagesOptions.push({ name:this.$route.query.language[i], value:this.$route.query.language[i] });
-              }
-            }
-          }
-        }
-        if (this.$route.query.category) {
-          params.category = this.$route.query.category;
-          if (this.selectedCategoriesOptions.length == 0) {
-            if (typeof this.$route.query.category === "string") {
-              this.selectedCategoriesOptions.push({ name:this.$route.query.category, value:this.$route.query.category })
-            }
-            else {
-              for(i=0; i<this.$route.query.category.length; i++) {
-                this.selectedCategoriesOptions.push({ name:this.$route.query.category[i], value:this.$route.query.category[i] });
-              }
-            }
-          }
-        }
-        if (this.$route.query.tags) {
-          params.tag = this.$route.query.tags;
-          if (this.selectedTagsOptions.length == 0) {
-              if (typeof this.$route.query.tags === "string") {
-                this.selectedTagsOptions.push({ name:this.$route.query.tags, value:this.$route.query.tags });
+
+        // adding filters to url 
+        [["Categories","category"], ["Languages","lang"], ["Tags","tag"]].forEach(function (key) {
+        if (parent.$route.query[key[0]]) {
+          params[key[1]] = parent.$route.query[key[0]];
+            if (parent["selected"+key[0]+"Options"].length == 0) {
+              if (typeof parent.$route.query[key[0]] === "string") {
+                parent["selected"+key[0]+"Options"].push({ name:parent.$route.query[key[0]], value:parent.$route.query[key[0]] })
               }
               else {
-                for(i=0; i<this.$route.query.tags.length; i++){
-                  this.selectedTagsOptions.push({ name:this.$route.query.tags[i], value:this.$route.query.tags[i] });
+                for(var i=0; i<parent.$route.query[key[0]].length; i++) {
+                  parent["selected"+key[0]+"Options"].push({ name:parent.$route.query[key[0]][i], value:parent.$route.query[key[0]][i] });
                 }
               }
-          } 
-        }
+            }
+          }
+        });
         if (this.$route.query.name) {
           params.name = this.$route.query.name;
           if (this.selectedName.length == 0) {
               this.selectedName = this.$route.query.name;
           }
         }
-
         parent.error = null;
         parent.queryAPI('get', '/schedules/', {params: params})
           .then(function (response) {
                 parent.schedules = [];
                 parent.meta = response.data.meta;
                 parent.schedules = response.data.items;
-
                 parent.queryAPI('get', '/requested-tasks/', {params: {
                     limit: parent.selectedLimit,
                     'schedule_name': parent.selection}})

--- a/dispatcher/frontend-ui/src/components/SchedulesList.vue
+++ b/dispatcher/frontend-ui/src/components/SchedulesList.vue
@@ -98,10 +98,12 @@
 
 <script type="text/javascript">
   import Multiselect from 'vue-multiselect'
+
   import Constants from '../constants.js'
   import ZimfarmMixins from '../components/Mixins.js'
   import RequestSelectionButton from '../components/RequestSelectionButton.vue'
   import TaskLink from '../components/TaskLink.vue'
+
   export default {
     name: 'SchedulesList',
     mixins: [ZimfarmMixins],
@@ -209,19 +211,20 @@
 
         // adding filters to url 
         [["Categories","category"], ["Languages","lang"], ["Tags","tag"]].forEach(function (key) {
-        if (parent.$route.query[key[0]]) {
-          params[key[1]] = parent.$route.query[key[0]];
-            if (parent["selected"+key[0]+"Options"].length == 0) {
-              if (typeof parent.$route.query[key[0]] === "string") {
-                parent["selected"+key[0]+"Options"].push({ name:parent.$route.query[key[0]], value:parent.$route.query[key[0]] })
-              }
-              else {
-                for(var i=0; i<parent.$route.query[key[0]].length; i++) {
-                  parent["selected"+key[0]+"Options"].push({ name:parent.$route.query[key[0]][i], value:parent.$route.query[key[0]][i] });
+          var selectedFilterOption =  "selected"+key[0]+"Options"
+          if (parent.$route.query[key[0]]) {
+            params[key[1]] = parent.$route.query[key[0]];
+              if (parent[selectedFilterOption].length == 0) {
+                if (typeof parent.$route.query[key[0]] === "string") {
+                  parent[selectedFilterOption].push({ name:parent.$route.query[key[0]], value:parent.$route.query[key[0]] })
+                }
+                else {
+                  for(var i=0; i<parent.$route.query[key[0]].length; i++) {
+                    parent[selectedFilterOption].push({ name:parent.$route.query[key[0]][i], value:parent.$route.query[key[0]][i] });
+                  }
                 }
               }
             }
-          }
         });
         if (this.$route.query.name) {
           params.name = this.$route.query.name;
@@ -235,6 +238,7 @@
                 parent.schedules = [];
                 parent.meta = response.data.meta;
                 parent.schedules = response.data.items;
+
                 parent.queryAPI('get', '/requested-tasks/', {params: {
                     limit: parent.selectedLimit,
                     'schedule_name': parent.selection}})

--- a/dispatcher/frontend-ui/src/components/SchedulesList.vue
+++ b/dispatcher/frontend-ui/src/components/SchedulesList.vue
@@ -120,6 +120,12 @@
       selectedLanguagesOptions: {  // multiple-select value for selected languages to filter on (union)
         set(selectedLanguagesOptions) {
           this.$store.commit('SET_SELECTED_LANGUAGES_OPTIONS', selectedLanguagesOptions);
+          if (this.selectedName.length > 0) {
+            this.$router.replace({ name:"schedules-list" ,query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags, name:this.selectedName }});
+          }
+          else {
+            this.$router.replace({ name:"schedules-list" ,query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags }});
+          }
         },
         get() {
           return this.$store.state.selectedLanguagesOptions;
@@ -128,6 +134,12 @@
       selectedCategoriesOptions: {  // multiple-select value for selected languages to filter on (union)
         set(selectedCategoriesOptions) {
           this.$store.commit('SET_SELECTED_CATEGORIES_OPTIONS', selectedCategoriesOptions);
+          if (this.selectedName.length > 0) {
+            this.$router.replace({ name:"schedules-list" ,query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags, name:this.selectedName} });
+          }
+          else {
+            this.$router.replace({ name:"schedules-list" ,query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags }});
+          }
         },
         get() {
           return this.$store.state.selectedCategoriesOptions;
@@ -136,6 +148,12 @@
       selectedTagsOptions: {  // multiple-select value for selected tags to filter on (intersection)
         set(selectedTagsOptions) {
           this.$store.commit('SET_SELECTED_TAGS_OPTIONS', selectedTagsOptions);
+          if (this.selectedName.length > 0) {
+            this.$router.replace({ name:"schedules-list" ,query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags, name:this.selectedName }});
+          }
+          else {
+            this.$router.replace({ name:"schedules-list" ,query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags }});
+          }
         },
         get() {
           return this.$store.state.selectedTagsOptions;
@@ -144,6 +162,12 @@
       selectedName: {  // entered regexp to match schedule names on
         set(selectedName) {
           this.$store.commit('SET_SELECTED_NAME', selectedName);
+          if (this.selectedName.length > 0 ) {
+            this.$router.replace({ name:"schedules-list", query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags, name:this.selectedName }});
+          }
+          else {
+            this.$router.replace({ name:"schedules-list" ,query:{ category:this.selectedCategories, language:this.selectedLanguages, tags:this.selectedTags }});
+          }
         },
         get() {
           return this.$store.state.selectedName;
@@ -193,22 +217,53 @@
       },
       loadSchedules() {  // load filtered schedules from API
         let parent = this;
-
         this.toggleLoader("fetching recipes…");
-
-        // prepare params for filering
         let params = {limit: parent.selectedLimit};
-        if (this.selectedLanguages.filter(item => item.length).length) {
-          params.lang = this.selectedLanguages;
+        // prepare params for filering
+        if (this.$route.query.language) {
+          params.lang = this.$route.query.language;
+          if (this.selectedLanguagesOptions.length == 0) {
+            if (typeof this.$route.query.language === "string") {
+              this.selectedLanguagesOptions.push({ name:this.$route.query.language, value:this.$route.query.language })
+            }
+            else {
+              for(var i=0; i<this.$route.query.language.length; i++) {
+                this.selectedLanguagesOptions.push({ name:this.$route.query.language[i], value:this.$route.query.language[i] });
+              }
+            }
+          }
         }
-        if (this.selectedTags.filter(item => item.length).length) {
-          params.tag = this.selectedTags;
+        if (this.$route.query.category) {
+          params.category = this.$route.query.category;
+          if (this.selectedCategoriesOptions.length == 0) {
+            if (typeof this.$route.query.category === "string") {
+              this.selectedCategoriesOptions.push({ name:this.$route.query.category, value:this.$route.query.category })
+            }
+            else {
+              for(i=0; i<this.$route.query.category.length; i++) {
+                this.selectedCategoriesOptions.push({ name:this.$route.query.category[i], value:this.$route.query.category[i] });
+              }
+            }
+          }
         }
-        if (this.selectedCategories.filter(item => item.length).length) {
-          params.category = this.selectedCategories;
+        if (this.$route.query.tags) {
+          params.tag = this.$route.query.tags;
+          if (this.selectedTagsOptions.length == 0) {
+              if (typeof this.$route.query.tags === "string") {
+                this.selectedTagsOptions.push({ name:this.$route.query.tags, value:this.$route.query.tags });
+              }
+              else {
+                for(i=0; i<this.$route.query.tags.length; i++){
+                  this.selectedTagsOptions.push({ name:this.$route.query.tags[i], value:this.$route.query.tags[i] });
+                }
+              }
+          } 
         }
-        if (this.selectedName.length) {
-          params.name = this.selectedName;
+        if (this.$route.query.name) {
+          params.name = this.$route.query.name;
+          if (this.selectedName.length == 0) {
+              this.selectedName = this.$route.query.name;
+          }
         }
 
         parent.error = null;


### PR DESCRIPTION
## Rationale

[//]: # (Briefly explain the reason behind this change.)
Web recipe filters added in url which will allow to store and copy the url and reload the page 
<!--
Issue: [Title](link) or #123 for Github issues.
-->
#510 
## Changes
I have pushed the selected categories in url and once the page is reloaded url retains the filters but selected categories become empty so I have extracted filters to url and added to selected categories in each of the four category

Now one can add the filters and reload the page and still the page will retain all the information about the filters being added