### PR TITLE
Don't allow trailing and leading spaces in recipe name

### DIFF
--- a/dispatcher/backend/src/common/schemas/fields.py
+++ b/dispatcher/backend/src/common/schemas/fields.py
@@ -12,7 +12,10 @@ from common.enum import (
 
 # validators
 validate_priority = validate.Range(min=0, max=10)
-validate_schedule_name = validate.Length(min=2)
+validate_schedule_name = validate.Regexp(
+    regex=r"^(?! ).+(?<! )$",
+    error="Recipe name cannot contain leading and/or trailing space(s)",
+)
 validate_not_empty = validate.Length(min=1)
 validate_role = validate.OneOf(ROLES.keys())
 validate_cpu = validate.Range(min=0)

--- a/dispatcher/frontend-ui/src/components/CloneSchedule.vue
+++ b/dispatcher/frontend-ui/src/components/CloneSchedule.vue
@@ -25,14 +25,16 @@
       };
     },
     computed: {
-      ready() { return this.from && this.form_name.trim() && this.from != this.form_name; },
+      ready() { return this.from && this.form_name.trim() && this.from != this.form_name.trim(); },
     },
     methods: {
       cloneSchedule() {
+        // trailing spaces not allowed in schedule names
+        this.form_name = this.form_name.trim();
         if (!this.ready)
           return;
         let parent = this;
-        let payload = {name: this.form_name.trim()};
+        let payload = {name: this.form_name};
         parent.toggleLoader("Cloning recipe…");
         parent.queryAPI('post', '/schedules/' + parent.from + '/clone', payload)
           .then(function () {

--- a/dispatcher/frontend-ui/src/components/CloneSchedule.vue
+++ b/dispatcher/frontend-ui/src/components/CloneSchedule.vue
@@ -25,14 +25,14 @@
       };
     },
     computed: {
-      ready() { return this.from && this.form_name && this.from != this.form_name; },
+      ready() { return this.from && this.form_name.trim() && this.from != this.form_name; },
     },
     methods: {
       cloneSchedule() {
         if (!this.ready)
           return;
         let parent = this;
-        let payload = {name: this.form_name};
+        let payload = {name: this.form_name.trim()};
         parent.toggleLoader("Cloning recipe…");
         parent.queryAPI('post', '/schedules/' + parent.from + '/clone', payload)
           .then(function () {

--- a/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
+++ b/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
@@ -386,10 +386,10 @@
         let payload = {};
         let parent = this;
 
-        if (parent.edit_schedule["name"].trim() != parent.schedule["name"])
-            payload["name"] = parent.edit_schedule["name"].trim();
+        // trailing spaces not allowed in schedule names
+        parent.edit_schedule["name"] = parent.edit_schedule["name"].trim();
 
-        ["category", "enabled", "periodicity"].forEach(function (key) {
+        ["name", "category", "enabled", "periodicity"].forEach(function (key) {
           if (parent.edit_schedule[key] != parent.schedule[key])
             payload[key] = parent.edit_schedule[key];
         });

--- a/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
+++ b/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
@@ -386,7 +386,10 @@
         let payload = {};
         let parent = this;
 
-        ["name", "category", "enabled", "periodicity"].forEach(function (key) {
+        if (parent.edit_schedule["name"].trim() != parent.schedule["name"])
+            payload["name"] = parent.edit_schedule["name"].trim();
+
+        ["category", "enabled", "periodicity"].forEach(function (key) {
           if (parent.edit_schedule[key] != parent.schedule[key])
             payload[key] = parent.edit_schedule[key];
         });

--- a/dispatcher/frontend-ui/src/components/SchedulesList.vue
+++ b/dispatcher/frontend-ui/src/components/SchedulesList.vue
@@ -208,7 +208,7 @@
           params.category = this.selectedCategories;
         }
         if (this.selectedName.length) {
-          params.name = this.selectedName;
+          params.name = this.selectedName.trim();
         }
 
         parent.error = null;


### PR DESCRIPTION
## Rationale
#458 

Fixes #458 
<!--
Issue: [Title](link) or #123 for Github issues.
-->
#458 
## Changes
Changed validation format in schema for recipe name so that there are no trailing spaces added, it also makes sure the recipe name is found even if there is a typo(of blank space) in filters(name)

Now even if recipe name contains trailing or preceding spacing in a new recipe it will trim the spaces 