### PR TITLE
prevent zim from being uploaded to root

### DIFF
--- a/receiver/apps/check_zim.sh
+++ b/receiver/apps/check_zim.sh
@@ -38,6 +38,15 @@ function moveZim () {
    mv -f $ZIMFILE $2
 }
 
+# prevent zim from being uploaded to root of zimDstDir
+if [ $(dirname $ZIMPATH) = "." ] ; then
+  echo "Zim outside subfolder. moving to quarantine"
+  QUARFILE=$4$ZIMPATH
+  QUARDIR=$(dirname $QUARFILE)
+  moveZim $QUARDIR $QUARFILE
+  exit 0
+fi
+
 if [ "$OPTION" = "NO_CHECK" ]
 then
   echo "move $ZIMFILE to $DESTFILE"


### PR DESCRIPTION
At fs level, uploader can upload zim files to the root of the `zim/` folder (inside the jail).
While worker should not do such thing, it's better to prevent the receiver from moving files from there to the production `zim/` folder.

This moves such files to the quarantine folder. We could also delete those directly. @kelson42 ?