### PR TITLE
better token invalidity management

### DIFF
--- a/dispatcher/frontend-ui/src/components/CloneSchedule.vue
+++ b/dispatcher/frontend-ui/src/components/CloneSchedule.vue
@@ -10,7 +10,6 @@
 </template>
 
 <script type="text/javascript">
-  import Constants from '../constants.js'
   import ZimfarmMixins from '../components/Mixins.js'
 
   export default {
@@ -42,7 +41,7 @@
             parent.redirectTo('schedule-detail', {schedule_name: payload.name});
           })
           .catch(function (error) {
-            parent.alertError(Constants.standardHTTPError(error.response), true);
+            parent.standardErrorHandling(error);
           })
           .then(function () {
             parent.toggleLoader(false);

--- a/dispatcher/frontend-ui/src/components/DeleteItem.vue
+++ b/dispatcher/frontend-ui/src/components/DeleteItem.vue
@@ -11,7 +11,6 @@
 </template>
 
 <script type="text/javascript">
-  import Constants from '../constants.js'
   import ZimfarmMixins from '../components/Mixins.js'
 
   export default {
@@ -45,7 +44,7 @@
             parent.redirectTo(parent.target);
           })
           .catch(function (error) {
-            parent.alertDanger("Error", Constants.standardHTTPError(error.response));
+            parent.standardErrorHandling(error);
           })
           .then(function () {
             parent.toggleLoader(false);

--- a/dispatcher/frontend-ui/src/components/PipelineTable.vue
+++ b/dispatcher/frontend-ui/src/components/PipelineTable.vue
@@ -137,7 +137,7 @@
           })
           .catch(function (error) {
             parent.resetData();
-            parent.error = Constants.standardHTTPError(error.response);
+            parent.standardErrorHandling(error);
           })
           .then(function () {
               parent.toggleLoader(false);

--- a/dispatcher/frontend-ui/src/components/RemoveRequestedTaskButton.vue
+++ b/dispatcher/frontend-ui/src/components/RemoveRequestedTaskButton.vue
@@ -44,7 +44,7 @@
             parent.alertSuccess("Un-scheduled!", msg);
           })
           .catch(function (error) {
-            parent.alertError(Constants.standardHTTPError(error.response));
+            parent.standardErrorHandling(error);
           })
           .then(function () {
             parent.working = false;

--- a/dispatcher/frontend-ui/src/components/RequestSelectionButton.vue
+++ b/dispatcher/frontend-ui/src/components/RequestSelectionButton.vue
@@ -90,7 +90,7 @@
             parent.alertSuccess("Requested!", msg, 10);
           })
           .catch(function (error) {
-            parent.alertError(Constants.standardHTTPError(error.response));
+            parent.standardErrorHandling(error);
           })
           .then(function () {
             parent.working_text = null;

--- a/dispatcher/frontend-ui/src/components/ScheduleActionButton.vue
+++ b/dispatcher/frontend-ui/src/components/ScheduleActionButton.vue
@@ -131,6 +131,7 @@
                 parent.ready = true;
               }).catch(function() {
                 parent.ready = false;
+
               });
           })
           .catch(function() {
@@ -160,7 +161,7 @@
             parent.alertSuccess("Scheduled!", msg);
           })
           .catch(function (error) {
-            parent.alertError(Constants.standardHTTPError(error.response));
+            parent.standardErrorHandling(error);
           })
           .then(function () {
             parent.working_text = null;
@@ -180,7 +181,7 @@
           parent.alertSuccess("Prioritized!", msg);
         })
         .catch(function (error) {
-          parent.alertError(Constants.standardHTTPError(error.response));
+          parent.standardErrorHandling(error);
         })
         .then(function () {
           parent.working_text = null;
@@ -210,7 +211,7 @@
             parent.alertSuccess("Un-scheduled!", msg);
           })
           .catch(function (error) {
-            parent.alertError(Constants.standardHTTPError(error.response));
+            parent.standardErrorHandling(error);
           })
           .then(function () {
             parent.working_text = null;

--- a/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
+++ b/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
@@ -493,7 +493,7 @@
         })
         .catch(function (error) {
           parent.image_tags = [];
-          parent.alertError(Constants.standardHTTPError(error.response));
+          parent.standardErrorHandling(error);
         });
       },
       commit_form() {
@@ -513,10 +513,9 @@
               parent.loadSchedule(true);
         })
         .catch(function (error) {
+          parent.standardErrorHandling(error);
           if (error.response.status == 400) {
             parent.alertWarning("Error!", Constants.standardHTTPError(error.response));
-          } else {
-            parent.alertError(Constants.standardHTTPError(error.response));
           }
         })
         .then(function () {

--- a/dispatcher/frontend-ui/src/components/SchedulesList.vue
+++ b/dispatcher/frontend-ui/src/components/SchedulesList.vue
@@ -99,7 +99,6 @@
 <script type="text/javascript">
   import Multiselect from 'vue-multiselect'
 
-  import Constants from '../constants.js'
   import ZimfarmMixins from '../components/Mixins.js'
   import RequestSelectionButton from '../components/RequestSelectionButton.vue'
   import TaskLink from '../components/TaskLink.vue'
@@ -292,7 +291,7 @@
           })
           .catch(function (error) {
             parent.schedules = [];
-            parent.error = Constants.standardHTTPError(error.response);
+            parent.standardErrorHandling(error);
           })
           .then(function () {
             parent.toggleLoader(false);

--- a/dispatcher/frontend-ui/src/components/UpdateUser.vue
+++ b/dispatcher/frontend-ui/src/components/UpdateUser.vue
@@ -118,7 +118,7 @@
             parent.redirectTo('users-list');
         })
         .catch(function (error) {
-          parent.alertDanger("Error", Constants.standardHTTPError(error.response), 10);
+          parent.standardErrorHandling(error, 10);
         })
         .then(function () {
             parent.toggleLoader(false);
@@ -137,7 +137,7 @@
             parent.redirectTo('users-list');
           })
           .catch(function (error) {
-            parent.alertDanger("Error", Constants.standardHTTPError(error.response), 10);
+            parent.standardErrorHandling(error, 10);
           })
           .then(function () {
             parent.toggleLoader(false);
@@ -154,7 +154,7 @@
               parent.redirectTo('users-list');
             })
             .catch(function (error) {
-              parent.alertDanger("Error", Constants.standardHTTPError(error.response), 10);
+              parent.standardErrorHandling(error, 10);
             })
             .then(function () {
               parent.toggleLoader(false);

--- a/dispatcher/frontend-ui/src/components/UserButton.vue
+++ b/dispatcher/frontend-ui/src/components/UserButton.vue
@@ -61,7 +61,6 @@
 
 
 <script type="text/javascript">
-  import Constants from '../constants.js'
   import ZimfarmMixins from '../components/Mixins.js'
 
   export default {
@@ -79,18 +78,7 @@
           });
       },
       signOut() {
-        let parent = this;
-        let msg = "";
-        if (this.token_expired) {
-          msg = "Your token already expired anyway 🤷🏾‍♂️";
-        } else {
-          let expiry = this.$store.getters.token_expiry;
-          let human_diff = (expiry === null) ? "some time" : Constants.format_duration(expiry.diff());
-          msg = "Your token is still valid for about " + human_diff + " though";
-        }
-        parent.$store.dispatch('clearAuthentication');
-        parent.$cookie.delete(Constants.TOKEN_COOKIE_NAME);
-        parent.alertInfo("Signed-out!", msg);
+        this.removeToken(true);
         this.redirectTo('home')
       }
     },

--- a/dispatcher/frontend-ui/src/views/ChangePassword.vue
+++ b/dispatcher/frontend-ui/src/views/ChangePassword.vue
@@ -54,7 +54,7 @@
               parent.$router.back();  // redirect
             })
             .catch(function (error) {
-              parent.error = Constants.standardHTTPError(error.response);
+              parent.standardErrorHandling(error);
             })
             .then(function () {
               parent.working = false;

--- a/dispatcher/frontend-ui/src/views/TaskView.vue
+++ b/dispatcher/frontend-ui/src/views/TaskView.vue
@@ -230,7 +230,7 @@
               parent.task = response.data;
           })
           .catch(function (error) {
-            parent.error = Constants.standardHTTPError(error.response);
+            parent.standardErrorHandling(error);
           })
           .then(function () {
               parent.toggleLoader(false);

--- a/dispatcher/frontend-ui/src/views/UserView.vue
+++ b/dispatcher/frontend-ui/src/views/UserView.vue
@@ -90,7 +90,6 @@
 </template>
 
 <script type="text/javascript">
-  import Constants from '../constants.js'
   import ZimfarmMixins from '../components/Mixins.js'
   import ErrorMessage from '../components/ErrorMessage.vue'
   import DeleteItem from '../components/DeleteItem.vue'
@@ -159,7 +158,7 @@
             parent.loadUser();
           })
           .catch(function (error) {
-            parent.alertError(Constants.standardHTTPError(error.response));
+            parent.standardErrorHandling(error);
           })
           .then(function () {
             parent.toggleLoader(false);
@@ -176,7 +175,7 @@
             parent.user = response.data;
           })
           .catch(function (error) {
-            parent.error = Constants.standardHTTPError(error.response);
+            parent.standardErrorHandling(error);
           })
           .then(function () {
             parent.toggleLoader(false);

--- a/dispatcher/frontend-ui/src/views/UsersView.vue
+++ b/dispatcher/frontend-ui/src/views/UsersView.vue
@@ -97,7 +97,7 @@
             parent.loadUsersList();
         })
         .catch(function (error) {
-          parent.alertDanger("Error", Constants.standardHTTPError(error.response));
+          parent.standardErrorHandling(error);
         })
         .then(function () {
             parent.toggleLoader(false);
@@ -117,7 +117,7 @@
             }
           })
           .catch(function (error) {
-            parent.error = Constants.standardHTTPError(error.response);
+            parent.standardErrorHandling(error);
           })
           .then(function () {
             parent.toggleLoader(false);

--- a/dispatcher/frontend-ui/src/views/WorkersView.vue
+++ b/dispatcher/frontend-ui/src/views/WorkersView.vue
@@ -211,7 +211,7 @@
 
           })
           .catch(function (error) {
-            parent.error = Constants.standardHTTPError(error.response);
+            parent.standardErrorHandling(error);
           })
           .then(function () {
             parent.toggleLoader(false);
@@ -233,7 +233,7 @@
             parent.loadRunningTasks();
           })
           .catch(function (error) {
-            parent.error = Constants.standardHTTPError(error.response);
+            parent.standardErrorHandling(error);
           })
           .then(function () {
             parent.toggleLoader(false);


### PR DESCRIPTION
When the backend (dispatcher) is restarted, all issued tokens become invalid
because we salt out tokens using a random string generated on startup.

In the UI, since we keep track of token expiration date and permission inside our cookie
we have no idea our token became invalid until we attempt to use it and get rejected.
This lead to a 401 Forbidden error message being displayed on restricted actions.

This doesn't change the backend behavior but improves the user experience in the UI:
Most API requests' errors goes through a common function that displays the error msg
If the API response was a 401 status: attempt to renew token and inform user.

New bahavior now would be to be redirected to home page with a message saying that
the token has been refreshed. User is still logged-in and can perform restricted
actions.

Further step could be to transparently retry the failing query and not be affected
at all by invalidated tokens but that would require additional work to prevent request
loops in case we're in a different scenario.

## Rationale

[//]: # (Briefly explain the reason behind this change.)

<!--
Issue: [Title](link) or #123 for Github issues.
-->

## Changes

[//]: # (Summarize what has changed.)
