### PR TITLE
Added support for Workers with dynamic IPs

### DIFF
--- a/dispatcher/backend/requirements.txt
+++ b/dispatcher/backend/requirements.txt
@@ -11,3 +11,4 @@ marshmallow>=3.3.0,<3.4
 requests>=2.24.0,<2.26
 humanfriendly>=9.0,<10
 jinja2>=2.11,<2.12
+kiwixstorage>=0.8.1,<0.9

--- a/dispatcher/backend/src/common/__init__.py
+++ b/dispatcher/backend/src/common/__init__.py
@@ -18,3 +18,24 @@ def to_naive_utc(timestamp_or_iso):
         new_date = timestamp_or_iso
 
     return new_date.astimezone(pytz.utc).replace(tzinfo=None)
+
+
+class WorkersIpChangesCounts:
+    today: datetime.date.today()
+    counts: dict()
+
+    @classmethod
+    def reset(cls):
+        cls.today = datetime.date.today()
+        cls.counts = dict()
+
+    @classmethod
+    def add(cls, worker: str) -> int:
+        if worker not in cls.counts.keys():
+            cls.counts[worker] = 0
+        cls.counts[worker] += 1
+        return cls.get(worker)
+
+    @classmethod
+    def get(cls, worker: str) -> int:
+        return cls.counts.get(worker, 0)

--- a/dispatcher/backend/src/common/constants.py
+++ b/dispatcher/backend/src/common/constants.py
@@ -58,3 +58,22 @@ SLACK_ICON = os.getenv("SLACK_ICON")
 
 # string to replace hidden secrets with
 SECRET_REPLACEMENT = "********"  # nosec
+
+# ###
+# workers whitelist management
+# ###
+# using the following, it is possible to automate
+# the update of a whitelist of workers IPs on Wasabi (S3 provider)
+# enable this feature (default is off)
+USES_WORKERS_IPS_WHITELIST = bool(os.getenv("USES_WORKERS_IPS_WHITELIST", ""))
+MAX_WORKER_IP_CHANGES_PER_DAY = 4
+# wasabi URL with credentials to update policy
+WASABI_URL = os.getenv("WASABI_URL", "")
+# policy ARN such as arn:aws:iam::xxxxxxxxxxxx:policy/yyyyyyyy
+WASABI_WHITELIST_POLICY_ARN = os.getenv("WASABI_WHITELIST_POLICY_ARN", "")
+# ID of the statement to set on the policy for the whitelist
+WASABI_WHITELIST_STATEMENT_ID = os.getenv("ZimfarmWorkersIPsWhiteList")
+# list of IPs and networks to always allow (regardless of used by workers or not)
+WHITELISTED_IPS = [
+    ip.strip() for ip in os.getenv("WHITELISTED_IPS", "").split(",") if ip.strip()
+]

--- a/dispatcher/backend/src/common/external.py
+++ b/dispatcher/backend/src/common/external.py
@@ -1,0 +1,133 @@
+import ipaddress
+import json
+import logging
+import typing
+
+from kiwixstorage import KiwixStorage, AuthenticationError
+
+from common.constants import (
+    WASABI_URL,
+    WASABI_WHITELIST_POLICY_ARN,
+    WASABI_WHITELIST_STATEMENT_ID,
+    WHITELISTED_IPS,
+)
+from common.mongo import Workers
+
+logging.basicConfig(level=logging.DEBUG)
+logger = logging.getLogger(__name__)
+
+
+def update_workers_whitelist():
+    """update whitelist of workers on external services"""
+    update_wasabi_whitelist(build_workers_whitelist())
+
+
+def build_workers_whitelist() -> typing.List[str]:
+    """list of worker IP adresses and networks (text) to use as whitelist"""
+    wl_networks = []
+    wl_ips = []
+    for item in WHITELISTED_IPS:
+        if "/" in item:
+            wl_networks.append(ipaddress.ip_network(item))
+        else:
+            wl_ips.append(ipaddress.ip_address(item))
+
+    def is_covered(ip_addr):
+        for network in wl_networks:
+            if ip_addr in network:
+                return True
+        return False
+
+    for row in Workers().find({"last_ip": {"$exists": True}}, {"last_ip": 1}):
+        ip_addr = ipaddress.ip_address(row["last_ip"])
+        if not is_covered(ip_addr):
+            wl_ips.append(ip_addr)
+
+    return [str(addr) for addr in set(wl_networks + wl_ips)]
+
+
+def update_wasabi_whitelist(ip_addresses: typing.List):
+    """update Wasabi policy to change IP adresses whitelist"""
+    logger.info("Updating Wasabi whitelist")
+
+    def get_statement():
+        return {
+            "Sid": f"{WASABI_WHITELIST_STATEMENT_ID}",
+            "Effect": "Deny",
+            "Action": "s3:*",
+            "Resource": "arn:aws:s3:::*",
+            "Condition": {"NotIpAddress": {"aws:SourceIp": ip_addresses}},
+        }
+
+    if not WASABI_URL:
+        logger.error("> Unable to update workers whitelist: missing WASABI_URL")
+        return
+
+    s3 = KiwixStorage(url=WASABI_URL)
+    try:
+        if not s3.check_credentials(list_buckets=True, failsafe=False):
+            raise AuthenticationError("check_credentials failed")
+    except Exception as exc:
+        logger.error(
+            f"> Unable to update workers whitelist: no auth for WASABI_URL: {exc}"
+        )
+        return
+
+    iam = s3.get_service("iam")
+    versions = iam.list_policy_versions(PolicyArn=WASABI_WHITELIST_POLICY_ARN).get(
+        "Versions", []
+    )
+    logger.debug(f" > {len(versions)} versions for {WASABI_WHITELIST_POLICY_ARN}")
+
+    version_id = None
+    for version in versions:
+        if version["IsDefaultVersion"]:
+            version_id = version["VersionId"]
+
+    logger.debug(f"> Default version is {version_id}")
+
+    # delete all other versions
+    if len(versions) == 5:
+        logger.debug("> Deleting all other versions…")
+        for version in versions:
+            if version["VersionId"] == version_id:
+                continue
+            logger.debug(f"> Deleting version {version['VersionId']}")
+            iam.delete_policy_version(
+                PolicyArn=WASABI_WHITELIST_POLICY_ARN, VersionId=version["VersionId"]
+            )
+
+    if not version_id:
+        logger.error("> Existing policy doesn't exist. probably a mistake?")
+        return
+
+    pv = (
+        iam.get_policy_version(
+            PolicyArn=WASABI_WHITELIST_POLICY_ARN, VersionId=version_id
+        )
+        .get("PolicyVersion", {})
+        .get("Document")
+    )
+    if not pv:
+        logger.error("> We don't have a policy document.")
+        return
+
+    statement = get_statement()  # gen new statement
+
+    try:
+        stmt_index = [s["Sid"] for s in pv["Statement"]].index(
+            WASABI_WHITELIST_STATEMENT_ID
+        )
+        pv["Statement"][stmt_index] = statement
+    except ValueError:
+        pv["Statement"].append(statement)
+
+    new_policy = json.dumps(pv, indent=4)
+    # logger.debug(f"New Policy:\n{new_policy}")
+
+    logger.debug("> Overwriting policy…")
+    iam.create_policy_version(
+        PolicyArn=WASABI_WHITELIST_POLICY_ARN,
+        PolicyDocument=new_policy,
+        SetAsDefault=True,
+    )


### PR DESCRIPTION
When a worker requests tasks (/requested-tasks/worker), its IP is now stored in DB.
If this IP is different from the one we had for it in DB, we'll record the change.

We keep track of the number of times a worker changed its IP per day. If this is
within the set limit (4/day), then we trigger the whitelist update, otherwise we don't.
This is to prevent excessively calling external API (we have workers requesting task ALL THE TIME).

Whitelist update currently only consists in updating the whitelist on our Wasabi policy.

A new environ `USES_WORKERS_IPS_WHITELIST` must be set for the following to work.

The list is built using IPs from all workers as well as additional manual entries
that can be passed in `WHITELISTED_IPS` environ. We'll use this to whitelist the
wikimedia cloud network for instance.

Along with `WHITELISTED_IPS`, this adds requirement for `WASABI_URL` environ which is
used to authenticate over Wasabi API.
