### PR TITLE
Added openZIM CMS call on ZIM check

### DIFF
--- a/dispatcher/backend/src/common/constants.py
+++ b/dispatcher/backend/src/common/constants.py
@@ -79,3 +79,12 @@ WASABI_WHITELIST_STATEMENT_ID = os.getenv(
 WHITELISTED_IPS = [
     ip.strip() for ip in os.getenv("WHITELISTED_IPS", "").split(",") if ip.strip()
 ]
+
+
+# openZIM CMS can be called upon receival of each ZIM
+INFORM_CMS = bool(os.getenv("INFORM_CMS"))
+CMS_ENDPOINT = os.getenv("CMS_ENDPOINT", "https://api.cms.openzim.org/v1/books/add")
+# URL to tell the CMS where to download ZIM from
+CMS_ZIM_DOWNLOAD_URL = os.getenv(
+    "CMS_ZIM_DOWNLOAD_URL", "https://download.kiwix.org/zim"
+)

--- a/dispatcher/backend/src/common/utils.py
+++ b/dispatcher/backend/src/common/utils.py
@@ -8,7 +8,9 @@ import datetime
 from bson import ObjectId
 
 from common import getnow, to_naive_utc
+from common.constants import INFORM_CMS
 from common.enum import TaskStatus
+from common.external import advertise_book_to_cms
 from common.mongo import Tasks, Schedules
 from common.notifications import handle_notification
 from utils.scheduling import update_schedule_duration
@@ -330,6 +332,9 @@ def task_checked_file_event_handler(task_id, payload):
     logger.info(f"Task checked file: {task_id}, {file['name']}")
 
     save_event(task_id, TaskStatus.checked_file, timestamp, file=file)
+
+    if INFORM_CMS:
+        advertise_book_to_cms(task_id, file["name"])
 
 
 def task_update_event_handler(task_id, payload):


### PR DESCRIPTION
if INFORM_CMS is set, when the Zimfarm receives the result of a ZIM's zimcheck,
it calls the openZIM CMS add-book endpoint.
The result of the call (a title ident, mostly) is stored and we know this book/ZIM
has been recorded in the CMS.

New environment variables:
- `INFORM_CMS`: enabled the feature if set
- `CMS_ENDPOINT`: URL of the CMS add-book endpoint
- `CMS_ZIM_DOWNLOAD_URL`: URL to tell the CMS where to download ZIM from
