### PR TITLE
Added overall max number of tasks for platforms

### DIFF
--- a/dispatcher/backend/src/common/enum.py
+++ b/dispatcher/backend/src/common/enum.py
@@ -255,8 +255,15 @@ class Platform:
         return [cls.wikimedia, cls.youtube, cls.wikihow]
 
     @classmethod
-    def get_max_concurrent_for(cls, platform) -> int:
+    def get_max_per_worker_tasks_for(cls, platform) -> int:
         try:
-            return int(os.getenv(f"PLATFORM_{platform}_MAX_TASKS"))
+            return int(os.getenv(f"PLATFORM_{platform}_MAX_TASKS_PER_WORKER"))
+        except (TypeError, ValueError):
+            return None
+
+    @classmethod
+    def get_max_overall_tasks_for(cls, platform) -> int:
+        try:
+            return int(os.getenv(f"PLATFORM_{platform}_MAX_TASKS_TOTAL"))
         except (TypeError, ValueError):
             return None


### PR DESCRIPTION
In addition to per-platform, per-worker max nb of tasks (to prevent individual workers
from being banned by platforms), we are now supporting overall per-platform limits to
prevent platform servers from receiving multiple scrapers at once.

WARNING: server-level environment variables used to set limits have changed.

`PLATFORM_{platform}_MAX_TASKS` is renamed to `PLATFORM_{platform}_MAX_TASKS_PER_WORKER`
`PLATFORM_{platform}_MAX_TASKS_TOTAL` is used to set the overall limit
