### PR TITLE
Issue 784: /schedules/backup/ must exclude most_recent_task

### DIFF
--- a/dispatcher/backend/src/routes/schedules/schedule.py
+++ b/dispatcher/backend/src/routes/schedules/schedule.py
@@ -157,7 +157,7 @@ class SchedulesBackupRoute(BaseRoute):
         """Return all schedules backup"""
 
         def dump(schedule):
-            payload = ScheduleFullSchema().dump(schedule)
+            payload = ScheduleFullSchema(exclude=("most_recent_task",)).dump(schedule)
             if not token or not token.get_permission("schedules", "update"):
                 payload["notification"] = None
 

--- a/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
+++ b/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
@@ -431,3 +431,16 @@ class TestScheduleDelete:
         response = client.delete(url)
         assert response.status_code == 401
         assert response.get_json() == {"error": "token invalid"}
+
+
+class TestScheduleBackup:
+    def test_schedule_backup(self, client, access_token, schedules):
+        """Test get a backup of all schedules"""
+        response = client.get(
+            "/schedules/backup/", headers={"Authorization": access_token}
+        )
+        assert response.status_code == 200
+        schedules_retrieved = response.get_json()
+        assert type(schedules_retrieved) is list
+        for schedule_retrieved in schedules_retrieved:
+            assert "most_recent_task" not in schedule_retrieved


### PR DESCRIPTION
## Rationale

Fix #784 

## Changes

- `most_recent_task` are not exported anymore in `/schedules/backup/`