### PR TITLE
Fix remove_secrets_from_response with a more robust approach

### DIFF
--- a/dispatcher/backend/src/routes/utils.py
+++ b/dispatcher/backend/src/routes/utils.py
@@ -1,34 +1,85 @@
+import logging
+from urllib.parse import urlparse
+
 from common.constants import SECRET_REPLACEMENT
 from common.schemas.models import ScheduleConfigSchema
 from utils.offliners import build_str_command
 
+logger = logging.getLogger(__name__)
+
 
 def remove_secrets_from_response(response: dict):
+    """replaces or removes (in-place) all occurences of secrets"""
+    remove_upload_secrets_from_flags_and_commands(response)
+    remove_upload_secrets_from_response(response)
+
+
+def remove_upload_secrets_from_flags_and_commands(response: dict):
     """replaces (in-place) all occurences of secrets in flags/commands with stars"""
 
-    if "config" not in response:
+    # we need flags to retrieve the secret value and replace it where we find it
+    # in commands
+    if "config" not in response or "flags" not in response["config"]:
         return
 
     schema = ScheduleConfigSchema.get_offliner_schema(
         response["config"]["task_name"]
     )().to_desc()
-    fields = [flag["data_key"] for flag in schema if flag.get("secret", False)]
+    fields = [field["data_key"] for field in schema if field.get("secret", False)]
 
+    flags = response["config"]["flags"]
+
+    # look after each fields of schema in flags
     for field in fields:
-        flags = response["config"]["flags"]
-        command = response["config"].get("command", [])
-        if field in flags:
-            flags[field] = SECRET_REPLACEMENT
-            try:
-                index = command.index(f'--{field}="{flags[field]}"')
-                command[index] = f'--{field}="{SECRET_REPLACEMENT}"'
-            except ValueError:
-                continue
-            if response.get("container"):
-                response["container"]["command"][
-                    index
-                ] = f'--{field}="{SECRET_REPLACEMENT}"'
-        if command:
-            response["config"]["str_command"] = build_str_command(
-                response["config"]["command"]
+        if field not in flags:
+            continue
+
+        secret_flag_value = flags[field]
+
+        flags[field] = SECRET_REPLACEMENT
+
+        secret_command_value = f'--{field}="{secret_flag_value}"'
+
+        if (
+            "command" in response["config"]
+            and secret_command_value in response["config"]["command"]
+        ):
+            index = response["config"]["command"].index(secret_command_value)
+            response["config"]["command"][index] = f'--{field}="{SECRET_REPLACEMENT}"'
+
+        if (
+            "container" in response
+            and "command" in response["container"]
+            and secret_command_value in response["container"]["command"]
+        ):
+            index = response["container"]["command"].index(secret_command_value)
+            response["container"]["command"][
+                index
+            ] = f'--{field}="{SECRET_REPLACEMENT}"'
+
+    # rebuild str_command from command
+    if "str_command" in response["config"]:
+        response["config"]["str_command"] = build_str_command(
+            response["config"]["command"]
+        )
+
+
+def remove_upload_secrets_from_response(response: dict):
+    """remove keyId and secretAccessKey upload_uri, since we upload logs to
+    S3 but still need the rest of the URL to download scraper logs"""
+    if (
+        "upload" in response
+        and "logs" in response["upload"]
+        and "upload_uri" in response["upload"]["logs"]
+    ):
+        url = urlparse(response["upload"]["logs"]["upload_uri"])
+        response["upload"]["logs"]["upload_uri"] = url._replace(
+            query="&".join(
+                [
+                    param
+                    for param in url.query.split("&")
+                    if not param.lower().startswith("keyid")
+                    and not param.lower().startswith("secretaccesskey")
+                ]
             )
+        ).geturl()

--- a/dispatcher/backend/src/tests/unit/routes/test_utils.py
+++ b/dispatcher/backend/src/tests/unit/routes/test_utils.py
@@ -1,0 +1,139 @@
+import pytest
+
+from routes.utils import remove_secrets_from_response
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {
+            "name": "normal_schedule",
+            "config": {
+                "task_name": "kolibri",
+                "flags": {
+                    "name": "khanacademy_en_all",
+                    "optimization-cache": "this_is_super_secret",
+                },
+                "command": [
+                    "kolibri2zim",
+                    '--name="khanacademy_en_all"',
+                    '--optimization-cache="this_is_super_secret"',
+                ],
+            },
+        },
+        {
+            "name": "schedule_with_command_with_missing_flag",
+            "config": {
+                "task_name": "kolibri",
+                "flags": {
+                    "name": "khanacademy_en_all",
+                    "optimization-cache": "this_is_super_secret",
+                    "flag_missing_in_commang": "some_value",
+                },
+                "command": [
+                    "kolibri2zim",
+                    '--name="khanacademy_en_all"',
+                    '--optimization-cache="this_is_super_secret"',
+                ],
+            },
+        },
+        {
+            "name": "schedule_without_command",
+            "config": {
+                "task_name": "kolibri",
+                "flags": {
+                    "name": "khanacademy_en_all",
+                    "optimization-cache": "this_is_super_secret",
+                    "flag_missing_in_commang": "some_value",
+                },
+            },
+        },
+        {
+            "name": "task_with_command_and_container",
+            "config": {
+                "task_name": "kolibri",
+                "flags": {
+                    "name": "khanacademy_en_all",
+                    "optimization-cache": "this_is_super_secret",
+                },
+                "command": [
+                    "kolibri2zim",
+                    '--name="khanacademy_en_all"',
+                    '--optimization-cache="this_is_super_secret"',
+                ],
+                "str_command": (
+                    'kolibri2zim --name="khanacademy_en_all" '
+                    '--optimization-cache="this_is_super_secret"'
+                ),
+            },
+            "container": {
+                "command": [
+                    "kolibri2zim",
+                    '--name="khanacademy_en_all"',
+                    '--optimization-cache="this_is_super_secret"',
+                ],
+            },
+        },
+        {
+            "name": "task_with_command_and_container_with_additional_param",
+            "config": {
+                "task_name": "kolibri",
+                "flags": {
+                    "name": "khanacademy_en_all",
+                    "optimization-cache": "this_is_super_secret",
+                },
+                "command": [
+                    "kolibri2zim",
+                    '--name="khanacademy_en_all"',
+                    '--optimization-cache="this_is_super_secret"',
+                ],
+                "str_command": (
+                    'kolibri2zim --name="khanacademy_en_all" '
+                    '--optimization-cache="this_is_super_secret"'
+                ),
+            },
+            "container": {
+                "command": [
+                    "something",
+                    "kolibri2zim",
+                    '--name="khanacademy_en_all"',
+                    '--optimization-cache="this_is_super_secret"',
+                ],
+            },
+        },
+        {
+            "name": "task_with_upload_logs",
+            "config": {
+                "task_name": "kolibri",
+                "flags": {
+                    "name": "khanacademy_en_all",
+                    "optimization-cache": "this_is_super_secret",
+                },
+                "command": [
+                    "kolibri2zim",
+                    '--name="khanacademy_en_all"',
+                    '--optimization-cache="this_is_super_secret"',
+                ],
+                "str_command": (
+                    'kolibri2zim --name="khanacademy_en_all" '
+                    '--optimization-cache="this_is_super_secret"'
+                ),
+            },
+            "upload": {
+                "logs": {
+                    "expiration": 60,
+                    "upload_uri": (
+                        "s3://s3.us-west-1.wasabisys.com/"
+                        "?keyId=this_is_super_secret"
+                        "&secretAccessKey=this_is_super_secret"
+                        "&bucketName=org-kiwix-zimfarm-logs"
+                    ),
+                },
+            },
+        },
+    ],
+)
+def test_remove_secrets(response):
+    remove_secrets_from_response(response)
+    assert r"""'name': 'khanacademy_en_all'""" in str(response)
+    assert "this_is_super_secret" not in str(response)


### PR DESCRIPTION
## Rationale

Fix #799 

## Changes

- more robust / generic code to cope with many situations
- add code to also clean `upload.logs.upload_uri`
- add tests