### PR TITLE
Add timeouts for GHCR + CMS requests

### DIFF
--- a/dispatcher/backend/src/common/constants.py
+++ b/dispatcher/backend/src/common/constants.py
@@ -39,8 +39,6 @@ ZIMCHECK_OPTION = os.getenv("ZIMCHECK_OPTION", "")
 
 # NOTIFICATIONS
 
-WEB_NOTIFICATIONS_TIMEOUT = int(os.getenv("WEB_NOTIFICATIONS_TIMEOUT", 5))
-
 # in-notification URLs
 PUBLIC_URL = os.getenv("PUBLIC_URL", "https://farm.openzim.org")
 ZIM_DOWNLOAD_URL = os.getenv(
@@ -94,3 +92,8 @@ CMS_ZIM_DOWNLOAD_URL = os.getenv(
 
 # [DEBUG] prevent scraper containers from running wit extended capabilities
 DISALLOW_CAPABILITIES = bool(os.getenv("ZIMFARM_DISALLOW_CAPABILITIES"))
+
+# Timeout for requests to other services
+REQ_TIMEOUT_NOTIFICATIONS = int(os.getenv("REQ_TIMEOUT_NOTIFICATIONS", 5))
+REQ_TIMEOUT_CMS = int(os.getenv("REQ_TIMEOUT_CMS", 10))
+REQ_TIMEOUT_GHCR = int(os.getenv("REQ_TIMEOUT_GHCR", 10))

--- a/dispatcher/backend/src/common/emailing.py
+++ b/dispatcher/backend/src/common/emailing.py
@@ -12,7 +12,7 @@ from common.constants import (
     MAILGUN_API_KEY,
     MAILGUN_API_URL,
     MAILGUN_FROM,
-    WEB_NOTIFICATIONS_TIMEOUT,
+    REQ_TIMEOUT_NOTIFICATIONS,
 )
 
 logger = logging.getLogger(__name__)
@@ -57,7 +57,7 @@ def send_email_via_mailgun(
             ]
             if attachments
             else [],
-            timeout=WEB_NOTIFICATIONS_TIMEOUT,
+            timeout=REQ_TIMEOUT_NOTIFICATIONS,
         )
         resp.raise_for_status()
     except Exception as exc:

--- a/dispatcher/backend/src/common/external.py
+++ b/dispatcher/backend/src/common/external.py
@@ -14,6 +14,7 @@ import db.models as dbm
 from common.constants import (
     CMS_ENDPOINT,
     CMS_ZIM_DOWNLOAD_URL,
+    REQ_TIMEOUT_CMS,
     WASABI_URL,
     WASABI_WHITELIST_POLICY_ARN,
     WASABI_WHITELIST_STATEMENT_ID,
@@ -183,7 +184,9 @@ def advertise_book_to_cms(task: dbm.Task, file_name):
     }
     try:
         resp = requests.post(
-            CMS_ENDPOINT, json=get_openzimcms_payload(file_data, download_prefix)
+            CMS_ENDPOINT,
+            json=get_openzimcms_payload(file_data, download_prefix),
+            timeout=REQ_TIMEOUT_CMS,
         )
     except Exception as exc:
         logger.error(f"Unable to query CMS at {CMS_ENDPOINT}: {exc}")

--- a/dispatcher/backend/src/common/notifications.py
+++ b/dispatcher/backend/src/common/notifications.py
@@ -15,11 +15,11 @@ from marshmallow import ValidationError
 import db.models as dbm
 from common.constants import (
     PUBLIC_URL,
+    REQ_TIMEOUT_NOTIFICATIONS,
     SLACK_EMOJI,
     SLACK_ICON,
     SLACK_URL,
     SLACK_USERNAME,
-    WEB_NOTIFICATIONS_TIMEOUT,
     ZIM_DOWNLOAD_URL,
 )
 from common.emailing import send_email_via_mailgun
@@ -96,7 +96,7 @@ def handle_webhook_notification(task, urls):
                 url,
                 data=dumps(task).encode("UTF-8"),
                 headers={"Content-Type": "application/json"},
-                timeout=WEB_NOTIFICATIONS_TIMEOUT,
+                timeout=REQ_TIMEOUT_NOTIFICATIONS,
             )
             resp.raise_for_status()
         except Exception as exc:
@@ -114,7 +114,7 @@ def handle_slack_notification(task, channels):
         try:
             requests.post(
                 SLACK_URL,
-                timeout=WEB_NOTIFICATIONS_TIMEOUT,
+                timeout=REQ_TIMEOUT_NOTIFICATIONS,
                 json={
                     # destination. prefix with # for chans or @ for account
                     "channel": channel,

--- a/dispatcher/backend/src/routes/schedules/schedule.py
+++ b/dispatcher/backend/src/routes/schedules/schedule.py
@@ -10,6 +10,7 @@ from marshmallow import ValidationError
 from sqlalchemy.exc import IntegrityError
 
 import db.models as dbm
+from common.constants import REQ_TIMEOUT_GHCR
 from common.schemas.models import ScheduleConfigSchema, ScheduleSchema
 from common.schemas.orms import ScheduleFullSchema, ScheduleLightSchema
 from common.schemas.parameters import CloneSchema, SchedulesSchema, UpdateSchema
@@ -302,6 +303,7 @@ class ScheduleImageNames(BaseRoute):
                     "Authorization": f"Bearer {token}",
                     "User-Agent": "Docker-Client/20.10.2 (linux)",
                 },
+                timeout=REQ_TIMEOUT_GHCR,
             )
         except Exception as exc:
             logger.error(f"Unable to connect to GHCR Tags list: {exc}")


### PR DESCRIPTION
## Rationale

See #817 for details

## Changes

- add timeout to requests to GHCR + CMS
- timeout values have a default of 10 secs, which can be override by an environment variable
- more homogeneity in environment variables / constants naming across all requests timeouts
