### PR TITLE
Enhance offliners definitions

### DIFF
--- a/dispatcher/backend/src/common/schemas/fields.py
+++ b/dispatcher/backend/src/common/schemas/fields.py
@@ -9,6 +9,7 @@ from common.enum import (
     WarehousePath,
 )
 from common.roles import ROLES
+from common.schemas import String
 
 # validators
 validate_priority = validate.Range(min=0, max=10)
@@ -65,11 +66,11 @@ limit_field_20_200 = fields.Integer(
     required=False, load_default=20, validate=validate.Range(min=0, max=200)
 )
 priority_field = fields.Integer(required=False, validate=validate_priority)
-worker_field = fields.String(required=False, validate=validate_worker_name)
-schedule_name_field = fields.String(validate=validate_schedule_name)
-category_field = fields.String(required=False, validate=validate_category)
-periodicity_field = fields.String(required=False, validate=validate_periodicity)
-tag_field = fields.List(fields.String(validate=validate_not_empty), required=False)
-offliner_field = fields.String(required=False, validate=validate_offliner)
+worker_field = String(required=False, validate=validate_worker_name)
+schedule_name_field = String(validate=validate_schedule_name)
+category_field = String(required=False, validate=validate_category)
+periodicity_field = String(required=False, validate=validate_periodicity)
+tag_field = fields.List(String(validate=validate_not_empty), required=False)
+offliner_field = String(required=False, validate=validate_offliner)
 email_field = fields.Email(required=False, validate=validate_not_empty)
-username_field = fields.String(required=True, validate=validate_not_empty)
+username_field = String(required=True, validate=validate_not_empty)

--- a/dispatcher/backend/src/common/schemas/models.py
+++ b/dispatcher/backend/src/common/schemas/models.py
@@ -3,7 +3,7 @@ import re
 from marshmallow import Schema, fields, pre_load, validate, validates_schema
 
 from common.enum import DockerImageName, Offliner, Platform
-from common.schemas import SerializableSchema
+from common.schemas import SerializableSchema, String
 from common.schemas.fields import (
     validate_category,
     validate_cpu,
@@ -37,9 +37,9 @@ from common.schemas.offliners import (
 
 
 class LanguageSchema(Schema):
-    code = fields.String(required=True, validate=validate_lang_code)
-    name_en = fields.String(required=True, validate=validate_not_empty)
-    name_native = fields.String(required=True, validate=validate_not_empty)
+    code = String(required=True, validate=validate_lang_code)
+    name_en = String(required=True, validate=validate_not_empty)
+    name_native = String(required=True, validate=validate_not_empty)
 
 
 class ResourcesSchema(Schema):
@@ -47,13 +47,13 @@ class ResourcesSchema(Schema):
     memory = fields.Integer(required=True, validate=validate_memory)
     disk = fields.Integer(required=True, validate=validate_disk)
     shm = fields.Integer(required=False, validate=validate_memory)
-    cap_add = fields.List(fields.String(), required=False)
-    cap_drop = fields.List(fields.String(), required=False)
+    cap_add = fields.List(String(), required=False)
+    cap_drop = fields.List(String(), required=False)
 
 
 class DockerImageSchema(Schema):
-    name = fields.String(required=True, validate=validate.OneOf(DockerImageName.all()))
-    tag = fields.String(required=True)
+    name = String(required=True, validate=validate.OneOf(DockerImageName.all()))
+    tag = String(required=True)
 
     @pre_load
     def strip_prefix(self, in_data, **kwargs):
@@ -65,12 +65,12 @@ class DockerImageSchema(Schema):
 
 
 class ScheduleConfigSchema(SerializableSchema):
-    task_name = fields.String(required=True, validate=validate_offliner)
-    warehouse_path = fields.String(required=True, validate=validate_warehouse_path)
+    task_name = String(required=True, validate=validate_offliner)
+    warehouse_path = String(required=True, validate=validate_warehouse_path)
     image = fields.Nested(DockerImageSchema(), required=True)
     resources = fields.Nested(ResourcesSchema(), required=True)
     flags = fields.Dict(required=True)
-    platform = fields.String(required=True, allow_none=True, validate=validate_platform)
+    platform = String(required=True, allow_none=True, validate=validate_platform)
     monitor = fields.Boolean(required=True, truthy=[True], falsy=[False])
 
     @staticmethod
@@ -101,7 +101,7 @@ class ScheduleConfigSchema(SerializableSchema):
 class EventNotificationSchema(SerializableSchema):
     mailgun = fields.List(fields.Email(), required=False)
     webhook = fields.List(fields.Url(), required=False)
-    slack = fields.List(fields.String(validate=validate_slack_target), required=False)
+    slack = fields.List(String(validate=validate_slack_target), required=False)
 
 
 class ScheduleNotificationSchema(SerializableSchema):
@@ -111,12 +111,12 @@ class ScheduleNotificationSchema(SerializableSchema):
 
 
 class ScheduleSchema(Schema):
-    name = fields.String(required=True, validate=validate_schedule_name)
+    name = String(required=True, validate=validate_schedule_name)
     language = fields.Nested(LanguageSchema(), required=True)
-    category = fields.String(required=True, validate=validate_category)
-    periodicity = fields.String(required=True, validate=validate_periodicity)
+    category = String(required=True, validate=validate_category)
+    periodicity = String(required=True, validate=validate_periodicity)
     tags = fields.List(
-        fields.String(validate=validate_not_empty), required=True, dump_default=[]
+        String(validate=validate_not_empty), required=True, dump_default=[]
     )
     enabled = fields.Boolean(required=True, truthy=[True], falsy=[False])
     config = fields.Nested(ScheduleConfigSchema(), required=True)

--- a/dispatcher/backend/src/common/schemas/offliners/freecodecamp.py
+++ b/dispatcher/backend/src/common/schemas/offliners/freecodecamp.py
@@ -1,6 +1,6 @@
 from marshmallow import fields, validate
 
-from common.schemas import SerializableSchema, StringEnum
+from common.schemas import SerializableSchema, StringEnum, LongString
 from common.schemas.fields import (
     validate_output,
     validate_zim_description,
@@ -70,7 +70,7 @@ class FreeCodeCampFlagsSchema(SerializableSchema):
         validate=validate_zim_description,
     )
 
-    long_description = fields.String(
+    long_description = LongString(
         metadata={
             "label": "Long description",
             "description": "Optional long description for your ZIM",

--- a/dispatcher/backend/src/common/schemas/offliners/freecodecamp.py
+++ b/dispatcher/backend/src/common/schemas/offliners/freecodecamp.py
@@ -1,12 +1,25 @@
-from marshmallow import fields
+from marshmallow import fields, validate
 
-from common.schemas import SerializableSchema
+from common.schemas import SerializableSchema, StringEnum
 from common.schemas.fields import (
     validate_output,
     validate_zim_description,
     validate_zim_filename,
     validate_zim_longdescription,
 )
+
+FCC_LANG_MAP = {
+    "ara": "arabic",
+    "cmn": "chinese",
+    "lzh": "chinese-traditional",
+    "eng": "english",
+    "spa": "espanol",
+    "deu": "german",
+    "ita": "italian",
+    "jpn": "japanese",
+    "por": "portuguese",
+    "ukr": "ukranian",
+}
 
 
 class FreeCodeCampFlagsSchema(SerializableSchema):
@@ -21,15 +34,15 @@ class FreeCodeCampFlagsSchema(SerializableSchema):
         required=True,
     )
 
-    language = fields.String(
+    language = StringEnum(
         metadata={
             "label": "Language",
-            "description": "Language of zim file and curriculum. Either (without "
-            "quotes) 'ara' (arabic), 'cmn' (chinese), 'lzh' (chinese-traditional), "
-            "'eng' (english), 'spa' (espanol), 'deu' (german), 'ita' (italian), "
-            "'jpn' (japanese), 'por' (portuguese), 'ukr' (ukranian).",
+            "description": "Language of zim file and curriculum. One of "
+            + ", ".join([f"'{key}' ({desc})" for key, desc in FCC_LANG_MAP.items()])
+            + ".",
         },
         required=True,
+        validate=validate.OneOf(list(FCC_LANG_MAP.keys())),
     )
 
     name = fields.String(

--- a/dispatcher/backend/src/common/schemas/offliners/freecodecamp.py
+++ b/dispatcher/backend/src/common/schemas/offliners/freecodecamp.py
@@ -1,6 +1,6 @@
 from marshmallow import fields, validate
 
-from common.schemas import SerializableSchema, StringEnum, LongString
+from common.schemas import LongString, SerializableSchema, String, StringEnum
 from common.schemas.fields import (
     validate_output,
     validate_zim_description,
@@ -26,7 +26,7 @@ class FreeCodeCampFlagsSchema(SerializableSchema):
     class Meta:
         ordered = True
 
-    course = fields.String(
+    course = String(
         metadata={
             "label": "Course(s)",
             "description": "Course or course list (separated by commas)",
@@ -45,7 +45,7 @@ class FreeCodeCampFlagsSchema(SerializableSchema):
         validate=validate.OneOf(list(FCC_LANG_MAP.keys())),
     )
 
-    name = fields.String(
+    name = String(
         metadata={
             "label": "Name",
             "description": "ZIM name",
@@ -53,7 +53,7 @@ class FreeCodeCampFlagsSchema(SerializableSchema):
         required=True,
     )
 
-    title = fields.String(
+    title = String(
         metadata={
             "label": "Title",
             "description": "ZIM title",
@@ -61,7 +61,7 @@ class FreeCodeCampFlagsSchema(SerializableSchema):
         required=True,
     )
 
-    description = fields.String(
+    description = String(
         metadata={
             "label": "Description",
             "description": "Description for your ZIM",
@@ -79,14 +79,14 @@ class FreeCodeCampFlagsSchema(SerializableSchema):
         data_key="long-description",
     )
 
-    creator = fields.String(
+    creator = String(
         metadata={
             "label": "Content Creator",
             "description": "Name of content creator. “freeCodeCamp” otherwise",
         }
     )
 
-    publisher = fields.String(
+    publisher = String(
         metadata={
             "label": "Publisher",
             "description": "Custom publisher name (ZIM metadata). “OpenZIM” otherwise",
@@ -99,7 +99,7 @@ class FreeCodeCampFlagsSchema(SerializableSchema):
         metadata={"label": "Debug", "description": "Enable verbose output"},
     )
 
-    output_dir = fields.String(
+    output_dir = String(
         metadata={
             "label": "Output folder",
             "placeholder": "/output",
@@ -111,7 +111,7 @@ class FreeCodeCampFlagsSchema(SerializableSchema):
         validate=validate_output,
     )
 
-    zim_file = fields.String(
+    zim_file = String(
         metadata={
             "label": "ZIM filename",
             "description": "ZIM file name (based on --name if not provided). "

--- a/dispatcher/backend/src/common/schemas/offliners/gutenberg.py
+++ b/dispatcher/backend/src/common/schemas/offliners/gutenberg.py
@@ -1,6 +1,7 @@
 from marshmallow import fields
 
 from common.schemas import SerializableSchema, String
+from common.schemas.fields import validate_zim_description
 
 
 class GutenbergFlagsSchema(SerializableSchema):
@@ -38,6 +39,7 @@ class GutenbergFlagsSchema(SerializableSchema):
     zim_desc = String(
         metadata={"label": "Description", "description": "Description for ZIM"},
         data_key="zim-desc",
+        validate=validate_zim_description,
     )
 
     books = String(

--- a/dispatcher/backend/src/common/schemas/offliners/gutenberg.py
+++ b/dispatcher/backend/src/common/schemas/offliners/gutenberg.py
@@ -1,13 +1,13 @@
 from marshmallow import fields
 
-from common.schemas import SerializableSchema
+from common.schemas import SerializableSchema, String
 
 
 class GutenbergFlagsSchema(SerializableSchema):
     class Meta:
         ordered = True
 
-    languages = fields.String(
+    languages = String(
         metadata={
             "label": "Languages",
             "description": (
@@ -17,7 +17,7 @@ class GutenbergFlagsSchema(SerializableSchema):
         },
     )
 
-    formats = fields.String(
+    formats = String(
         metadata={
             "label": "Formats",
             "description": (
@@ -27,7 +27,7 @@ class GutenbergFlagsSchema(SerializableSchema):
         },
     )
 
-    zim_title = fields.String(
+    zim_title = String(
         metadata={
             "label": "Title",
             "description": "Custom title for your project and ZIM.",
@@ -35,12 +35,12 @@ class GutenbergFlagsSchema(SerializableSchema):
         data_key="zim-title",
     )
 
-    zim_desc = fields.String(
+    zim_desc = String(
         metadata={"label": "Description", "description": "Description for ZIM"},
         data_key="zim-desc",
     )
 
-    books = fields.String(
+    books = String(
         metadata={
             "label": "Books",
             "description": (

--- a/dispatcher/backend/src/common/schemas/offliners/ifixit.py
+++ b/dispatcher/backend/src/common/schemas/offliners/ifixit.py
@@ -1,7 +1,11 @@
 from marshmallow import fields, validate
 
 from common.schemas import SerializableSchema
-from common.schemas.fields import validate_output, validate_zim_filename
+from common.schemas.fields import (
+    validate_output,
+    validate_zim_description,
+    validate_zim_filename,
+)
 
 
 def validate_percent(value):
@@ -42,6 +46,7 @@ class IFixitFlagsSchema(SerializableSchema):
             "description": "Custom description for your ZIM. "
             "iFixIt homepage description (meta) otherwise",
         },
+        validate=validate_zim_description,
     )
 
     icon = fields.Url(

--- a/dispatcher/backend/src/common/schemas/offliners/ifixit.py
+++ b/dispatcher/backend/src/common/schemas/offliners/ifixit.py
@@ -1,6 +1,6 @@
 from marshmallow import fields, validate
 
-from common.schemas import SerializableSchema
+from common.schemas import SerializableSchema, String
 from common.schemas.fields import (
     validate_output,
     validate_zim_description,
@@ -16,7 +16,7 @@ class IFixitFlagsSchema(SerializableSchema):
     class Meta:
         ordered = True
 
-    language = fields.String(
+    language = String(
         metadata={
             "label": "Language",
             "description": "iFixIt website to build from",
@@ -24,7 +24,7 @@ class IFixitFlagsSchema(SerializableSchema):
         required=True,
     )
 
-    name = fields.String(
+    name = String(
         metadata={
             "label": "Name",
             "description": "ZIM name. Used as identifier and filename "
@@ -32,7 +32,7 @@ class IFixitFlagsSchema(SerializableSchema):
         },
     )
 
-    title = fields.String(
+    title = String(
         metadata={
             "label": "Title",
             "description": "Custom title for your ZIM. "
@@ -40,7 +40,7 @@ class IFixitFlagsSchema(SerializableSchema):
         },
     )
 
-    description = fields.String(
+    description = String(
         metadata={
             "label": "Description",
             "description": "Custom description for your ZIM. "
@@ -57,21 +57,21 @@ class IFixitFlagsSchema(SerializableSchema):
         }
     )
 
-    creator = fields.String(
+    creator = String(
         metadata={
             "label": "Creator",
             "description": "Name of content creator. “iFixit” otherwise",
         },
     )
 
-    publisher = fields.String(
+    publisher = String(
         metadata={
             "label": "Publisher",
             "description": "Custom publisher name (ZIM metadata). “openZIM” otherwise",
         },
     )
 
-    tag = fields.String(
+    tag = String(
         metadata={
             "label": "ZIM Tags",
             "description": "List of semi-colon-separated Tags for the ZIM file. "
@@ -79,7 +79,7 @@ class IFixitFlagsSchema(SerializableSchema):
         }
     )
 
-    output = fields.String(
+    output = String(
         metadata={
             "label": "Output folder",
             "placeholder": "/output",
@@ -90,7 +90,7 @@ class IFixitFlagsSchema(SerializableSchema):
         validate=validate_output,
     )
 
-    tmp_dir = fields.String(
+    tmp_dir = String(
         metadata={
             "label": "Temp folder",
             "placeholder": "/output",
@@ -103,7 +103,7 @@ class IFixitFlagsSchema(SerializableSchema):
         data_key="tmp-dir",
     )
 
-    zim_file = fields.String(
+    zim_file = String(
         metadata={
             "label": "ZIM filename",
             "description": "ZIM file name (based on --name if not provided). "
@@ -122,7 +122,7 @@ class IFixitFlagsSchema(SerializableSchema):
         data_key="optimization-cache",
     )
 
-    stats_filename = fields.String(
+    stats_filename = String(
         metadata={
             "label": "Stats filename",
             "placeholder": "/output/task_progress.json",
@@ -192,7 +192,7 @@ class IFixitFlagsSchema(SerializableSchema):
         validate=validate_percent,
     )
 
-    category = fields.String(
+    category = String(
         metadata={
             "label": "Categories",
             "description": "Only scrape those categories (comma-separated). "
@@ -207,7 +207,7 @@ class IFixitFlagsSchema(SerializableSchema):
         data_key="no-category",
     )
 
-    guide = fields.String(
+    guide = String(
         metadata={
             "label": "Guides",
             "description": "Only scrape this guide (comma-separated)). "
@@ -222,7 +222,7 @@ class IFixitFlagsSchema(SerializableSchema):
         data_key="no-guide",
     )
 
-    info = fields.String(
+    info = String(
         metadata={
             "label": "Info",
             "description": "Only scrape this info (comma-separated)). "

--- a/dispatcher/backend/src/common/schemas/offliners/kolibri.py
+++ b/dispatcher/backend/src/common/schemas/offliners/kolibri.py
@@ -1,6 +1,6 @@
 from marshmallow import fields
 
-from common.schemas import SerializableSchema
+from common.schemas import SerializableSchema, LongString
 from common.schemas.fields import (
     validate_output,
     validate_zim_description,
@@ -56,7 +56,7 @@ class KolibriFlagsSchema(SerializableSchema):
         validate=validate_zim_description,
     )
 
-    long_description = fields.String(
+    long_description = LongString(
         metadata={
             "label": "Long description",
             "description": "Custom long description for your ZIM. "

--- a/dispatcher/backend/src/common/schemas/offliners/kolibri.py
+++ b/dispatcher/backend/src/common/schemas/offliners/kolibri.py
@@ -1,7 +1,12 @@
 from marshmallow import fields
 
 from common.schemas import SerializableSchema
-from common.schemas.fields import validate_output, validate_zim_filename
+from common.schemas.fields import (
+    validate_output,
+    validate_zim_description,
+    validate_zim_filename,
+    validate_zim_longdescription,
+)
 
 
 class KolibriFlagsSchema(SerializableSchema):
@@ -47,7 +52,8 @@ class KolibriFlagsSchema(SerializableSchema):
             "label": "Description",
             "description": "Custom description for your ZIM. "
             "Kolibri channel description otherwise",
-        }
+        },
+        validate=validate_zim_description,
     )
 
     long_description = fields.String(
@@ -58,6 +64,7 @@ class KolibriFlagsSchema(SerializableSchema):
             "too long to fit entirely in ZIM description",
         },
         data_key="long-description",
+        validate=validate_zim_longdescription,
     )
 
     favicon = fields.Url(

--- a/dispatcher/backend/src/common/schemas/offliners/kolibri.py
+++ b/dispatcher/backend/src/common/schemas/offliners/kolibri.py
@@ -1,6 +1,6 @@
 from marshmallow import fields
 
-from common.schemas import SerializableSchema, LongString
+from common.schemas import LongString, SerializableSchema, String
 from common.schemas.fields import (
     validate_output,
     validate_zim_description,
@@ -13,7 +13,7 @@ class KolibriFlagsSchema(SerializableSchema):
     class Meta:
         ordered = True
 
-    channel_id = fields.String(
+    channel_id = String(
         metadata={
             "label": "Channel ID",
             "description": "The Kolibri channel ID that you want to scrape",
@@ -22,7 +22,7 @@ class KolibriFlagsSchema(SerializableSchema):
         required=True,
     )
 
-    root_id = fields.String(
+    root_id = String(
         metadata={
             "label": "Root ID",
             "description": "The node ID (usually Topic) from where to start "
@@ -31,7 +31,7 @@ class KolibriFlagsSchema(SerializableSchema):
         data_key="root-id",
     )
 
-    name = fields.String(
+    name = String(
         metadata={
             "label": "Name",
             "description": "ZIM name. Used as identifier "
@@ -40,14 +40,14 @@ class KolibriFlagsSchema(SerializableSchema):
         required=True,
     )
 
-    title = fields.String(
+    title = String(
         metadata={
             "label": "Title",
             "description": "Custom title for your ZIM. Kolibri channel name otherwise",
         }
     )
 
-    description = fields.String(
+    description = String(
         metadata={
             "label": "Description",
             "description": "Custom description for your ZIM. "
@@ -98,7 +98,7 @@ class KolibriFlagsSchema(SerializableSchema):
         required=False,
     )
 
-    creator = fields.String(
+    creator = String(
         metadata={
             "label": "Content Creator",
             "description": "Name of content creator. Kolibri "
@@ -106,14 +106,14 @@ class KolibriFlagsSchema(SerializableSchema):
         }
     )
 
-    publisher = fields.String(
+    publisher = String(
         metadata={
             "label": "Publisher",
             "description": "Custom publisher name (ZIM metadata). “OpenZIM” otherwise",
         }
     )
 
-    tags = fields.String(
+    tags = String(
         metadata={
             "label": "ZIM Tags",
             "description": "List of comma-separated Tags for the ZIM file. "
@@ -155,7 +155,7 @@ class KolibriFlagsSchema(SerializableSchema):
         falsy=[False],
     )
 
-    output = fields.String(
+    output = String(
         metadata={
             "label": "Output folder",
             "placeholder": "/output",
@@ -166,7 +166,7 @@ class KolibriFlagsSchema(SerializableSchema):
         validate=validate_output,
     )
 
-    tmp_dir = fields.String(
+    tmp_dir = String(
         metadata={
             "label": "Temp folder",
             "placeholder": "/output",
@@ -179,7 +179,7 @@ class KolibriFlagsSchema(SerializableSchema):
         data_key="tmp-dir",
     )
 
-    zim_file = fields.String(
+    zim_file = String(
         metadata={
             "label": "ZIM filename",
             "description": "ZIM file name (based on --name if not provided). "

--- a/dispatcher/backend/src/common/schemas/offliners/mwoffliner.py
+++ b/dispatcher/backend/src/common/schemas/offliners/mwoffliner.py
@@ -1,6 +1,12 @@
 from marshmallow import fields, validate
 
-from common.schemas import ListOfStringEnum, LongString, SerializableSchema, StringEnum
+from common.schemas import (
+    ListOfStringEnum,
+    LongString,
+    SerializableSchema,
+    String,
+    StringEnum,
+)
 from common.schemas.fields import (
     validate_output,
     validate_zim_description,
@@ -42,20 +48,20 @@ class MWOfflinerFlagsSchema(SerializableSchema):
             "to ignore (one per line)",
         }
     )
-    customMainPage = fields.String(
+    customMainPage = String(
         metadata={
             "label": "Main Page",
             "description": "Article Name to use as home page. "
             "Automatically built or guessed otherwise.",
         }
     )
-    customZimTitle = fields.String(
+    customZimTitle = String(
         metadata={
             "label": "ZIM Title",
             "description": "Custom ZIM title. Wiki name otherwise.",
         }
     )
-    customZimDescription = fields.String(
+    customZimDescription = String(
         metadata={"label": "ZIM Description", "description": "Max length is 80 chars"},
         validate=validate_zim_description,
     )
@@ -73,32 +79,32 @@ class MWOfflinerFlagsSchema(SerializableSchema):
             "Will be resized to 48x48px.",
         }
     )
-    customZimTags = fields.String(
+    customZimTags = String(
         metadata={
             "label": "ZIM Tags",
             "description": "Semi-colon separated list of ZIM tags",
         }
     )
-    customZimLanguage = fields.String(
+    customZimLanguage = String(
         metadata={
             "label": "ZIM Language metadata",
             "description": "Custom ISO-639-3 language code for the ZIM",
         }
     )
-    publisher = fields.String(
+    publisher = String(
         metadata={
             "label": "Publisher",
             "description": "ZIM publisher metadata. `Kiwix` otherwise.",
         }
     )
-    filenamePrefix = fields.String(
+    filenamePrefix = String(
         metadata={
             "label": "Filename prefix",
             "description": "Custome filename up to the formats and date parts.",
         }
     )
     formats = ListOfStringEnum(
-        fields.String(
+        String(
             validate=validate.OneOf(
                 [
                     "nodet,nopic:mini",
@@ -139,7 +145,7 @@ class MWOfflinerFlagsSchema(SerializableSchema):
         }
     )
 
-    addNamespaces = fields.String(
+    addNamespaces = String(
         metadata={
             "label": "Add Namespaces",
             "description": "Include addional namespaces (comma separated numbers)",
@@ -170,51 +176,51 @@ class MWOfflinerFlagsSchema(SerializableSchema):
         },
     )
 
-    mwWikiPath = fields.String(
+    mwWikiPath = String(
         metadata={
             "label": "Wiki Path",
             "description": "Mediawiki wiki base path. Otherwise `/wiki/`.",
         }
     )
-    mwApiPath = fields.String(
+    mwApiPath = String(
         metadata={
             "label": "API Path",
             "description": "Mediawiki API path. Otherwise `/w/api.php`.",
         }
     )
-    mwModulePath = fields.String(
+    mwModulePath = String(
         metadata={
             "label": "Module Path",
             "description": "Mediawiki module load path. Otherwise `/w/load.php`.",
         }
     )
-    mwDomain = fields.String(
+    mwDomain = String(
         metadata={
             "label": "User Domain",
             "description": "Mediawiki user domain (for private wikis)",
         }
     )
-    mwUsername = fields.String(
+    mwUsername = String(
         metadata={
             "label": "Username",
             "description": "Mediawiki username (for private wikis)",
         }
     )
-    mwPassword = fields.String(
+    mwPassword = String(
         metadata={
             "label": "Password",
             "description": "Mediawiki user password (for private wikis)",
         }
     )
 
-    osTmpDir = fields.String(
+    osTmpDir = String(
         metadata={
             "label": "OS Temp Dir",
             "description": "Override default operating system temporary "
             "directory path environnement variable",
         }
     )
-    outputDirectory = fields.String(
+    outputDirectory = String(
         metadata={
             "label": "Output folder",
             "placeholder": "/output",

--- a/dispatcher/backend/src/common/schemas/offliners/nautilus.py
+++ b/dispatcher/backend/src/common/schemas/offliners/nautilus.py
@@ -1,7 +1,11 @@
 from marshmallow import fields
 
 from common.schemas import HexColor, SerializableSchema
-from common.schemas.fields import validate_output, validate_zim_filename
+from common.schemas.fields import (
+    validate_output,
+    validate_zim_description,
+    validate_zim_filename,
+)
 
 
 class NautilusFlagsSchema(SerializableSchema):
@@ -100,7 +104,8 @@ class NautilusFlagsSchema(SerializableSchema):
         metadata={
             "label": "Description",
             "description": "Description for your project and ZIM.",
-        }
+        },
+        validate=validate_zim_description,
     )
     creator = fields.String(
         metadata={

--- a/dispatcher/backend/src/common/schemas/offliners/nautilus.py
+++ b/dispatcher/backend/src/common/schemas/offliners/nautilus.py
@@ -1,6 +1,6 @@
 from marshmallow import fields
 
-from common.schemas import HexColor, SerializableSchema
+from common.schemas import HexColor, SerializableSchema, String
 from common.schemas.fields import (
     validate_output,
     validate_zim_description,
@@ -30,7 +30,7 @@ class NautilusFlagsSchema(SerializableSchema):
         required=False,
     )
 
-    name = fields.String(
+    name = String(
         metadata={
             "label": "ZIM Name",
             "description": "Used as identifier and filename (date will be appended)",
@@ -59,7 +59,7 @@ class NautilusFlagsSchema(SerializableSchema):
         data_key="show-description",
     )
 
-    output = fields.String(
+    output = String(
         metadata={
             "label": "Output folder",
             "placeholder": "/output",
@@ -71,7 +71,7 @@ class NautilusFlagsSchema(SerializableSchema):
         dump_default="/output",
         validate=validate_output,
     )
-    zim_file = fields.String(
+    zim_file = String(
         metadata={
             "label": "ZIM filename",
             "description": "ZIM file name (based on --name if not provided)",
@@ -79,13 +79,13 @@ class NautilusFlagsSchema(SerializableSchema):
         data_key="zim-file",
         validate=validate_zim_filename,
     )
-    language = fields.String(
+    language = String(
         metadata={
             "label": "Language",
             "description": "ISO-639-3 (3 chars) language code of content",
         }
     )
-    locale = fields.String(
+    locale = String(
         metadata={
             "label": "Locale",
             "description": (
@@ -94,26 +94,26 @@ class NautilusFlagsSchema(SerializableSchema):
             ),
         }
     )
-    title = fields.String(
+    title = String(
         metadata={
             "label": "Title",
             "description": "Title for your project and ZIM. Otherwise --name.",
         }
     )
-    description = fields.String(
+    description = String(
         metadata={
             "label": "Description",
             "description": "Description for your project and ZIM.",
         },
         validate=validate_zim_description,
     )
-    creator = fields.String(
+    creator = String(
         metadata={
             "label": "Content Creator",
             "description": "Name of content creator.",
         }
     )
-    tags = fields.String(
+    tags = String(
         metadata={
             "label": "ZIM Tags",
             "description": "List of comma-separated Tags for the ZIM file.",

--- a/dispatcher/backend/src/common/schemas/offliners/openedx.py
+++ b/dispatcher/backend/src/common/schemas/offliners/openedx.py
@@ -1,6 +1,6 @@
 from marshmallow import fields, validate
 
-from common.schemas import SerializableSchema, StringEnum
+from common.schemas import SerializableSchema, String, StringEnum
 from common.schemas.fields import (
     validate_output,
     validate_zim_description,
@@ -21,7 +21,7 @@ class OpenedxFlagsSchema(SerializableSchema):
         required=True,
     )
 
-    email = fields.String(
+    email = String(
         metadata={
             "label": "Registered e-mail",
             "description": "The registered e-mail ID on the openedx instance",
@@ -30,7 +30,7 @@ class OpenedxFlagsSchema(SerializableSchema):
         required=True,
     )
 
-    password = fields.String(
+    password = String(
         metadata={
             "label": "Password",
             "description": "Password to the account registered on the openedx instance",
@@ -40,7 +40,7 @@ class OpenedxFlagsSchema(SerializableSchema):
         required=True,
     )
 
-    instance_login_page = fields.String(
+    instance_login_page = String(
         metadata={
             "label": "Login page path",
             "description": "The login path in the instance. Must start with /",
@@ -49,7 +49,7 @@ class OpenedxFlagsSchema(SerializableSchema):
         data_key="instance-login-page",
     )
 
-    instance_course_page = fields.String(
+    instance_course_page = String(
         metadata={
             "label": "Course page path",
             "description": (
@@ -60,7 +60,7 @@ class OpenedxFlagsSchema(SerializableSchema):
         data_key="instance-course-page",
     )
 
-    instance_course_prefix = fields.String(
+    instance_course_prefix = String(
         metadata={
             "label": "Course prefix path",
             "description": (
@@ -156,7 +156,7 @@ class OpenedxFlagsSchema(SerializableSchema):
         data_key="autoplay",
     )
 
-    name = fields.String(
+    name = String(
         metadata={
             "label": "Name",
             "description": (
@@ -168,7 +168,7 @@ class OpenedxFlagsSchema(SerializableSchema):
         required=True,
     )
 
-    title = fields.String(
+    title = String(
         metadata={
             "label": "Title",
             "description": "Custom title for your ZIM. Based on MOOC otherwise",
@@ -176,7 +176,7 @@ class OpenedxFlagsSchema(SerializableSchema):
         data_key="title",
     )
 
-    description = fields.String(
+    description = String(
         metadata={
             "label": "Description",
             "description": "Custom description for your ZIM. Based on MOOC otherwise",
@@ -185,7 +185,7 @@ class OpenedxFlagsSchema(SerializableSchema):
         validate=validate_zim_description,
     )
 
-    creator = fields.String(
+    creator = String(
         metadata={
             "label": "Content Creator",
             "description": "Name of content creator. Defaults to edX",
@@ -193,7 +193,7 @@ class OpenedxFlagsSchema(SerializableSchema):
         data_key="creator",
     )
 
-    tags = fields.String(
+    tags = String(
         metadata={
             "label": "ZIM Tags",
             "description": (
@@ -225,7 +225,7 @@ class OpenedxFlagsSchema(SerializableSchema):
         data_key="use-any-optimized-version",
     )
 
-    output = fields.String(
+    output = String(
         metadata={
             "label": "Output folder",
             "placeholder": "/output",
@@ -237,7 +237,7 @@ class OpenedxFlagsSchema(SerializableSchema):
         data_key="output",
     )
 
-    tmp_dir = fields.String(
+    tmp_dir = String(
         metadata={
             "label": "Temp folder",
             "description": (
@@ -250,7 +250,7 @@ class OpenedxFlagsSchema(SerializableSchema):
         data_key="tmp-dir",
     )
 
-    zim_file = fields.String(
+    zim_file = String(
         metadata={
             "label": "ZIM filename",
             "description": "ZIM file name (based on ZIM name if not provided)",
@@ -273,7 +273,7 @@ class OpenedxFlagsSchema(SerializableSchema):
         validate=validate.Range(min=1),
     )
 
-    locale = fields.String(
+    locale = String(
         metadata={
             "label": "Locale",
             "description": "The locale to use for the translations in ZIM",

--- a/dispatcher/backend/src/common/schemas/offliners/openedx.py
+++ b/dispatcher/backend/src/common/schemas/offliners/openedx.py
@@ -1,7 +1,11 @@
 from marshmallow import fields, validate
 
 from common.schemas import SerializableSchema, StringEnum
-from common.schemas.fields import validate_output, validate_zim_filename
+from common.schemas.fields import (
+    validate_output,
+    validate_zim_description,
+    validate_zim_filename,
+)
 
 
 class OpenedxFlagsSchema(SerializableSchema):
@@ -178,6 +182,7 @@ class OpenedxFlagsSchema(SerializableSchema):
             "description": "Custom description for your ZIM. Based on MOOC otherwise",
         },
         data_key="description",
+        validate=validate_zim_description,
     )
 
     creator = fields.String(

--- a/dispatcher/backend/src/common/schemas/offliners/sotoki.py
+++ b/dispatcher/backend/src/common/schemas/offliners/sotoki.py
@@ -1,7 +1,11 @@
 from marshmallow import fields, validate
 
 from common.schemas import SerializableSchema
-from common.schemas.fields import validate_output, validate_zim_filename
+from common.schemas.fields import (
+    validate_output,
+    validate_zim_description,
+    validate_zim_filename,
+)
 
 
 class SotokiFlagsSchema(SerializableSchema):
@@ -36,6 +40,7 @@ class SotokiFlagsSchema(SerializableSchema):
             "label": "Description",
             "description": "Custom description for your ZIM. Site tagline otherwise",
         },
+        validate=validate_zim_description,
     )
 
     favicon = fields.Url(

--- a/dispatcher/backend/src/common/schemas/offliners/sotoki.py
+++ b/dispatcher/backend/src/common/schemas/offliners/sotoki.py
@@ -1,6 +1,6 @@
 from marshmallow import fields, validate
 
-from common.schemas import SerializableSchema
+from common.schemas import SerializableSchema, String
 from common.schemas.fields import (
     validate_output,
     validate_zim_description,
@@ -12,7 +12,7 @@ class SotokiFlagsSchema(SerializableSchema):
     class Meta:
         ordered = True
 
-    domain = fields.String(
+    domain = String(
         metadata={
             "label": "Domain",
             "description": "Domain name from StackExchange to scrape.",
@@ -20,7 +20,7 @@ class SotokiFlagsSchema(SerializableSchema):
         required=True,
     )
 
-    name = fields.String(
+    name = String(
         metadata={
             "label": "Name",
             "description": "ZIM name. Used as identifier and filename "
@@ -28,14 +28,14 @@ class SotokiFlagsSchema(SerializableSchema):
         },
     )
 
-    title = fields.String(
+    title = String(
         metadata={
             "label": "Title",
             "description": "Custom title for your ZIM. Site name otherwise",
         },
     )
 
-    description = fields.String(
+    description = String(
         metadata={
             "label": "Description",
             "description": "Custom description for your ZIM. Site tagline otherwise",
@@ -50,21 +50,21 @@ class SotokiFlagsSchema(SerializableSchema):
         }
     )
 
-    creator = fields.String(
+    creator = String(
         metadata={
             "label": "Creator",
             "description": "Name of content creator. “Stack Exchange” otherwise",
         },
     )
 
-    publisher = fields.String(
+    publisher = String(
         metadata={
             "label": "Publisher",
             "description": "Custom publisher name (ZIM metadata). “OpenZIM” otherwise",
         },
     )
 
-    tags = fields.String(
+    tags = String(
         metadata={
             "label": "ZIM Tags",
             "description": "List of comma-separated Tags for the ZIM file. "
@@ -141,7 +141,7 @@ class SotokiFlagsSchema(SerializableSchema):
         data_key="censor-words-list",
     )
 
-    output = fields.String(
+    output = String(
         metadata={
             "label": "Output folder",
             "placeholder": "/output",
@@ -160,7 +160,7 @@ class SotokiFlagsSchema(SerializableSchema):
         }
     )
 
-    tmp_dir = fields.String(
+    tmp_dir = String(
         metadata={
             "label": "Temp folder",
             "placeholder": "/output",
@@ -173,7 +173,7 @@ class SotokiFlagsSchema(SerializableSchema):
         data_key="tmp-dir",
     )
 
-    zim_file = fields.String(
+    zim_file = String(
         metadata={
             "label": "ZIM filename",
             "description": "ZIM file name (based on --name if not provided). "
@@ -199,7 +199,7 @@ class SotokiFlagsSchema(SerializableSchema):
         },
     )
 
-    stats_filename = fields.String(
+    stats_filename = String(
         metadata={
             "label": "Stats filename",
             "placeholder": "/output/task_progress.json",
@@ -212,7 +212,7 @@ class SotokiFlagsSchema(SerializableSchema):
         validate=validate.Equal("/output/task_progress.json"),
     )
 
-    redis_url = fields.String(
+    redis_url = String(
         metadata={
             "label": "Redis URL",
             "description": "Redis URL to use as database. "
@@ -224,7 +224,7 @@ class SotokiFlagsSchema(SerializableSchema):
         data_key="redis-url",
     )
 
-    defrag_redis = fields.String(
+    defrag_redis = String(
         metadata={
             "label": "Defrag redis",
             "description": "Keep it as ENV:REDIS_PID",

--- a/dispatcher/backend/src/common/schemas/offliners/ted.py
+++ b/dispatcher/backend/src/common/schemas/offliners/ted.py
@@ -1,6 +1,6 @@
 from marshmallow import ValidationError, fields, validate, validates_schema
 
-from common.schemas import SerializableSchema, StringEnum
+from common.schemas import SerializableSchema, String, StringEnum
 from common.schemas.fields import (
     validate_output,
     validate_zim_description,
@@ -22,7 +22,7 @@ class TedFlagsSchema(SerializableSchema):
         data_key="indiv-zims",
     )
 
-    topics = fields.String(
+    topics = String(
         metadata={
             "label": "Topics",
             "description": (
@@ -32,7 +32,7 @@ class TedFlagsSchema(SerializableSchema):
         },
     )
 
-    playlists = fields.String(
+    playlists = String(
         metadata={
             "label": "TED Playlists",
             "description": (
@@ -42,7 +42,7 @@ class TedFlagsSchema(SerializableSchema):
         },
     )
 
-    languages = fields.String(
+    languages = String(
         metadata={
             "label": "Languages",
             "description": "Comma-seperated list of languages to filter videos",
@@ -61,7 +61,7 @@ class TedFlagsSchema(SerializableSchema):
         },
     )
 
-    subtitles = fields.String(
+    subtitles = String(
         metadata={
             "label": "Subtitles Setting",
             "description": (
@@ -103,7 +103,7 @@ class TedFlagsSchema(SerializableSchema):
         },
     )
 
-    name = fields.String(
+    name = String(
         metadata={
             "label": "Name",
             "description": (
@@ -113,7 +113,7 @@ class TedFlagsSchema(SerializableSchema):
         },
     )
 
-    name_format = fields.String(
+    name_format = String(
         metadata={
             "label": "Name Format",
             "description": (
@@ -125,14 +125,14 @@ class TedFlagsSchema(SerializableSchema):
         data_key="name-format",
     )
 
-    title = fields.String(
+    title = String(
         metadata={
             "label": "Title",
             "description": "Custom title for your ZIM. Based on selection otherwise",
         }
     )
 
-    title_format = fields.String(
+    title_format = String(
         metadata={
             "label": "Title Format",
             "description": "Custom title format for individual ZIMs",
@@ -140,7 +140,7 @@ class TedFlagsSchema(SerializableSchema):
         data_key="title-format",
     )
 
-    description = fields.String(
+    description = String(
         metadata={
             "label": "Description",
             "description": (
@@ -150,7 +150,7 @@ class TedFlagsSchema(SerializableSchema):
         validate=validate_zim_description,
     )
 
-    description_format = fields.String(
+    description_format = String(
         metadata={
             "label": "Description Format",
             "description": "Custom description format for individual ZIMs",
@@ -158,14 +158,14 @@ class TedFlagsSchema(SerializableSchema):
         data_key="description-format",
     )
 
-    creator = fields.String(
+    creator = String(
         metadata={
             "label": "Content Creator",
             "description": "Name of content creator. Defaults to TED",
         }
     )
 
-    tags = fields.String(
+    tags = String(
         metadata={
             "label": "ZIM Tags",
             "description": (
@@ -196,7 +196,7 @@ class TedFlagsSchema(SerializableSchema):
         data_key="use-any-optimized-version",
     )
 
-    output = fields.String(
+    output = String(
         metadata={
             "label": "Output folder",
             "placeholder": "/output",
@@ -207,7 +207,7 @@ class TedFlagsSchema(SerializableSchema):
         validate=validate_output,
     )
 
-    tmp_dir = fields.String(
+    tmp_dir = String(
         metadata={
             "label": "Temp folder",
             "description": (
@@ -220,7 +220,7 @@ class TedFlagsSchema(SerializableSchema):
         data_key="tmp-dir",
     )
 
-    metadata_from = fields.String(
+    metadata_from = String(
         metadata={
             "label": "Metadata JSON",
             "description": (
@@ -231,7 +231,7 @@ class TedFlagsSchema(SerializableSchema):
         data_key="metadata-from",
     )
 
-    zim_file = fields.String(
+    zim_file = String(
         metadata={
             "label": "ZIM filename",
             "description": "ZIM file name (based on ZIM name if not provided)",
@@ -240,7 +240,7 @@ class TedFlagsSchema(SerializableSchema):
         validate=validate_zim_filename,
     )
 
-    zim_file_format = fields.String(
+    zim_file_format = String(
         metadata={
             "label": "ZIM filename format",
             "description": (
@@ -265,7 +265,7 @@ class TedFlagsSchema(SerializableSchema):
         validate=validate.Range(min=1),
     )
 
-    locale = fields.String(
+    locale = String(
         metadata={
             "label": "Locale",
             "description": "The locale to use for the translations in ZIM",

--- a/dispatcher/backend/src/common/schemas/offliners/ted.py
+++ b/dispatcher/backend/src/common/schemas/offliners/ted.py
@@ -1,7 +1,11 @@
 from marshmallow import ValidationError, fields, validate, validates_schema
 
 from common.schemas import SerializableSchema, StringEnum
-from common.schemas.fields import validate_output, validate_zim_filename
+from common.schemas.fields import (
+    validate_output,
+    validate_zim_description,
+    validate_zim_filename,
+)
 
 
 class TedFlagsSchema(SerializableSchema):
@@ -142,7 +146,8 @@ class TedFlagsSchema(SerializableSchema):
             "description": (
                 "Custom description for your ZIM. Based on selection otherwise"
             ),
-        }
+        },
+        validate=validate_zim_description,
     )
 
     description_format = fields.String(

--- a/dispatcher/backend/src/common/schemas/offliners/wikihow.py
+++ b/dispatcher/backend/src/common/schemas/offliners/wikihow.py
@@ -1,7 +1,11 @@
 from marshmallow import fields, validate
 
 from common.schemas import SerializableSchema
-from common.schemas.fields import validate_output, validate_zim_filename
+from common.schemas.fields import (
+    validate_output,
+    validate_zim_description,
+    validate_zim_filename,
+)
 
 
 class WikihowFlagsSchema(SerializableSchema):
@@ -38,6 +42,7 @@ class WikihowFlagsSchema(SerializableSchema):
             "description": "Custom description for your ZIM. "
             "Wikihow homepage description (meta) otherwise",
         },
+        validate=validate_zim_description,
     )
 
     icon = fields.Url(

--- a/dispatcher/backend/src/common/schemas/offliners/wikihow.py
+++ b/dispatcher/backend/src/common/schemas/offliners/wikihow.py
@@ -1,6 +1,6 @@
 from marshmallow import fields, validate
 
-from common.schemas import SerializableSchema
+from common.schemas import SerializableSchema, String
 from common.schemas.fields import (
     validate_output,
     validate_zim_description,
@@ -12,7 +12,7 @@ class WikihowFlagsSchema(SerializableSchema):
     class Meta:
         ordered = True
 
-    language = fields.String(
+    language = String(
         metadata={
             "label": "Language",
             "description": "wikiHow website to build from. 2-letters language code.",
@@ -20,7 +20,7 @@ class WikihowFlagsSchema(SerializableSchema):
         required=True,
     )
 
-    name = fields.String(
+    name = String(
         metadata={
             "label": "Name",
             "description": "ZIM name. Used as identifier and filename "
@@ -28,7 +28,7 @@ class WikihowFlagsSchema(SerializableSchema):
         },
     )
 
-    title = fields.String(
+    title = String(
         metadata={
             "label": "Title",
             "description": "Custom title for your ZIM. "
@@ -36,7 +36,7 @@ class WikihowFlagsSchema(SerializableSchema):
         },
     )
 
-    description = fields.String(
+    description = String(
         metadata={
             "label": "Description",
             "description": "Custom description for your ZIM. "
@@ -53,21 +53,21 @@ class WikihowFlagsSchema(SerializableSchema):
         }
     )
 
-    creator = fields.String(
+    creator = String(
         metadata={
             "label": "Creator",
             "description": "Name of content creator. “wikiHow” otherwise",
         },
     )
 
-    publisher = fields.String(
+    publisher = String(
         metadata={
             "label": "Publisher",
             "description": "Custom publisher name (ZIM metadata). “openZIM” otherwise",
         },
     )
 
-    tag = fields.String(
+    tag = String(
         metadata={
             "label": "ZIM Tags",
             "description": "List of semi-colon-separated Tags for the ZIM file. "
@@ -121,7 +121,7 @@ class WikihowFlagsSchema(SerializableSchema):
         data_key="low-quality",
     )
 
-    output = fields.String(
+    output = String(
         metadata={
             "label": "Output folder",
             "placeholder": "/output",
@@ -132,7 +132,7 @@ class WikihowFlagsSchema(SerializableSchema):
         validate=validate_output,
     )
 
-    tmp_dir = fields.String(
+    tmp_dir = String(
         metadata={
             "label": "Temp folder",
             "placeholder": "/output",
@@ -145,7 +145,7 @@ class WikihowFlagsSchema(SerializableSchema):
         data_key="tmp-dir",
     )
 
-    zim_file = fields.String(
+    zim_file = String(
         metadata={
             "label": "ZIM filename",
             "description": "ZIM file name (based on --name if not provided). "
@@ -164,7 +164,7 @@ class WikihowFlagsSchema(SerializableSchema):
         data_key="optimization-cache",
     )
 
-    category = fields.String(
+    category = String(
         metadata={
             "label": "Categories",
             "description": "Only scrape those categories (comma-separated). "
@@ -174,7 +174,7 @@ class WikihowFlagsSchema(SerializableSchema):
         },
     )
 
-    stats_filename = fields.String(
+    stats_filename = String(
         metadata={
             "label": "Stats filename",
             "placeholder": "/output/task_progress.json",

--- a/dispatcher/backend/src/common/schemas/offliners/youtube.py
+++ b/dispatcher/backend/src/common/schemas/offliners/youtube.py
@@ -1,6 +1,6 @@
 from marshmallow import ValidationError, fields, validate, validates_schema
 
-from common.schemas import HexColor, SerializableSchema, StringEnum
+from common.schemas import HexColor, SerializableSchema, String, StringEnum
 from common.schemas.fields import (
     validate_output,
     validate_zim_description,
@@ -31,7 +31,7 @@ class YoutubeFlagsSchema(SerializableSchema):
         data_key="type",
         required=True,
     )
-    ident = fields.String(
+    ident = String(
         metadata={
             "label": "Youtube ID",
             "description": "Youtube ID of the collection. "
@@ -40,20 +40,20 @@ class YoutubeFlagsSchema(SerializableSchema):
         data_key="id",
         required=True,
     )
-    api_key = fields.String(
+    api_key = String(
         metadata={"label": "API Key", "description": "Youtube API Token"},
         data_key="api-key",
         required=True,
     )
 
-    name = fields.String(
+    name = String(
         metadata={
             "label": "ZIM Name",
             "description": "Used as identifier and filename (date will be appended)",
             "placeholder": "mychannel_eng_all",
         },
     )
-    playlists_name = fields.String(
+    playlists_name = String(
         metadata={
             "label": "Playlists name",
             "description": "Format for building individual --name argument. "
@@ -87,7 +87,7 @@ class YoutubeFlagsSchema(SerializableSchema):
         },
     )
 
-    dateafter = fields.String(
+    dateafter = String(
         metadata={
             "label": "Only after date",
             "description": "Custom filter to download videos uploaded on "
@@ -139,7 +139,7 @@ class YoutubeFlagsSchema(SerializableSchema):
             "(home never have autoplay).",
         },
     )
-    output = fields.String(
+    output = String(
         metadata={
             "label": "Output folder",
             "placeholder": "/output",
@@ -149,7 +149,7 @@ class YoutubeFlagsSchema(SerializableSchema):
         dump_default="/output",
         validate=validate_output,
     )
-    tmp_dir = fields.String(
+    tmp_dir = String(
         metadata={
             "label": "Temp folder",
             "placeholder": "/output",
@@ -162,7 +162,7 @@ class YoutubeFlagsSchema(SerializableSchema):
         data_key="tmp-dir",
     )
 
-    zim_file = fields.String(
+    zim_file = String(
         metadata={
             "label": "ZIM filename",
             "description": "ZIM file name (based on --name if not provided). "
@@ -171,7 +171,7 @@ class YoutubeFlagsSchema(SerializableSchema):
         data_key="zim-file",
         validate=validate_zim_filename,
     )
-    playlists_zim_file = fields.String(
+    playlists_zim_file = String(
         metadata={
             "label": "Playlists ZIM filename",
             "description": "Format for building individual --zim-file argument. "
@@ -180,13 +180,13 @@ class YoutubeFlagsSchema(SerializableSchema):
         data_key="playlists-zim-file",
     )
 
-    language = fields.String(
+    language = String(
         metadata={
             "label": "Language",
             "description": "ISO-639-3 (3 chars) language code of content",
         }
     )
-    locale = fields.String(
+    locale = String(
         metadata={
             "label": "Locale",
             "description": "Locale name to use for translations (if avail) "
@@ -194,14 +194,14 @@ class YoutubeFlagsSchema(SerializableSchema):
         }
     )
 
-    title = fields.String(
+    title = String(
         metadata={
             "label": "Title",
             "description": "Custom title for your project and ZIM. Default to "
             "Channel name (of first video if playlists)",
         }
     )
-    playlists_title = fields.String(
+    playlists_title = String(
         metadata={
             "label": "Playlists title",
             "description": "Custom title format for individual playlist ZIM",
@@ -209,11 +209,11 @@ class YoutubeFlagsSchema(SerializableSchema):
         data_key="playlists-title",
     )
 
-    description = fields.String(
+    description = String(
         metadata={"label": "Description", "description": "Description for ZIM"},
         validate=validate_zim_description,
     )
-    playlists_description = fields.String(
+    playlists_description = String(
         metadata={
             "label": "Playlists description",
             "description": "Custom description format for individual playlist ZIM",
@@ -221,14 +221,14 @@ class YoutubeFlagsSchema(SerializableSchema):
         data_key="playlists-description",
     )
 
-    creator = fields.String(
+    creator = String(
         metadata={
             "label": "Content Creator",
             "description": "Name of content creator. Defaults to Channel name "
             "or “Youtue Channels”",
         }
     )
-    tags = fields.String(
+    tags = String(
         metadata={
             "label": "ZIM Tags",
             "description": "List of Tags for the ZIM file. "
@@ -236,7 +236,7 @@ class YoutubeFlagsSchema(SerializableSchema):
         }
     )
 
-    metadata_from = fields.String(
+    metadata_from = String(
         metadata={
             "label": "Metadata JSON",
             "description": "File path or URL to a JSON file holding custom metadata "

--- a/dispatcher/backend/src/common/schemas/offliners/youtube.py
+++ b/dispatcher/backend/src/common/schemas/offliners/youtube.py
@@ -1,7 +1,11 @@
 from marshmallow import ValidationError, fields, validate, validates_schema
 
 from common.schemas import HexColor, SerializableSchema, StringEnum
-from common.schemas.fields import validate_output, validate_zim_filename
+from common.schemas.fields import (
+    validate_output,
+    validate_zim_description,
+    validate_zim_filename,
+)
 
 
 class YoutubeFlagsSchema(SerializableSchema):
@@ -206,7 +210,8 @@ class YoutubeFlagsSchema(SerializableSchema):
     )
 
     description = fields.String(
-        metadata={"label": "Description", "description": "Description for ZIM"}
+        metadata={"label": "Description", "description": "Description for ZIM"},
+        validate=validate_zim_description,
     )
     playlists_description = fields.String(
         metadata={

--- a/dispatcher/backend/src/common/schemas/offliners/zimit.py
+++ b/dispatcher/backend/src/common/schemas/offliners/zimit.py
@@ -1,6 +1,6 @@
 from marshmallow import fields, validate
 
-from common.schemas import SerializableSchema, StringEnum
+from common.schemas import SerializableSchema, String, StringEnum
 from common.schemas.fields import (
     validate_output,
     validate_zim_description,
@@ -145,7 +145,7 @@ class ZimitFlagsSchema(SerializableSchema):
         required=True,
     )
 
-    name = fields.String(
+    name = String(
         metadata={
             "label": "Name",
             "description": "Name of the ZIM. "
@@ -154,7 +154,7 @@ class ZimitFlagsSchema(SerializableSchema):
         required=True,
     )
 
-    lang = fields.String(
+    lang = String(
         metadata={
             "label": "Language",
             "description": "ISO-639-3 (3 chars) language code of content. "
@@ -162,14 +162,14 @@ class ZimitFlagsSchema(SerializableSchema):
         }
     )
 
-    title = fields.String(
+    title = String(
         metadata={
             "label": "Title",
             "description": "Custom title for ZIM. Defaults to title of main page",
         }
     )
 
-    description = fields.String(
+    description = String(
         metadata={"label": "Description", "description": "Description for ZIM"},
         validate=validate_zim_description,
     )
@@ -183,7 +183,7 @@ class ZimitFlagsSchema(SerializableSchema):
         required=False,
     )
 
-    zim_file = fields.String(
+    zim_file = String(
         metadata={
             "label": "ZIM filename",
             "description": "ZIM file name (based on --name if not provided). "
@@ -193,21 +193,21 @@ class ZimitFlagsSchema(SerializableSchema):
         validate=validate_zim_filename,
     )
 
-    tags = fields.String(
+    tags = String(
         metadata={
             "label": "ZIM Tags",
             "description": "List of Tags for the ZIM file.",
         }
     )
 
-    creator = fields.String(
+    creator = String(
         metadata={
             "label": "Content Creator",
             "description": "Name of content creator.",
         }
     )
 
-    source = fields.String(
+    source = String(
         metadata={
             "label": "Content Source",
             "description": "Source name/URL of content",
@@ -222,7 +222,7 @@ class ZimitFlagsSchema(SerializableSchema):
         required=False,
     )
 
-    wait_until = fields.String(
+    wait_until = String(
         metadata={
             "label": "WaitUntil",
             "description": "Puppeteer page.goto() condition to wait for "
@@ -279,7 +279,7 @@ class ZimitFlagsSchema(SerializableSchema):
         ),
     )
 
-    include = fields.String(
+    include = String(
         metadata={
             "label": "Include",
             "description": "Regex of page URLs that should be "
@@ -288,7 +288,7 @@ class ZimitFlagsSchema(SerializableSchema):
         required=False,
     )
 
-    exclude = fields.String(
+    exclude = String(
         metadata={
             "label": "Exclude",
             "description": "Regex of page URLs that should be excluded from the crawl",
@@ -318,7 +318,7 @@ class ZimitFlagsSchema(SerializableSchema):
         validate=validate_devicelist,
     )
 
-    user_agent = fields.String(
+    user_agent = String(
         metadata={
             "label": "User Agent",
             "description": "Override user-agent with specified",
@@ -327,7 +327,7 @@ class ZimitFlagsSchema(SerializableSchema):
         required=False,
     )
 
-    user_agent_suffix = fields.String(
+    user_agent_suffix = String(
         metadata={
             "label": "User Agent Suffix",
             "description": "Append suffix to existing browser user-agent. "
@@ -347,7 +347,7 @@ class ZimitFlagsSchema(SerializableSchema):
         required=False,
     )
 
-    behaviors = fields.String(
+    behaviors = String(
         metadata={
             "label": "Behaviors",
             "description": "Which background behaviors to enable on each page. "
@@ -425,7 +425,7 @@ class ZimitFlagsSchema(SerializableSchema):
         required=False,
     )
 
-    output = fields.String(
+    output = String(
         metadata={
             "label": "Output folder",
             "placeholder": "/output",
@@ -436,7 +436,7 @@ class ZimitFlagsSchema(SerializableSchema):
         validate=validate_output,
     )
 
-    stats_filename = fields.String(
+    stats_filename = String(
         metadata={
             "label": "Stats filename",
             "placeholder": "/output/task_progress.json",
@@ -459,7 +459,7 @@ class ZimitFlagsSchema(SerializableSchema):
         required=False,
     )
 
-    admin_email = fields.String(
+    admin_email = String(
         metadata={
             "label": "Admin Email",
             "description": "Admin Email for crawler: used in UserAgent "

--- a/dispatcher/backend/src/common/schemas/offliners/zimit.py
+++ b/dispatcher/backend/src/common/schemas/offliners/zimit.py
@@ -1,7 +1,11 @@
 from marshmallow import fields, validate
 
 from common.schemas import SerializableSchema, StringEnum
-from common.schemas.fields import validate_output, validate_zim_filename
+from common.schemas.fields import (
+    validate_output,
+    validate_zim_description,
+    validate_zim_filename,
+)
 
 # https://github.com/puppeteer/puppeteer/blob/main/src/common/DeviceDescriptors.ts
 # https://github.com/puppeteer/puppeteer/blob/
@@ -164,8 +168,10 @@ class ZimitFlagsSchema(SerializableSchema):
             "description": "Custom title for ZIM. Defaults to title of main page",
         }
     )
+
     description = fields.String(
-        metadata={"label": "Description", "description": "Description for ZIM"}
+        metadata={"label": "Description", "description": "Description for ZIM"},
+        validate=validate_zim_description,
     )
 
     favicon = fields.Url(

--- a/dispatcher/backend/src/common/schemas/parameters.py
+++ b/dispatcher/backend/src/common/schemas/parameters.py
@@ -1,5 +1,6 @@
 from marshmallow import Schema, fields
 
+from common.schemas import String
 from common.schemas.fields import (
     category_field,
     email_field,
@@ -63,7 +64,7 @@ class RequestedTaskSchema(Schema):
 
 # requested-tasks for worker
 class WorkerRequestedTaskSchema(Schema):
-    worker = fields.String(required=True, validate=validate_worker_name)
+    worker = String(required=True, validate=validate_worker_name)
     avail_cpu = fields.Integer(required=True, validate=validate_cpu)
     avail_memory = fields.Integer(required=True, validate=validate_memory)
     avail_disk = fields.Integer(required=True, validate=validate_disk)
@@ -87,7 +88,7 @@ class SchedulesSchema(Schema):
     limit = limit_field_20_200
     category = fields.List(category_field, required=False)
     tag = tag_field
-    lang = fields.List(fields.String(validate=validate_not_empty), required=False)
+    lang = fields.List(String(validate=validate_not_empty), required=False)
     name = schedule_name_field
 
 
@@ -100,11 +101,9 @@ class UpdateSchema(Schema):
     tags = tag_field
     enabled = fields.Boolean(required=False, truthy={True}, falsy={False})
     task_name = offliner_field
-    warehouse_path = fields.String(required=False, validate=validate_warehouse_path)
+    warehouse_path = String(required=False, validate=validate_warehouse_path)
     image = fields.Nested(DockerImageSchema, required=False)
-    platform = fields.String(
-        required=False, validate=validate_platform, allow_none=True
-    )
+    platform = String(required=False, validate=validate_platform, allow_none=True)
     resources = fields.Nested(ResourcesSchema, required=False)
     monitor = fields.Boolean(required=False, truthy={True}, falsy={False})
     flags = fields.Dict(required=False)
@@ -112,46 +111,46 @@ class UpdateSchema(Schema):
 
 # schedule clone
 class CloneSchema(Schema):
-    name = fields.String(required=True, validate=validate_schedule_name)
+    name = String(required=True, validate=validate_schedule_name)
 
 
 # tasks GET
 class TasksSchema(Schema):
     skip = skip_field
     limit = limit_field_20_200
-    status = fields.List(fields.String(validate=validate_status), required=False)
+    status = fields.List(String(validate=validate_status), required=False)
     schedule_name = schedule_name_field
 
 
 # tasks POST
 class TaskCreateSchema(Schema):
-    worker_name = fields.String(required=True, validate=validate_worker_name)
+    worker_name = String(required=True, validate=validate_worker_name)
 
 
 # tasks PATCH
 class TasKUpdateSchema(Schema):
-    event = fields.String(required=True, validate=validate_event)
+    event = String(required=True, validate=validate_event)
     payload = fields.Dict(required=True)
 
 
 # users keys POST
 class KeySchema(Schema):
-    name = fields.String(required=True, validate=validate_not_empty)
-    key = fields.String(required=True, validate=validate_not_empty)
+    name = String(required=True, validate=validate_not_empty)
+    key = String(required=True, validate=validate_not_empty)
 
 
 # users POST
 class UserCreateSchema(Schema):
     username = username_field
-    password = fields.String(required=True, validate=validate_not_empty)
+    password = String(required=True, validate=validate_not_empty)
     email = email_field
-    role = fields.String(required=True, validate=validate_role)
+    role = String(required=True, validate=validate_role)
 
 
 # users PATCH
 class UserUpdateSchema(Schema):
     email = email_field
-    role = fields.String(required=False, validate=validate_role)
+    role = String(required=False, validate=validate_role)
 
 
 # workers checkin

--- a/dispatcher/backend/src/routes/auth/validate.py
+++ b/dispatcher/backend/src/routes/auth/validate.py
@@ -6,11 +6,12 @@ import paramiko
 import sqlalchemy as sa
 import sqlalchemy.orm as so
 from flask import Response, request
-from marshmallow import Schema, ValidationError, fields, validate
+from marshmallow import Schema, ValidationError, validate
 
 import db.models as dbm
 import errors.http as http_errors
 from common import getnow
+from common.schemas import String
 from routes import errors
 from utils.check import raise_if_none
 
@@ -22,8 +23,8 @@ def ssh_key(session: so.Session):
 
     # validate request json
     class KeySchema(Schema):
-        username = fields.String(required=True, validate=validate.Length(min=1))
-        key = fields.String(required=True, validate=validate.Length(min=1))
+        username = String(required=True, validate=validate.Length(min=1))
+        key = String(required=True, validate=validate.Length(min=1))
 
     try:
         request_json = KeySchema().load(request.get_json())

--- a/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
+++ b/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
@@ -87,6 +87,19 @@ bad_patch_updates = [
         "image": {"name": "openzim/youtube", "tag": "latest"},
         "resources": {"cpu": -1, "memory": MIN_RAM, "disk": ONE_GiB},
     },
+    {"name": "new\u0000name"},
+    {
+        "flags": {
+            "mwUrl": "https://fr.wiki\u0000pedia.org",
+            "adminEmail": "hello@test.de",
+        }
+    },
+    {
+        "flags": {
+            "mwUrl": "https://fr.wikipedia.org",
+            "adminEmail": "he\u0000llo@test.de",
+        }
+    },
 ]
 
 


### PR DESCRIPTION
## Rationale

- Fix #828 
- Fix #810 
- Fix #819
- Enhance FCC definition

## Changes

- all `description` and `long_description` fields are now checked with the appropriate validator
- `long_description` are now a `LongString` field, so that the UI is populated properly with a text area
- FCC `language` field is now validated with a `oneof` validator, which will be reflected in the `/offliners` API as a `choices` property and in the UI as a combobox instead of a text field
- All marshmallow `fields.String` are replaced by a custom `String` which forbids the presence of Unicode null character in the value at validation ; this allows to fix issue for all API endpoints, even if some values would have been rejected by postgreSQL (unicode null string is not allowed in VARCAHR columns, but it is in JSON columns) it allows for much nicer error messages
