### PR TITLE
Add is_requested property to schedule endpoints

### DIFF
--- a/dispatcher/backend/docs/openapi_v1.yaml
+++ b/dispatcher/backend/docs/openapi_v1.yaml
@@ -1722,6 +1722,7 @@ components:
         - language
         - name
         - category
+        - is_requested
       properties:
         config:
           type: object
@@ -1736,6 +1737,8 @@ components:
           $ref: '#/components/schemas/Language'
         name:
           type: string
+        is_requested:
+          type: boolean
         most_recent_task:
           type: object
           required:
@@ -1780,6 +1783,7 @@ components:
         - language
         - name
         - tags
+        - is_requested
       properties:
         category:
           $ref: '#/components/schemas/ScheduleCategory'
@@ -1792,6 +1796,8 @@ components:
           $ref: '#/components/schemas/Language'
         name:
           $ref: '#/components/schemas/ScheduleName'
+        is_requested:
+          type: boolean
         most_recent_task:
           type: object
           required:

--- a/dispatcher/backend/src/common/schemas/orms.py
+++ b/dispatcher/backend/src/common/schemas/orms.py
@@ -139,11 +139,15 @@ class LanguageSchema(m.Schema):
 
 
 class ScheduleLightSchema(m.Schema):
+    def get_is_requested(schedule: dbm.Schedule):
+        return schedule.count_requested_task > 0
+
     name = mf.String()
     category = mf.String()
     most_recent_task = mf.Nested(MostRecentTaskSchema)
     config = mf.Nested(ConfigTaskOnlySchema)
     language = mf.Nested(LanguageSchema)
+    is_requested = mf.Function(get_is_requested)
 
 
 class ScheduleFullSchema(BaseSchema):
@@ -180,6 +184,9 @@ class ScheduleFullSchema(BaseSchema):
                 ] = ScheduleFullSchema.get_one_duration(duration)
         return duration_res
 
+    def get_is_requested(schedule: dbm.Schedule):
+        return len(schedule.requested_tasks) > 0
+
     name = auto_field()
     category = auto_field()
     config = auto_field()
@@ -190,3 +197,4 @@ class ScheduleFullSchema(BaseSchema):
     language = mf.Function(get_language)
     most_recent_task = mf.Nested(MostRecentTaskSchema)
     duration = mf.Function(get_duration)
+    is_requested = mf.Function(get_is_requested)

--- a/dispatcher/backend/src/tests/integration/routes/business_logic/test_requested_task_bl.py
+++ b/dispatcher/backend/src/tests/integration/routes/business_logic/test_requested_task_bl.py
@@ -60,3 +60,55 @@ class TestRequestedTaskBusiness:
         assert response.json["schedule_name"] == "none"
         assert "original_schedule_name" in response.json
         assert response.json["original_schedule_name"] == temp_schedule["name"]
+
+    def test_schedule_is_not_requested(self, client, headers, temp_schedule):
+        # check in GET /schedules/{schedule_name}
+        url = f"/schedules/{temp_schedule['name']}"
+        response = client.get(
+            url,
+            headers=headers,
+        )
+        assert response.status_code == 200
+        assert "is_requested" in response.json
+        assert response.json["is_requested"] is False
+
+        # check in GET /schedules
+        url = "/schedules/"
+        response = client.get(
+            url,
+            headers=headers,
+        )
+        assert response.status_code == 200
+        assert "items" in response.json
+        for item in response.json["items"]:
+            if item["name"] != temp_schedule["name"]:
+                continue
+            assert "is_requested" in item
+            assert item["is_requested"] is False
+
+    def test_schedule_is_requested(
+        self, client, headers, temp_schedule, temp_requested_task
+    ):
+        # check in GET /schedules/{schedule_name}
+        url = f"/schedules/{temp_schedule['name']}"
+        response = client.get(
+            url,
+            headers=headers,
+        )
+        assert response.status_code == 200
+        assert "is_requested" in response.json
+        assert response.json["is_requested"] is True
+
+        # check in GET /schedules
+        url = "/schedules/"
+        response = client.get(
+            url,
+            headers=headers,
+        )
+        assert response.status_code == 200
+        assert "items" in response.json
+        for item in response.json["items"]:
+            if item["name"] != temp_schedule["name"]:
+                continue
+            assert "is_requested" in item
+            assert item["is_requested"] is True

--- a/dispatcher/backend/src/tests/integration/routes/business_logic/test_requested_task_bl.py
+++ b/dispatcher/backend/src/tests/integration/routes/business_logic/test_requested_task_bl.py
@@ -8,12 +8,12 @@ class TestRequestedTaskBusiness:
     def headers(self, access_token):
         return {"Authorization": access_token, "Content-Type": "application/json"}
 
-    @pytest.fixture(scope="module")
-    def requested_task(self, client, headers, schedule):
+    @pytest.fixture
+    def temp_requested_task(self, client, headers, temp_schedule):
         response = client.post(
             "/requested-tasks/",
             headers=headers,
-            data=json.dumps({"schedule_names": [schedule["name"]]}),
+            data=json.dumps({"schedule_names": [temp_schedule["name"]]}),
         )
         assert response.status_code == 201
         assert "requested" in response.json
@@ -28,29 +28,29 @@ class TestRequestedTaskBusiness:
         assert response.status_code == 200
 
     def test_requested_task_with_schedule(
-        self, client, headers, schedule, requested_task
+        self, client, headers, temp_schedule, temp_requested_task
     ):
-        url = f"/requested-tasks/{requested_task}"
+        url = f"/requested-tasks/{temp_requested_task}"
         response = client.get(
             url,
             headers=headers,
         )
         assert response.status_code == 200
         assert "schedule_name" in response.json
-        assert response.json["schedule_name"] == schedule["name"]
+        assert response.json["schedule_name"] == temp_schedule["name"]
         assert "original_schedule_name" in response.json
-        assert response.json["original_schedule_name"] == schedule["name"]
+        assert response.json["original_schedule_name"] == temp_schedule["name"]
 
     def test_requested_task_without_schedule(
-        self, client, headers, schedule, requested_task
+        self, client, headers, temp_schedule, temp_requested_task
     ):
-        url = f"/schedules/{schedule['name']}"
+        url = f"/schedules/{temp_schedule['name']}"
         response = client.delete(
             url,
             headers=headers,
         )
         assert response.status_code == 204
-        url = f"/requested-tasks/{requested_task}"
+        url = f"/requested-tasks/{temp_requested_task}"
         response = client.get(
             url,
             headers=headers,
@@ -59,4 +59,4 @@ class TestRequestedTaskBusiness:
         assert "schedule_name" in response.json
         assert response.json["schedule_name"] == "none"
         assert "original_schedule_name" in response.json
-        assert response.json["original_schedule_name"] == schedule["name"]
+        assert response.json["original_schedule_name"] == temp_schedule["name"]

--- a/dispatcher/backend/src/tests/integration/routes/conftest.py
+++ b/dispatcher/backend/src/tests/integration/routes/conftest.py
@@ -103,22 +103,20 @@ def temp_schedule(make_schedule):
     NB: associated tasks and requested tasks are also deleted
     """
     schedule = make_schedule(name="periodic_sched_test")
+    schedule_id = schedule["_id"]
     yield schedule
     with Session.begin() as session:
-        schedule_obj = dbm.Schedule.get(session, schedule["name"])
-        schedule_obj.most_recent_task = None
-        session.flush()
+        schedule_obj = dbm.Schedule.get(session, schedule["name"], run_checks=False)
+        if schedule_obj:
+            schedule_obj.most_recent_task = None
+            session.flush()
         session.execute(
             sa.delete(dbm.RequestedTask).where(
-                dbm.RequestedTask.schedule_id == schedule["_id"]
+                dbm.RequestedTask.schedule_id == schedule_id
             )
         )
-        session.execute(
-            sa.delete(dbm.Task).where(dbm.Task.schedule_id == schedule["_id"])
-        )
-        session.execute(
-            sa.delete(dbm.Schedule).where(dbm.Schedule.id == schedule["_id"])
-        )
+        session.execute(sa.delete(dbm.Task).where(dbm.Task.schedule_id == schedule_id))
+        session.execute(sa.delete(dbm.Schedule).where(dbm.Schedule.id == schedule_id))
 
 
 @pytest.fixture(scope="module")

--- a/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
+++ b/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
@@ -118,6 +118,7 @@ class TestScheduleList:
             assert isinstance(item["language"]["code"], str)
             assert isinstance(item["language"]["name_en"], str)
             assert isinstance(item["language"]["name_native"], str)
+            assert isinstance(item["is_requested"], bool)
 
     @pytest.mark.parametrize(
         "skip, limit, expected",
@@ -238,6 +239,9 @@ class TestSchedulePost:
         assert "most_recent_task" in response_json
         response_json.pop("duration", None)
         response_json.pop("most_recent_task", None)
+        assert "is_requested" in response_json
+        assert response_json["is_requested"] is False
+        response_json.pop("is_requested")
 
         assert response_json == document
 
@@ -367,6 +371,9 @@ class TestScheduleGet:
         response_json.pop("duration", None)
         response_json.pop("most_recent_task", None)
         schedule.pop("_id")
+        assert "is_requested" in response_json
+        assert response_json["is_requested"] is False
+        response_json.pop("is_requested")
 
         assert response_json == schedule
 

--- a/dispatcher/frontend-ui/src/components/SchedulesList.vue
+++ b/dispatcher/frontend-ui/src/components/SchedulesList.vue
@@ -82,7 +82,7 @@
           <td>{{ schedule.category }}</td>
           <td>{{ schedule.language.name_en }}</td>
           <td>{{ schedule.config.task_name }}</td>
-          <td><font-awesome-icon v-if="has_requested_task(schedule.name)" icon="check"/></td>
+          <td><font-awesome-icon v-if="schedule.is_requested" icon="check"/></td>
           <td v-if="schedule.most_recent_task">
             <code :class="statusClass(schedule.most_recent_task.status)">{{ schedule.most_recent_task.status }}</code>
           </td>
@@ -115,7 +115,6 @@
         error: null,  // API originated error message
         meta: {}, // API query metadata (count, skip, limit)
         schedules: [],  // list of schedules returned by the API
-        requested_tasks: [],  // list of schedule_names with requested tasks
         block_url_updates: false,
       };
     },
@@ -186,7 +185,6 @@
       selectedTags() { return this.selectedTagsOptions.map((x) => x.value); },
     },
     methods: {
-      has_requested_task(schedule_name) { return this.requested_tasks.indexOf(schedule_name) != -1;},
       clearSelection() {
         this.selectedName = "";
         this.selectedCategoriesOptions = [];
@@ -277,18 +275,6 @@
                 parent.schedules = [];
                 parent.meta = response.data.meta;
                 parent.schedules = response.data.items;
-
-                parent.queryAPI('get', '/requested-tasks/', {params: {
-                    limit: parent.selectedLimit,
-                    'schedule_name': parent.selection}})
-                  .then(function (response) {
-                    parent.requested_tasks = response.data.items.map((item) => {
-                      return item["schedule_name"];
-                    });
-                  })
-                  .catch(function () {
-                    parent.requested_tasks = [];
-                  })
           })
           .catch(function (error) {
             parent.schedules = [];


### PR DESCRIPTION
## Rationale

Fix #720 

## Changes

- new `is_requested` property on `GET /schedules/` and `GET /schedules/{schedule_name}` endpoints
- for `GET /schedules/`, property is computed based on an addition to the complex SQL Query retrieving schedules and their properties
- for `GET /schedules/{schedule_name}`, property is computed based on an additional SQL Query (transparent) to retrieve requested_tasks of current schedule (not an issue since we have only one schedule and rarely a requested_task)
- UI does not use the `GET /requested_tasks` endpoint anymore, column is sourced directly from `is_requested` property
