### PR TITLE
Fix worker IP update to use one single DB session

### DIFF
--- a/dispatcher/backend/src/common/constants.py
+++ b/dispatcher/backend/src/common/constants.py
@@ -3,12 +3,6 @@ import os
 
 from common.enum import SchedulePeriodicity
 
-
-def refreshable_constant(fn):
-    """Refreshable constants helper for those we have interest to live update"""
-    return fn
-
-
 OPENSSL_BIN = os.getenv("OPENSSL_BIN", "/usr/bin/openssl")
 MESSAGE_VALIDITY = 60  # number of seconds before a message expire
 
@@ -72,11 +66,7 @@ SECRET_REPLACEMENT = "********"  # nosec
 # using the following, it is possible to automate
 # the update of a whitelist of workers IPs on Wasabi (S3 provider)
 # enable this feature (default is off)
-# Nota: this is a refreshable constant so that it can be dynamically updated
-# (including in tests)
-USES_WORKERS_IPS_WHITELIST = refreshable_constant(
-    lambda: bool(os.getenv("USES_WORKERS_IPS_WHITELIST", ""))
-)
+USES_WORKERS_IPS_WHITELIST = bool(os.getenv("USES_WORKERS_IPS_WHITELIST"))
 MAX_WORKER_IP_CHANGES_PER_DAY = 4
 # wasabi URL with credentials to update policy
 WASABI_URL = os.getenv("WASABI_URL", "")

--- a/dispatcher/backend/src/common/constants.py
+++ b/dispatcher/backend/src/common/constants.py
@@ -3,6 +3,12 @@ import os
 
 from common.enum import SchedulePeriodicity
 
+
+def refreshable_constant(fn):
+    """Refreshable constants helper for those we have interest to live update"""
+    return fn
+
+
 OPENSSL_BIN = os.getenv("OPENSSL_BIN", "/usr/bin/openssl")
 MESSAGE_VALIDITY = 60  # number of seconds before a message expire
 
@@ -66,7 +72,11 @@ SECRET_REPLACEMENT = "********"  # nosec
 # using the following, it is possible to automate
 # the update of a whitelist of workers IPs on Wasabi (S3 provider)
 # enable this feature (default is off)
-USES_WORKERS_IPS_WHITELIST = bool(os.getenv("USES_WORKERS_IPS_WHITELIST", ""))
+# Nota: this is a refreshable constant so that it can be dynamically updated
+# (including in tests)
+USES_WORKERS_IPS_WHITELIST = refreshable_constant(
+    lambda: bool(os.getenv("USES_WORKERS_IPS_WHITELIST", ""))
+)
 MAX_WORKER_IP_CHANGES_PER_DAY = 4
 # wasabi URL with credentials to update policy
 WASABI_URL = os.getenv("WASABI_URL", "")

--- a/dispatcher/backend/src/common/external.py
+++ b/dispatcher/backend/src/common/external.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 def update_workers_whitelist(session: so.Session):
     """update whitelist of workers on external services"""
-    ExternalIpUpdater.update_fn(build_workers_whitelist(session=session))
+    ExternalIpUpdater.update(build_workers_whitelist(session=session))
 
 
 def build_workers_whitelist(session: so.Session) -> typing.List[str]:
@@ -150,7 +150,13 @@ def update_wasabi_whitelist(ip_addresses: typing.List):
 
 
 class ExternalIpUpdater:
-    update_fn = update_wasabi_whitelist
+    """Class responsible to push IP updates to external system(s)
+
+    `update` is called with the new list of all workers IPs everytime
+    a change is detected.
+    By default, this class update our IPs whitelist in Wasabi"""
+
+    update = update_wasabi_whitelist
 
 
 @dbsession

--- a/dispatcher/backend/src/common/external.py
+++ b/dispatcher/backend/src/common/external.py
@@ -27,12 +27,11 @@ logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 
-def update_workers_whitelist():
+def update_workers_whitelist(session: so.Session):
     """update whitelist of workers on external services"""
-    update_wasabi_whitelist(build_workers_whitelist())
+    IpUpdater.update_fn(build_workers_whitelist(session=session))
 
 
-@dbsession
 def build_workers_whitelist(session: so.Session) -> typing.List[str]:
     """list of worker IP adresses and networks (text) to use as whitelist"""
     wl_networks = []
@@ -148,6 +147,10 @@ def update_wasabi_whitelist(ip_addresses: typing.List):
         PolicyDocument=new_policy,
         SetAsDefault=True,
     )
+
+
+class IpUpdater:
+    update_fn = update_wasabi_whitelist
 
 
 @dbsession

--- a/dispatcher/backend/src/common/external.py
+++ b/dispatcher/backend/src/common/external.py
@@ -29,7 +29,7 @@ logger = logging.getLogger(__name__)
 
 def update_workers_whitelist(session: so.Session):
     """update whitelist of workers on external services"""
-    IpUpdater.update_fn(build_workers_whitelist(session=session))
+    ExternalIpUpdater.update_fn(build_workers_whitelist(session=session))
 
 
 def build_workers_whitelist(session: so.Session) -> typing.List[str]:
@@ -149,7 +149,7 @@ def update_wasabi_whitelist(ip_addresses: typing.List):
     )
 
 
-class IpUpdater:
+class ExternalIpUpdater:
     update_fn = update_wasabi_whitelist
 
 

--- a/dispatcher/backend/src/db/__init__.py
+++ b/dispatcher/backend/src/db/__init__.py
@@ -52,6 +52,20 @@ def dbsession(func):
     return inner
 
 
+def dbsession_manual(func):
+    """Decorator to create an SQLAlchemy ORM session object and wrap the function
+    inside the session. A `session` argument is automatically set. Transaction must
+    be managed by the developer (e.g. perform a commit / rollback).
+    """
+
+    def inner(*args, **kwargs):
+        with Session() as session:
+            kwargs["session"] = session
+            return func(*args, **kwargs)
+
+    return inner
+
+
 def count_from_stmt(session: OrmSession, stmt: SelectBase) -> int:
     """Count all records returned by any statement `stmt` passed as parameter"""
     return session.execute(

--- a/dispatcher/backend/src/routes/requested_tasks/requested_task.py
+++ b/dispatcher/backend/src/routes/requested_tasks/requested_task.py
@@ -9,12 +9,8 @@ from flask import Response, jsonify, make_response, request
 from marshmallow import ValidationError
 
 import db.models as dbm
-from common import WorkersIpChangesCounts, getnow
-from common.constants import (
-    ENABLED_SCHEDULER,
-    MAX_WORKER_IP_CHANGES_PER_DAY,
-    USES_WORKERS_IPS_WHITELIST,
-)
+from common import WorkersIpChangesCounts, constants, getnow
+from common.constants import ENABLED_SCHEDULER, MAX_WORKER_IP_CHANGES_PER_DAY
 from common.external import update_workers_whitelist
 from common.schemas.orms import RequestedTaskFullSchema, RequestedTaskLightSchema
 from common.schemas.parameters import (
@@ -25,7 +21,7 @@ from common.schemas.parameters import (
 )
 from common.utils import task_event_handler
 from db import count_from_stmt, dbsession, dbsession_manual
-from errors.http import InvalidRequestJSON, TaskNotFound, WorkerNotFound, HTTPBase
+from errors.http import HTTPBase, InvalidRequestJSON, TaskNotFound, WorkerNotFound
 from routes import auth_info_if_supplied, authenticate, require_perm, url_uuid
 from routes.base import BaseRoute
 from routes.errors import NotFound

--- a/dispatcher/backend/src/tests/conftest.py
+++ b/dispatcher/backend/src/tests/conftest.py
@@ -1,0 +1,12 @@
+from typing import Generator
+
+import pytest
+from sqlalchemy.orm import Session as OrmSession
+
+from db import Session
+
+
+@pytest.fixture
+def dbsession() -> Generator[OrmSession, None, None]:
+    with Session.begin() as session:
+        yield session

--- a/dispatcher/backend/src/tests/integration/routes/workers/test_worker.py
+++ b/dispatcher/backend/src/tests/integration/routes/workers/test_worker.py
@@ -296,7 +296,7 @@ class TestWorkerRequestedTasks:
         # setup custom ip updater to intercept Wasabi operations
         updater = IpUpdaterAndChecker(should_fail=external_update_fails)
         assert TestWorkerRequestedTasks.new_ip_address not in updater.ip_addresses
-        ExternalIpUpdater.update_fn = updater.ip_update
+        ExternalIpUpdater.update = updater.ip_update
         constants.USES_WORKERS_IPS_WHITELIST = external_update_enabled
 
         # call it once to set next_ip

--- a/dispatcher/backend/src/tests/integration/routes/workers/test_worker.py
+++ b/dispatcher/backend/src/tests/integration/routes/workers/test_worker.py
@@ -212,8 +212,6 @@ class TestWorkerCheckIn:
 
 
 class TestWorkerRequestedTasks:
-    new_ip_address = "88.88.88.88"
-
     def test_requested_task_worker_as_admin(self, client, access_token, worker):
         response = client.get(
             "/requested-tasks/worker",
@@ -239,13 +237,6 @@ class TestWorkerRequestedTasks:
             headers={"Authorization": make_access_token(worker["username"], "worker")},
         )
         assert response.status_code == 200
-
-    def custom_ip_update(self, ip_addresses: List):
-        self.ip_updated = True
-        assert TestWorkerRequestedTasks.new_ip_address in ip_addresses
-
-    def custom_failing_ip_update(self, ip_addresses: List):
-        raise Exception()
 
     @pytest.mark.parametrize(
         "prev_ip, new_ip, external_update_enabled, external_update_fails,"
@@ -295,7 +286,7 @@ class TestWorkerRequestedTasks:
 
         # setup custom ip updater to intercept Wasabi operations
         updater = IpUpdaterAndChecker(should_fail=external_update_fails)
-        assert TestWorkerRequestedTasks.new_ip_address not in updater.ip_addresses
+        assert new_ip not in updater.ip_addresses
         ExternalIpUpdater.update = updater.ip_update
         constants.USES_WORKERS_IPS_WHITELIST = external_update_enabled
 


### PR DESCRIPTION
## Rationale

Fix #857

## Changes (original ones, see below for updated list)

- use on single DB session instead of two which obviously leads to inconsistent results
- add log information about which worker has changed IP, including previous and new IP
- refresh `USES_WORKERS_IPS_WHITELIST` dynamically so that it can be manipulated in tests
- removed previous fix on this topic, since it was not working / needed
- simplified code paths when comparing / setting IPs

## Remarks
- I'm not a huge fan of the dynamic refresh of `USES_WORKERS_IPS_WHITELIST` but this is the less intrusive change I found to keep this in `constants.py` since this file is useful to have the list of available environment variables
- I've done a quick and dirty change with the `IpUpdater` class ; this should not be done like this, we should have a cleaner code architecture + use a mocking library, but again, this is not a small change
- as mentioned in the issue, I fixed only the bug, the other part should be moved to a specific issue from my PoV

