### PR TITLE
Check schedule flags validity also when creating a schedule from scratch

### DIFF
--- a/dispatcher/backend/src/routes/schedules/schedule.py
+++ b/dispatcher/backend/src/routes/schedules/schedule.py
@@ -125,6 +125,10 @@ class SchedulesRoute(BaseRoute):
 
         try:
             document = ScheduleSchema().load(request.get_json())
+            flags_schema = ScheduleConfigSchema.get_offliner_schema(
+                document["config"]["task_name"]
+            )
+            flags_schema().load(document["config"]["flags"])
         except ValidationError as e:
             raise InvalidRequestJSON(e.messages)
 

--- a/dispatcher/backend/src/tests/integration/routes/schedules/test_freecodecamp.py
+++ b/dispatcher/backend/src/tests/integration/routes/schedules/test_freecodecamp.py
@@ -31,7 +31,6 @@ class TestFreeCodeCamp:
             url, json=schedule, headers={"Authorization": access_token}
         )
         response_data = response.get_json()
-        print(response_data)
         if "_id" in response_data:
             garbage_collector.add_schedule_id(response_data["_id"])
         assert response.status_code == 201
@@ -94,7 +93,6 @@ class TestFreeCodeCamp:
             url, json=schedule, headers={"Authorization": access_token}
         )
         response_data = response.get_json()
-        print(response_data)
         if "_id" in response_data:
             garbage_collector.add_schedule_id(response_data["_id"])
         assert response.status_code == 400

--- a/dispatcher/backend/src/tests/integration/routes/schedules/test_freecodecamp.py
+++ b/dispatcher/backend/src/tests/integration/routes/schedules/test_freecodecamp.py
@@ -1,9 +1,9 @@
 class TestFreeCodeCamp:
-    def test_create_freecodecamp_schedule(
+    def test_create_freecodecamp_schedule_ok(
         self, client, access_token, garbage_collector
     ):
         schedule = {
-            "name": "fcc_javascript_test",
+            "name": "fcc_javascript_test_ok",
             "category": "freecodecamp",
             "enabled": False,
             "tags": [],
@@ -14,7 +14,13 @@ class TestFreeCodeCamp:
                 "image": {"name": "openzim/freecodecamp", "tag": "1.0.0"},
                 "monitor": False,
                 "platform": None,
-                "flags": {},
+                "flags": {
+                    "course": ("somecourse"),
+                    "language": "eng",
+                    "name": "acourse",
+                    "title": "a title",
+                    "description": "a description",
+                },
                 "resources": {"cpu": 3, "memory": 1024, "disk": 0},
             },
             "periodicity": "quarterly",
@@ -24,9 +30,11 @@ class TestFreeCodeCamp:
         response = client.post(
             url, json=schedule, headers={"Authorization": access_token}
         )
-        assert response.status_code == 201
         response_data = response.get_json()
-        garbage_collector.add_schedule_id(response_data["_id"])
+        print(response_data)
+        if "_id" in response_data:
+            garbage_collector.add_schedule_id(response_data["_id"])
+        assert response.status_code == 201
 
         patch_data = {
             "enabled": True,
@@ -50,3 +58,49 @@ class TestFreeCodeCamp:
             url, json=patch_data, headers={"Authorization": access_token}
         )
         assert response.status_code == 204
+
+    def test_create_freecodecamp_schedule_ko(
+        self, client, access_token, garbage_collector
+    ):
+        schedule = {
+            "name": "fcc_javascript_test_ko",
+            "category": "freecodecamp",
+            "enabled": False,
+            "tags": [],
+            "language": {"code": "fr", "name_en": "French", "name_native": "Français"},
+            "config": {
+                "task_name": "freecodecamp",
+                "warehouse_path": "/freecodecamp",
+                "image": {"name": "openzim/freecodecamp", "tag": "1.0.0"},
+                "monitor": False,
+                "platform": None,
+                "flags": {
+                    "course": ("somecourse"),
+                    "language": "eng",
+                    "name": "acourse",
+                    "title": "a title",
+                    "description": (
+                        "a description which is way way way way way way way way way "
+                        "way way way way way way way way way too long"
+                    ),
+                },
+                "resources": {"cpu": 3, "memory": 1024, "disk": 0},
+            },
+            "periodicity": "quarterly",
+        }
+
+        url = "/schedules/"
+        response = client.post(
+            url, json=schedule, headers={"Authorization": access_token}
+        )
+        response_data = response.get_json()
+        print(response_data)
+        if "_id" in response_data:
+            garbage_collector.add_schedule_id(response_data["_id"])
+        assert response.status_code == 400
+        assert "error_description" in response_data
+        assert "description" in response_data["error_description"]
+        assert (
+            "Longer than maximum length 80."
+            in response_data["error_description"]["description"]
+        )

--- a/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
+++ b/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
@@ -303,6 +303,43 @@ class TestSchedulePost:
         )
         assert response.status_code == 400
 
+    def test_create_schedule_flags_ko(self, client, access_token):
+        schedule = {
+            "name": "ifixit flags ko",
+            "category": "ifixit",
+            "enabled": False,
+            "tags": [],
+            "language": {
+                "code": "en",
+                "name_en": "English",
+                "name_native": "English",
+            },
+            "config": {
+                "task_name": "ifixit",
+                "warehouse_path": "/ifixit",
+                "flags": {},
+                "image": {"name": "openzim/ifixit", "tag": "latest"},
+                "monitor": False,
+                "platform": "ifixit",
+                "resources": {"cpu": 3, "memory": 1024, "disk": 0},
+            },
+            "periodicity": "quarterly",
+        }
+
+        url = "/schedules/"
+        response = client.post(
+            url, json=schedule, headers={"Authorization": access_token}
+        )
+        response_data = response.get_json()
+        print(response_data)
+        assert response.status_code == 400
+        assert "error_description" in response_data
+        assert "language" in response_data["error_description"]
+        assert (
+            "Missing data for required field."
+            in response_data["error_description"]["language"]
+        )
+
     def test_image_names(self, client, schedule, access_token):
         url = "/schedules/{}/image-names".format(schedule["name"])
         response = client.get(

--- a/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
+++ b/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
@@ -265,7 +265,10 @@ class TestSchedulePost:
                 "flags": {},
                 "image": {"name": "openzim/phet", "tag": "latest"},
                 "monitor": False,
+                "platform": None,
+                "resources": {"cpu": 3, "memory": 1024, "disk": 0},
             },
+            "periodicity": "quarterly",
         }
 
         del schedule[key]
@@ -273,7 +276,15 @@ class TestSchedulePost:
         response = client.post(
             url, json=schedule, headers={"Authorization": access_token}
         )
+        response_data = response.get_json()
+        print(response_data)
         assert response.status_code == 400
+        assert "error_description" in response_data
+        assert key in response_data["error_description"]
+        assert (
+            "Missing data for required field."
+            in response_data["error_description"][key]
+        )
 
     @pytest.mark.parametrize("key", ["warehouse_path", "flags", "image"])
     def test_create_schedule_missing_config_keys(self, client, access_token, key):
@@ -293,7 +304,10 @@ class TestSchedulePost:
                 "flags": {},
                 "image": {"name": "openzim/phet", "tag": "latest"},
                 "monitor": False,
+                "platform": None,
+                "resources": {"cpu": 3, "memory": 1024, "disk": 0},
             },
+            "periodicity": "quarterly",
         }
 
         del schedule["config"][key]
@@ -301,7 +315,16 @@ class TestSchedulePost:
         response = client.post(
             url, json=schedule, headers={"Authorization": access_token}
         )
+        response_data = response.get_json()
+        print(response_data)
         assert response.status_code == 400
+        assert "error_description" in response_data
+        assert "config" in response_data["error_description"]
+        assert key in response_data["error_description"]["config"]
+        assert (
+            "Missing data for required field."
+            in response_data["error_description"]["config"][key]
+        )
 
     def test_create_schedule_flags_ko(self, client, access_token):
         schedule = {

--- a/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
+++ b/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
@@ -277,7 +277,6 @@ class TestSchedulePost:
             url, json=schedule, headers={"Authorization": access_token}
         )
         response_data = response.get_json()
-        print(response_data)
         assert response.status_code == 400
         assert "error_description" in response_data
         assert key in response_data["error_description"]
@@ -316,7 +315,6 @@ class TestSchedulePost:
             url, json=schedule, headers={"Authorization": access_token}
         )
         response_data = response.get_json()
-        print(response_data)
         assert response.status_code == 400
         assert "error_description" in response_data
         assert "config" in response_data["error_description"]
@@ -354,7 +352,6 @@ class TestSchedulePost:
             url, json=schedule, headers={"Authorization": access_token}
         )
         response_data = response.get_json()
-        print(response_data)
         assert response.status_code == 400
         assert "error_description" in response_data
         assert "language" in response_data["error_description"]


### PR DESCRIPTION
## Rationale

Fix #864 

## Changes

- schedule flags are also checked when creating a recipe
- freecodecamp test case has been adapted to:
  - fix "normal" test case which was indeed not ok since mandatory flags were not provided at schedule creation
  - create an abnormal test case to exercise new check / avoid future regressions (this has been done on freecodecamp for simplicity, any scraper could be used indeed)
- an abnormal test case has also been created for the more generic schedule creation tests
- generic schedule creation tests have been fixed to ensure they are failing for the expected reason 