### PR TITLE
Feat:Added field to show automatic scheduling status

### DIFF
--- a/dispatcher/backend/src/common/schemas/orms.py
+++ b/dispatcher/backend/src/common/schemas/orms.py
@@ -148,6 +148,7 @@ class ScheduleLightSchema(m.Schema):
     config = mf.Nested(ConfigTaskOnlySchema)
     language = mf.Nested(LanguageSchema)
     is_requested = mf.Function(get_is_requested)
+    enabled = mf.Boolean()
 
 
 class ScheduleFullSchema(BaseSchema):

--- a/dispatcher/backend/src/routes/schedules/schedule.py
+++ b/dispatcher/backend/src/routes/schedules/schedule.py
@@ -65,6 +65,7 @@ class SchedulesRoute(BaseRoute):
             sa.select(
                 dbm.Schedule.name,
                 dbm.Schedule.category,
+                dbm.Schedule.enabled,
                 so.Bundle(
                     "language",
                     dbm.Schedule.language_code.label("code"),

--- a/dispatcher/frontend-ui/src/components/SchedulesList.vue
+++ b/dispatcher/frontend-ui/src/components/SchedulesList.vue
@@ -76,7 +76,10 @@
         <tr v-for="schedule in schedules" :key="schedule._id">
           <td>
             <router-link :to="{name: 'schedule-detail', params: {'schedule_name': schedule.name}}">
-              {{ schedule.name }}
+              <span style="display: flex; align-items: center">
+                {{ schedule.name }}
+                <font-awesome-icon v-if="!schedule.enabled" icon="pause" style="margin-left: 5px; color: orange"/>
+              </span>
             </router-link>
           </td>
           <td>{{ schedule.category }}</td>

--- a/dispatcher/frontend-ui/src/main.js
+++ b/dispatcher/frontend-ui/src/main.js
@@ -27,7 +27,7 @@ import { faSpinner, faUser, faUserCircle, faKey, faTimes, faTimesCircle,
          faCalendarAlt, faStopCircle, faTrashAlt, faPlug,
          faSkullCrossbones, faAsterisk, faCheck, faPlusCircle,
          faExclamationTriangle, faServer, faSortAmountUp,
-         faExternalLinkAlt, faClock, faCompactDisc, faGlasses, faBug } from '@fortawesome/free-solid-svg-icons'
+         faExternalLinkAlt, faClock, faCompactDisc, faGlasses, faBug, faPause, } from '@fortawesome/free-solid-svg-icons'
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome'
 library.add(faKey);
 library.add(faBug);
@@ -61,6 +61,7 @@ library.add(faExternalLinkAlt);
 library.add(faArrowCircleLeft);
 library.add(faSkullCrossbones);
 library.add(faExclamationTriangle);
+library.add(faPause);
 Vue.component('font-awesome-icon', FontAwesomeIcon);
 
 // Multiselect for schedules filter


### PR DESCRIPTION
## Rationale
Fix #816

## Changes
- Added `enabled` field to schedulelight schema & retrieved its value from Postgres.
- Added a `pause` icon to show it in the front end.

## Screenshot:
![Screenshot 2023-11-20 122716](https://github.com/openzim/zimfarm/assets/21984731/8996adaf-a809-400c-8d47-78f5a5281776)

