### PR TITLE
Artifacts upload

### DIFF
--- a/.github/workflows/QA.yml
+++ b/.github/workflows/QA.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install black==23.3.0 flake8==6.0.0 isort==5.12.0
+          pip install black==24.2.0 flake8==7.0.0 isort==5.13.2
           black --version
           flake8 --version
           isort --version

--- a/dispatcher/backend/maint-scripts/report_youtube_api_keys.py
+++ b/dispatcher/backend/maint-scripts/report_youtube_api_keys.py
@@ -55,9 +55,11 @@ def report_youtube_api_keys(session: so.Session, *, display_unknown_secrets=Fals
         if hashed_api_key not in schedules_by_api_key.keys():
             schedules_by_api_key[hashed_api_key] = {
                 "api_key": api_key,
-                "key_name": known_api_keys[hashed_api_key]
-                if hashed_api_key in known_api_keys
-                else "unknown",
+                "key_name": (
+                    known_api_keys[hashed_api_key]
+                    if hashed_api_key in known_api_keys
+                    else "unknown"
+                ),
                 "schedules": [],
             }
         schedules_by_api_key[hashed_api_key]["schedules"].append(schedule.name)
@@ -69,9 +71,11 @@ def report_youtube_api_keys(session: so.Session, *, display_unknown_secrets=Fals
     for hashed_api_key, data in schedules_by_api_key.items():
         report_data["keys"].append(
             {
-                "name": known_api_keys[hashed_api_key]
-                if hashed_api_key in known_api_keys.keys()
-                else "unknown",
+                "name": (
+                    known_api_keys[hashed_api_key]
+                    if hashed_api_key in known_api_keys.keys()
+                    else "unknown"
+                ),
                 "schedules": sorted(data["schedules"]),
             }
         )

--- a/dispatcher/backend/src/common/constants.py
+++ b/dispatcher/backend/src/common/constants.py
@@ -33,6 +33,13 @@ try:
     LOGS_EXPIRATION = int(os.getenv("LOGS_EXPIRATION", "30"))
 except Exception:
     LOGS_EXPIRATION = 30
+ARTIFACTS_UPLOAD_URI = os.getenv(
+    "ARTIFACTS_UPLOAD_URI", "sftp://uploader@warehouse.farm.openzim.org:1522/artifacts"
+)
+try:
+    ARTIFACTS_EXPIRATION = int(os.getenv("ARTIFACTS_EXPIRATION", "30"))
+except Exception:
+    ARTIFACTS_EXPIRATION = 30
 
 # empty ZIMCHECK_OPTION means no zimcheck
 ZIMCHECK_OPTION = os.getenv("ZIMCHECK_OPTION", "")

--- a/dispatcher/backend/src/common/constants.py
+++ b/dispatcher/backend/src/common/constants.py
@@ -35,9 +35,7 @@ try:
     LOGS_EXPIRATION = int(os.getenv("LOGS_EXPIRATION", "30"))
 except Exception:
     LOGS_EXPIRATION = 30
-ARTIFACTS_UPLOAD_URI = os.getenv(
-    "ARTIFACTS_UPLOAD_URI", "sftp://uploader@warehouse.farm.openzim.org:1522/artifacts"
-)
+ARTIFACTS_UPLOAD_URI = os.getenv("ARTIFACTS_UPLOAD_URI", None)
 try:
     # artifact files expiration, 0 to disable expiration
     ARTIFACTS_EXPIRATION = int(os.getenv("ARTIFACTS_EXPIRATION", "30"))

--- a/dispatcher/backend/src/common/constants.py
+++ b/dispatcher/backend/src/common/constants.py
@@ -23,6 +23,7 @@ ZIM_UPLOAD_URI = os.getenv(
     "ZIM_UPLOAD_URI", "sftp://uploader@warehouse.farm.openzim.org:1522/zim"
 )
 try:
+    # ZIM files expiration, 0 to disable expiration
     ZIM_EXPIRATION = int(os.getenv("ZIM_EXPIRATION", "0"))
 except Exception:
     ZIM_EXPIRATION = 0
@@ -30,6 +31,7 @@ LOGS_UPLOAD_URI = os.getenv(
     "LOGS_UPLOAD_URI", "sftp://uploader@warehouse.farm.openzim.org:1522/logs"
 )
 try:
+    # log files expiration, 0 to disable expiration
     LOGS_EXPIRATION = int(os.getenv("LOGS_EXPIRATION", "30"))
 except Exception:
     LOGS_EXPIRATION = 30
@@ -37,6 +39,7 @@ ARTIFACTS_UPLOAD_URI = os.getenv(
     "ARTIFACTS_UPLOAD_URI", "sftp://uploader@warehouse.farm.openzim.org:1522/artifacts"
 )
 try:
+    # artifact files expiration, 0 to disable expiration
     ARTIFACTS_EXPIRATION = int(os.getenv("ARTIFACTS_EXPIRATION", "30"))
 except Exception:
     ARTIFACTS_EXPIRATION = 30

--- a/dispatcher/backend/src/common/emailing.py
+++ b/dispatcher/backend/src/common/emailing.py
@@ -51,12 +51,14 @@ def send_email_via_mailgun(
             url=f"{MAILGUN_API_URL}/messages",
             auth=("api", MAILGUN_API_KEY),
             data=data,
-            files=[
-                ("attachment", (fpath.name, open(fpath, "rb").read()))
-                for fpath in attachments
-            ]
-            if attachments
-            else [],
+            files=(
+                [
+                    ("attachment", (fpath.name, open(fpath, "rb").read()))
+                    for fpath in attachments
+                ]
+                if attachments
+                else []
+            ),
             timeout=REQ_TIMEOUT_NOTIFICATIONS,
         )
         resp.raise_for_status()

--- a/dispatcher/backend/src/common/schemas/models.py
+++ b/dispatcher/backend/src/common/schemas/models.py
@@ -86,9 +86,11 @@ class ScheduleConfigSchema(SerializableSchema):
             Offliner.nautilus: NautilusFlagsSchema,
             Offliner.ted: TedFlagsSchema,
             Offliner.openedx: OpenedxFlagsSchema,
-            Offliner.zimit: ZimitFlagsSchemaRelaxed
-            if constants.ZIMIT_USE_RELAXED_SCHEMA
-            else ZimitFlagsSchema,
+            Offliner.zimit: (
+                ZimitFlagsSchemaRelaxed
+                if constants.ZIMIT_USE_RELAXED_SCHEMA
+                else ZimitFlagsSchema
+            ),
             Offliner.kolibri: KolibriFlagsSchema,
             Offliner.wikihow: WikihowFlagsSchema,
             Offliner.ifixit: IFixitFlagsSchema,

--- a/dispatcher/backend/src/common/schemas/models.py
+++ b/dispatcher/backend/src/common/schemas/models.py
@@ -73,6 +73,7 @@ class ScheduleConfigSchema(SerializableSchema):
     resources = fields.Nested(ResourcesSchema(), required=True)
     flags = fields.Dict(required=True)
     platform = String(required=True, allow_none=True, validate=validate_platform)
+    artifacts_globs = fields.List(String(validate=validate_not_empty), required=False)
     monitor = fields.Boolean(required=True, truthy=[True], falsy=[False])
 
     @staticmethod

--- a/dispatcher/backend/src/common/schemas/orms.py
+++ b/dispatcher/backend/src/common/schemas/orms.py
@@ -180,9 +180,9 @@ class ScheduleFullSchema(BaseSchema):
                 duration_res["default"] = ScheduleFullSchema.get_one_duration(duration)
             if duration.worker:
                 duration_res["available"] = True
-                duration_res["workers"][
-                    duration.worker.name
-                ] = ScheduleFullSchema.get_one_duration(duration)
+                duration_res["workers"][duration.worker.name] = (
+                    ScheduleFullSchema.get_one_duration(duration)
+                )
         return duration_res
 
     def get_is_requested(schedule: dbm.Schedule):

--- a/dispatcher/backend/src/common/schemas/parameters.py
+++ b/dispatcher/backend/src/common/schemas/parameters.py
@@ -107,6 +107,9 @@ class UpdateSchema(Schema):
     resources = fields.Nested(ResourcesSchema, required=False)
     monitor = fields.Boolean(required=False, truthy={True}, falsy={False})
     flags = fields.Dict(required=False)
+    artifacts_globs = fields.List(
+        String(validate=validate_not_empty), required=False, allow_none=True
+    )
 
 
 # schedule clone

--- a/dispatcher/backend/src/migrations/versions/0055fc77f5d8_add_unique_constraint_on_schedule_.py
+++ b/dispatcher/backend/src/migrations/versions/0055fc77f5d8_add_unique_constraint_on_schedule_.py
@@ -5,6 +5,7 @@ Revises: 76a074cc939b
 Create Date: 2023-05-04 12:36:14.802432
 
 """
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/dispatcher/backend/src/migrations/versions/0ad2bf164dae_alter_config_columns_types.py
+++ b/dispatcher/backend/src/migrations/versions/0ad2bf164dae_alter_config_columns_types.py
@@ -5,6 +5,7 @@ Revises: 8279abb2d6dc
 Create Date: 2023-04-26 12:21:57.205579
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/dispatcher/backend/src/migrations/versions/3c4d546fde7c_nullable_schedule_id_in_requested_tasks.py
+++ b/dispatcher/backend/src/migrations/versions/3c4d546fde7c_nullable_schedule_id_in_requested_tasks.py
@@ -5,6 +5,7 @@ Revises: 6970d8681400
 Create Date: 2023-05-18 13:35:13.362937
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/dispatcher/backend/src/migrations/versions/43f385b318d4_add_original_schedule_name.py
+++ b/dispatcher/backend/src/migrations/versions/43f385b318d4_add_original_schedule_name.py
@@ -5,6 +5,7 @@ Revises: 15354d56545a
 Create Date: 2023-09-26 07:56:45.008277
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/dispatcher/backend/src/migrations/versions/4de2adfc3d11_create_some_indexes.py
+++ b/dispatcher/backend/src/migrations/versions/4de2adfc3d11_create_some_indexes.py
@@ -5,6 +5,7 @@ Revises: d13a178652d5
 Create Date: 2023-04-06 05:13:40.448095
 
 """
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/dispatcher/backend/src/migrations/versions/62227054989d_remove_mongo_backup_columns.py
+++ b/dispatcher/backend/src/migrations/versions/62227054989d_remove_mongo_backup_columns.py
@@ -5,6 +5,7 @@ Revises: acf1446fa2aa
 Create Date: 2023-05-12 15:29:06.706797
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/dispatcher/backend/src/migrations/versions/6970d8681400_nullable_shedule_id_on_task.py
+++ b/dispatcher/backend/src/migrations/versions/6970d8681400_nullable_shedule_id_on_task.py
@@ -5,6 +5,7 @@ Revises: acf1446fa2aa
 Create Date: 2023-05-18 10:53:05.286686
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/dispatcher/backend/src/migrations/versions/76a074cc939b_drop_task_id_in_scheduleduration.py
+++ b/dispatcher/backend/src/migrations/versions/76a074cc939b_drop_task_id_in_scheduleduration.py
@@ -5,6 +5,7 @@ Revises: 0ad2bf164dae
 Create Date: 2023-05-04 11:27:30.248671
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/dispatcher/backend/src/migrations/versions/8279abb2d6dc_create_schedules_tasks_and_requested_.py
+++ b/dispatcher/backend/src/migrations/versions/8279abb2d6dc_create_schedules_tasks_and_requested_.py
@@ -5,6 +5,7 @@ Revises: 96203f95bc36
 Create Date: 2023-04-13 10:10:52.820099
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/dispatcher/backend/src/migrations/versions/96203f95bc36_add_worker_table.py
+++ b/dispatcher/backend/src/migrations/versions/96203f95bc36_add_worker_table.py
@@ -5,6 +5,7 @@ Revises: 4de2adfc3d11
 Create Date: 2023-04-06 15:56:02.435956
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/dispatcher/backend/src/migrations/versions/acf1446fa2aa_keep_deleted_users_and_workers_in_the_.py
+++ b/dispatcher/backend/src/migrations/versions/acf1446fa2aa_keep_deleted_users_and_workers_in_the_.py
@@ -5,6 +5,7 @@ Revises: e1d3894be9ea
 Create Date: 2023-04-28 11:29:30.878410
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/dispatcher/backend/src/migrations/versions/cbedcefd6059_store_mongo_id_as_well.py
+++ b/dispatcher/backend/src/migrations/versions/cbedcefd6059_store_mongo_id_as_well.py
@@ -5,6 +5,7 @@ Revises: f1a7eae2c347
 Create Date: 2023-04-03 18:01:18.286681
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/dispatcher/backend/src/migrations/versions/ceae21f592b7_remove_ssh_key_last_used.py
+++ b/dispatcher/backend/src/migrations/versions/ceae21f592b7_remove_ssh_key_last_used.py
@@ -5,6 +5,7 @@ Revises: 43f385b318d4
 Create Date: 2023-09-29 10:59:39.739351
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/dispatcher/backend/src/migrations/versions/d13a178652d5_apply_a_single_naming_convention.py
+++ b/dispatcher/backend/src/migrations/versions/d13a178652d5_apply_a_single_naming_convention.py
@@ -5,6 +5,7 @@ Revises: fe65a1b0f953
 Create Date: 2023-04-06 04:57:11.449333
 
 """
+
 from alembic import op
 
 # revision identifiers, used by Alembic.

--- a/dispatcher/backend/src/migrations/versions/dc811d96975c_added_user_sshkey_tables.py
+++ b/dispatcher/backend/src/migrations/versions/dc811d96975c_added_user_sshkey_tables.py
@@ -5,6 +5,7 @@ Revises:
 Create Date: 2023-03-31 14:03:52.822993
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/dispatcher/backend/src/migrations/versions/e1d3894be9ea_set_fields_as_non_nullable.py
+++ b/dispatcher/backend/src/migrations/versions/e1d3894be9ea_set_fields_as_non_nullable.py
@@ -5,6 +5,7 @@ Revises: 0055fc77f5d8
 Create Date: 2023-05-04 14:08:19.014269
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/dispatcher/backend/src/migrations/versions/f1a7eae2c347_user_username_is_mandatory_unique.py
+++ b/dispatcher/backend/src/migrations/versions/f1a7eae2c347_user_username_is_mandatory_unique.py
@@ -5,6 +5,7 @@ Revises: dc811d96975c
 Create Date: 2023-03-31 18:05:44.896451
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 

--- a/dispatcher/backend/src/migrations/versions/fe65a1b0f953_store_refresh_tokens.py
+++ b/dispatcher/backend/src/migrations/versions/fe65a1b0f953_store_refresh_tokens.py
@@ -5,6 +5,7 @@ Revises: cbedcefd6059
 Create Date: 2023-04-03 21:12:33.745734
 
 """
+
 import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects import postgresql

--- a/dispatcher/backend/src/routes/schedules/schedule.py
+++ b/dispatcher/backend/src/routes/schedules/schedule.py
@@ -291,12 +291,18 @@ class ScheduleRoute(BaseRoute):
 
         for key, value in update.items():
             if key in config_keys:
-                schedule.config[key] = value
+                if value is None:
+                    if key in schedule.config:
+                        del schedule.config[key]
+                else:
+                    schedule.config[key] = value
             elif key == "language":
                 schedule.language_code = value["code"]
                 schedule.language_name_en = value["name_en"]
                 schedule.language_name_native = value["name_native"]
             else:
+                # we do not handle yet the case where a key is set to null because it is
+                # not allowed (yet) in UpdateSchema, only config keys can be set to null
                 setattr(schedule, key, value)
 
         try:

--- a/dispatcher/backend/src/routes/schedules/schedule.py
+++ b/dispatcher/backend/src/routes/schedules/schedule.py
@@ -287,6 +287,7 @@ class ScheduleRoute(BaseRoute):
             "platform",
             "flags",
             "monitor",
+            "artifacts_globs",
         ]
 
         for key, value in update.items():

--- a/dispatcher/backend/src/routes/utils.py
+++ b/dispatcher/backend/src/routes/utils.py
@@ -1,6 +1,6 @@
 import logging
 from typing import Any, Dict, List
-from urllib.parse import urlparse
+from urllib.parse import parse_qs, urlparse
 
 from common.constants import SECRET_REPLACEMENT
 from common.schemas.models import ScheduleConfigSchema
@@ -101,10 +101,10 @@ def remove_s3_secrets(response: dict):
             response[key] = url._replace(
                 query="&".join(
                     [
-                        param
-                        for param in url.query.split("&")
-                        if not param.lower().startswith("keyid")
-                        and not param.lower().startswith("secretaccesskey")
+                        f"{key}={value}"
+                        for key, values in parse_qs(url.query).items()
+                        if str(key).lower() not in ["keyid", "secretaccesskey"]
+                        for value in values
                     ]
                 )
             ).geturl()

--- a/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
+++ b/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
@@ -516,7 +516,8 @@ class TestSchedulePatch:
                 "ghcr.io/" + update_patch["config"]["image"]["name"]
             )
 
-        patch_result = patch_dict(deepcopy(document), update_patch)
+        patch_result = deepcopy(document)
+        patch_dict(patch_result, update_patch)
         assert document == patch_result
 
     @pytest.mark.parametrize("update", bad_patch_updates)

--- a/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
+++ b/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
@@ -37,6 +37,7 @@ good_patch_updates = [
     {"flags": {"mwUrl": "https://fr.wikipedia.org", "adminEmail": "hello@test.de"}},
     {"warehouse_path": "/phet"},
     {"image": {"name": "openzim/mwoffliner", "tag": "1.12.2"}},
+    {"artifacts_globs": ["*.json", "**/*.json"]},
     {"resources": {"cpu": 3, "memory": MIN_RAM, "disk": ONE_GiB}},
     {
         "task_name": "gutenberg",
@@ -238,6 +239,7 @@ class TestSchedulePost:
                     "platform": None,
                     "resources": {"cpu": 3, "memory": MIN_RAM, "disk": ONE_GiB},
                     "monitor": False,
+                    "artifacts_globs": ["**/*.json"],
                 },
                 "notification": {},
             },
@@ -494,6 +496,7 @@ class TestSchedulePatch:
             "platform",
             "flags",
             "monitor",
+            "artifacts_globs",
         ]
         for key, value in update.items():
             if key in config_keys:

--- a/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
+++ b/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
@@ -541,6 +541,60 @@ class TestSchedulePatch:
         assert response.status_code == 401
         assert response.get_json() == {"error": "token invalid"}
 
+    def test_patch_schedule_does_not_set_null_config_keys(
+        self, client, access_token, schedule
+    ):
+
+        update = {"platform": None}
+        url = "/schedules/{}".format(schedule["name"])
+        response = client.patch(
+            url, json=update, headers={"Authorization": access_token}
+        )
+        assert response.status_code == 204
+
+        response = client.get(url, headers={"Authorization": access_token})
+        assert response.status_code == 200
+
+        document = response.get_json()
+
+        assert "config" in document
+        assert "platform" not in document["config"]
+
+    def test_patch_schedule_remove_null_config_keys(
+        self, client, access_token, schedule
+    ):
+
+        update = {"platform": "ifixit"}
+        url = "/schedules/{}".format(schedule["name"])
+        response = client.patch(
+            url, json=update, headers={"Authorization": access_token}
+        )
+        assert response.status_code == 204
+
+        response = client.get(url, headers={"Authorization": access_token})
+        assert response.status_code == 200
+
+        document = response.get_json()
+
+        assert "config" in document
+        assert "platform" in document["config"]
+        assert document["config"]["platform"] == "ifixit"
+
+        update = {"platform": None}
+        url = "/schedules/{}".format(schedule["name"])
+        response = client.patch(
+            url, json=update, headers={"Authorization": access_token}
+        )
+        assert response.status_code == 204
+
+        response = client.get(url, headers={"Authorization": access_token})
+        assert response.status_code == 200
+
+        document = response.get_json()
+
+        assert "config" in document
+        assert "platform" not in document["config"]
+
 
 class TestScheduleDelete:
     def test_delete_schedule(self, client, access_token, schedule):

--- a/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
+++ b/dispatcher/backend/src/tests/integration/routes/schedules/test_schedule.py
@@ -1,7 +1,9 @@
 import json
+from copy import deepcopy
 from uuid import uuid4
 
 import pytest
+from utils_for_tests import patch_dict
 
 from utils.offliners import expanded_config
 
@@ -24,76 +26,103 @@ good_patch_updates = [
     {"tags": ["full"]},
     {"tags": ["full", "small"]},
     {"tags": ["full", "small"], "category": "vikidia", "enabled": False},
-    {"task_name": "phet", "flags": {}},
+    {
+        "task_name": "mwoffliner",
+    },
+    {
+        "task_name": "phet",
+        "flags": {},
+        "image": {"name": "openzim/phet", "tag": "1.1.2"},
+    },
     {"flags": {"mwUrl": "https://fr.wikipedia.org", "adminEmail": "hello@test.de"}},
     {"warehouse_path": "/phet"},
-    {"image": {"name": "openzim/phet", "tag": "latest"}},
+    {"image": {"name": "openzim/mwoffliner", "tag": "1.12.2"}},
     {"resources": {"cpu": 3, "memory": MIN_RAM, "disk": ONE_GiB}},
     {
         "task_name": "gutenberg",
         "warehouse_path": "/gutenberg",
         "flags": {},
-        "image": {"name": "openzim/gutenberg", "tag": "latest"},
+        "image": {"name": "openzim/gutenberg", "tag": "1.1.2"},
         "resources": {"cpu": 3, "memory": MIN_RAM, "disk": ONE_GiB},
     },
     {"name": "new_name"},
 ]
 
 bad_patch_updates = [
+    # Empty patch not allowed
     {},
+    # wrong languages combinations
     {"language": {"name_en": "Bambara", "name_native": "Bamanankan"}},
     {"language": {"code": "bm", "name_en": "", "name_native": "Bamanankan"}},
     {"language": {"code": "bm", "name_en": "Bambara"}},
+    # enabled flag must be a boolean, not a string
     {"enabled": "False"},
+    # illegal category
     {"category": "ubuntu"},
+    # empty tags not allowed
     {"tags": ""},
+    # tags must be strings
     {"tags": ["full", 1]},
+    # tags must be a list
     {"tags": "full,small"},
+    # name cannot be empty
     {"name": ""},
+    # config cannot be empty
     {"config": ""},
+    # mwoffliner does not supports empty flags
     {"flags": {}},
+    # cannot change only offliner, image must be changed as well
+    {"task_name": "phet", "flags": {}},
+    # cannot change only image name, offliner must be changed as well
+    {"flags": {}, "image": {"name": "openzim/phet", "tag": "latest"}},
+    # illegal offliner name
     {
         "task_name": "hop",
-        "warehouse_path": "/phet",
         "flags": {},
-        "image": {"name": "openzim/phet", "tag": "latest"},
-        "resources": {"cpu": 3, "memory": MIN_RAM, "disk": ONE_GiB},
+        "image": {"name": "openzim/hop", "tag": "latest"},
     },
+    # wrong warehouse_path
     {
-        "task_name": "phet",
         "warehouse_path": "/ubuntu",
-        "flags": {},
-        "image": {"name": "openzim/phet", "tag": "latest"},
-        "resources": {"cpu": 3, "memory": MIN_RAM, "disk": ONE_GiB},
     },
+    # wrong mwUrl flag for phet
     {
         "task_name": "phet",
-        "warehouse_path": "/phet",
         "flags": {"mwUrl": "http://fr.wikipedia.org"},
         "image": {"name": "openzim/phet", "tag": "latest"},
-        "resources": {"cpu": 3, "memory": MIN_RAM, "disk": ONE_GiB},
     },
-    {
-        "task_name": "phet",
-        "warehouse_path": "/phet",
-        "flags": {},
-        "image": {"name": "openzim/youtuba", "tag": "latest"},
-        "resources": {"cpu": 3, "memory": MIN_RAM, "disk": ONE_GiB},
-    },
+    # image name not aligned with task name
     {
         "task_name": "gutenberg",
-        "warehouse_path": "/gutenberg",
         "flags": {},
         "image": {"name": "openzim/youtube", "tag": "latest"},
+    },
+    # bad cpu value
+    {
         "resources": {"cpu": -1, "memory": MIN_RAM, "disk": ONE_GiB},
     },
+    # bad mem value
+    {
+        "resources": {"cpu": 3, "memory": -1, "disk": ONE_GiB},
+    },
+    # bad disk value
+    {
+        "resources": {"cpu": 3, "memory": MIN_RAM, "disk": -1},
+    },
+    # one resource missing
+    {
+        "resources": {"cpu": 3, "memory": MIN_RAM},
+    },
+    # illegal characters in name
     {"name": "new\u0000name"},
+    # illegal characters in mwUrl
     {
         "flags": {
             "mwUrl": "https://fr.wiki\u0000pedia.org",
             "adminEmail": "hello@test.de",
         }
     },
+    # illegal characters in adminEmail
     {
         "flags": {
             "mwUrl": "https://fr.wikipedia.org",
@@ -455,6 +484,8 @@ class TestSchedulePatch:
         # let's reapply manually the changes that should have been done by the patch
         # so that we can confirm it has been done
         document = response.get_json()
+
+        update_patch = {}
         config_keys = [
             "task_name",
             "warehouse_path",
@@ -464,11 +495,26 @@ class TestSchedulePatch:
             "flags",
             "monitor",
         ]
-        # these keys must not be applied since they are somewhere else is the document
-        for key in config_keys:
-            update.pop(key, None)
-        document.update(update)
-        assert response.get_json() == document
+        for key, value in update.items():
+            if key in config_keys:
+                if "config" not in update_patch:
+                    update_patch["config"] = {}
+                update_patch["config"][key] = value
+            else:
+                update_patch[key] = value
+
+        # handle special situation for config image name
+        if (
+            "config" in update_patch
+            and "image" in update_patch["config"]
+            and "name" in update_patch["config"]["image"]
+        ):
+            update_patch["config"]["image"]["name"] = (
+                "ghcr.io/" + update_patch["config"]["image"]["name"]
+            )
+
+        patch_result = patch_dict(deepcopy(document), update_patch)
+        assert document == patch_result
 
     @pytest.mark.parametrize("update", bad_patch_updates)
     def test_patch_schedule_via_name_with_errors(

--- a/dispatcher/backend/src/tests/integration/routes/users/test_password.py
+++ b/dispatcher/backend/src/tests/integration/routes/users/test_password.py
@@ -76,9 +76,9 @@ class TestPassword:
             url,
             json=document,
             headers={
-                "Authorization": access_token
-                if use_admin_token
-                else make_access_token(username)
+                "Authorization": (
+                    access_token if use_admin_token else make_access_token(username)
+                )
             },
         )
         assert response.status_code == expected_status_code

--- a/dispatcher/backend/src/tests/unit/routes/test_utils.py
+++ b/dispatcher/backend/src/tests/unit/routes/test_utils.py
@@ -222,6 +222,25 @@ from routes.utils import has_dict_sub_key, remove_secrets_from_response
                 },
             },
         },
+        {
+            "config": {
+                "task_name": "kolibri",
+                "flags": {
+                    "name": "khanacademy_en_all",
+                    "optimization-cache": "this_is_super_secret",
+                },
+            },
+            "i_am_not_a_real": {
+                "response_but": {
+                    "please_clean_me": (
+                        "s3://s3.us-west-1.wasabisys.com/"
+                        "?keyId=this_is_super_secret"
+                        "&secretAccessKey=this_is_super_secret"
+                        "&bucketName=org-kiwix-zimfarm-logs"
+                    ),
+                },
+            },
+        },
     ],
 )
 def test_remove_secrets(response):

--- a/dispatcher/backend/src/tests/unit/routes/test_utils.py
+++ b/dispatcher/backend/src/tests/unit/routes/test_utils.py
@@ -211,6 +211,15 @@ from routes.utils import has_dict_sub_key, remove_secrets_from_response
                         "&bucketName=org-kiwix-zimfarm-logs"
                     ),
                 },
+                "artifacts": {
+                    "expiration": 20,
+                    "upload_uri": (
+                        "s3://s3.us-west-1.wasabisys.com/"
+                        "?keyId=this_is_super_secret"
+                        "&secretAccessKey=this_is_super_secret"
+                        "&bucketName=org-kiwix-zimfarm-artifacts"
+                    ),
+                },
             },
         },
     ],

--- a/dispatcher/backend/src/tests/unit/routes/test_utils.py
+++ b/dispatcher/backend/src/tests/unit/routes/test_utils.py
@@ -250,6 +250,68 @@ def test_remove_secrets(response):
 
 
 @pytest.mark.parametrize(
+    "response_before,response_after",
+    [
+        (
+            {
+                "please_clean_me1": (
+                    "s3://s3.us-west-1.wasabisys.com/"
+                    "?keyId=this_is_super_secret"
+                    "&secretAccessKey=this_is_super_secret"
+                    "&bucketName=org-kiwix-zimfarm-logs"
+                ),
+                "please_clean_me2": (
+                    "s3://s3.us-west-1.wasabisys.com/"
+                    "?bucketName=org-kiwix-zimfarm-logs"
+                    "&keyId=this_is_super_secret"
+                    "&secretAccessKey=this_is_super_secret"
+                ),
+                "please_clean_me3": (
+                    "s3://s3.us-west-1.wasabisys.com/"
+                    "?bucketName=org-kiwix-zimfarm-logs"
+                    "&keyId=this_is_super_secret"
+                    "&secretAccessKey=this_is_super_secret"
+                    "&something=somevalue"
+                ),
+                "please_clean_me4": (
+                    "s3://s3.us-west-1.wasabisys.com/"
+                    "?bucketName=org-kiwix-zimfarm-logs"
+                    "&secretAccessKey=this_is_super_secret"
+                    "&something=somevalue"
+                    "&keyId=this_is_super_secret"
+                    "&something2=somevalue2"
+                ),
+            },
+            {
+                "please_clean_me1": (
+                    "s3://s3.us-west-1.wasabisys.com/"
+                    "?bucketName=org-kiwix-zimfarm-logs"
+                ),
+                "please_clean_me2": (
+                    "s3://s3.us-west-1.wasabisys.com/"
+                    "?bucketName=org-kiwix-zimfarm-logs"
+                ),
+                "please_clean_me3": (
+                    "s3://s3.us-west-1.wasabisys.com/"
+                    "?bucketName=org-kiwix-zimfarm-logs"
+                    "&something=somevalue"
+                ),
+                "please_clean_me4": (
+                    "s3://s3.us-west-1.wasabisys.com/"
+                    "?bucketName=org-kiwix-zimfarm-logs"
+                    "&something=somevalue"
+                    "&something2=somevalue2"
+                ),
+            },
+        ),
+    ],
+)
+def test_remove_secrets_url_kept(response_before, response_after):
+    remove_secrets_from_response(response_before)
+    assert response_before == response_after
+
+
+@pytest.mark.parametrize(
     "data, keys, has",
     [
         (

--- a/dispatcher/backend/src/tests/utils_for_tests.py
+++ b/dispatcher/backend/src/tests/utils_for_tests.py
@@ -1,0 +1,21 @@
+def patch_dict(data, patch):
+    for key, patch_value in patch.items():
+        if key in data:
+            if patch_value is None:
+                # If the patch value is None, remove the key from the original
+                # dictionary
+                del data[key]
+            else:
+                original_value = data[key]
+                if isinstance(original_value, dict) and isinstance(patch_value, dict):
+                    # If both values are dictionaries, recursively patch the nested
+                    # dictionaries
+                    patch_dict(original_value, patch_value)
+                else:
+                    # Otherwise, update the value in the original dictionary
+                    data[key] = patch_value
+        else:
+            # If the key is not present in the original dictionary, set it with the
+            # patch value
+            data[key] = patch_value
+    return data

--- a/dispatcher/backend/src/tests/utils_for_tests.py
+++ b/dispatcher/backend/src/tests/utils_for_tests.py
@@ -1,4 +1,14 @@
 def patch_dict(data, patch):
+    """Apply a patch to a dictionnary
+
+    - data is the dictionnary to modify (in-place)
+    - patch is a dictionnary of modifications to apply (could contain nested dictionnary
+    when the value to modify is deep inside the data dictionnary)
+
+    E.g. if data is { "key1": { "subkey1": "value1", subkey2": "value2" } } and patch is
+    { "key1": { "subkey2": "newvalue2"}} then after the operation data will become
+    { "key1": { "subkey1": "value1", subkey2": "newvalue2" } }
+    """
     for key, patch_value in patch.items():
         if key in data:
             if patch_value is None:
@@ -18,4 +28,3 @@ def patch_dict(data, patch):
             # If the key is not present in the original dictionary, set it with the
             # patch value
             data[key] = patch_value
-    return data

--- a/dispatcher/backend/src/utils/offliners.py
+++ b/dispatcher/backend/src/utils/offliners.py
@@ -47,15 +47,19 @@ def command_for(offliner, flags, mount_point):
     cmd = offliner_def.cmd
     if offliner_def.std_output:
         flags[
-            offliner_def.std_output
-            if isinstance(offliner_def.std_output, str)
-            else "output"
+            (
+                offliner_def.std_output
+                if isinstance(offliner_def.std_output, str)
+                else "output"
+            )
         ] = str(mount_point)
     if offliner_def.std_stats:
         flags[
-            offliner_def.std_stats
-            if isinstance(offliner_def.std_stats, str)
-            else "stats-filename"
+            (
+                offliner_def.std_stats
+                if isinstance(offliner_def.std_stats, str)
+                else "stats-filename"
+            )
         ] = str(mount_point_for(offliner) / "task_progress.json")
 
     if offliner == Offliner.gutenberg:

--- a/dispatcher/backend/src/utils/offliners.py
+++ b/dispatcher/backend/src/utils/offliners.py
@@ -78,6 +78,7 @@ def command_for(offliner, flags, mount_point):
     if offliner == Offliner.zimit:
         if "adminEmail" not in flags:
             flags["adminEmail"] = "contact+zimfarm@kiwix.org"
+        flags["keep"] = True  # always keep temporary files, they will be deleted anyway
 
     _command_for_set_default_publisher(flags, offliner_def)
 

--- a/dispatcher/backend/src/utils/scheduling.py
+++ b/dispatcher/backend/src/utils/scheduling.py
@@ -14,6 +14,8 @@ from sqlalchemy.dialects.postgresql import insert
 import db.models as dbm
 from common import getnow
 from common.constants import (
+    ARTIFACTS_EXPIRATION,
+    ARTIFACTS_UPLOAD_URI,
     DEFAULT_SCHEDULE_DURATION,
     ENABLED_SCHEDULER,
     LOGS_EXPIRATION,
@@ -164,6 +166,10 @@ def request_a_schedule(
             "logs": {
                 "upload_uri": LOGS_UPLOAD_URI,
                 "expiration": LOGS_EXPIRATION,
+            },
+            "artifacts": {
+                "upload_uri": ARTIFACTS_UPLOAD_URI,
+                "expiration": ARTIFACTS_EXPIRATION,
             },
         },
         notification=schedule.notification if schedule.notification else {},

--- a/dispatcher/frontend-ui/src/App.vue
+++ b/dispatcher/frontend-ui/src/App.vue
@@ -141,6 +141,11 @@
           .then(function (response) {
               // parent.error = null;
               let schedule = response.data;
+
+              if (schedule.config.artifacts_globs) {
+                schedule.config.artifacts_globs_str = schedule.config.artifacts_globs.join("\n")
+              }
+
               parent.$store.dispatch('setSchedule', schedule);
 
               if (on_success) { on_success(); }

--- a/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
+++ b/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
@@ -193,6 +193,17 @@
       </b-col>
     </b-row>
 
+    <b-row>
+      <b-col>
+        <b-form-group label="Artifacts:"
+                      label-for="artifacts"
+                      description="Globs of artifacts to archive, one glob expression per line.">
+          <b-form-textarea id="artifacts"
+                         v-model="edit_schedule.config.artifacts_globs_str"></b-form-textarea>
+        </b-form-group>
+      </b-col>
+    </b-row>
+
     <hr />
 
     <b-row v-if="edit_flags_fields.length > 0"><b-col><h2><code>{{ edit_task_name}}</code> command flags</h2></b-col></b-row>
@@ -433,6 +444,15 @@
               parent.edit_schedule.config.resources.disk != parent.schedule.config.resources.disk ||
               parent.edit_schedule.config.resources.shm != parent.schedule.config.resources.shm) {
             payload.resources = parent.edit_schedule.config.resources;
+        }
+
+        // artifacts globs needs to be transformed into a real list
+        let new_artifacts_globs = null;
+        if (parent.edit_schedule.config.artifacts_globs_str && parent.edit_schedule.config.artifacts_globs_str.trim() !== "") {
+          new_artifacts_globs = parent.edit_schedule.config.artifacts_globs_str.split(/\r?\n/).map(s => s.trim()).filter(Boolean);
+        }
+        if (new_artifacts_globs != parent.schedule.config.artifacts_globs) {
+            payload.artifacts_globs = new_artifacts_globs;
         }
 
         if (this.flags_payload)

--- a/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
+++ b/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
@@ -120,7 +120,7 @@
     </b-row>
     <b-row>
       <b-col>
-        <b-form-group label="Image Name:" label-for="es_image" description="Just the image name (repo/name)">
+        <b-form-group label="Image Name:" label-for="es_image" description="Image name without tag (docker_repo/name)">
           <b-form-input v-model="edit_schedule.config.image.name"
                         id="es_image"
                         type="text"
@@ -131,7 +131,7 @@
         </b-form-group>
       </b-col>
       <b-col>
-         <b-form-group label="Image Tag" label-for="es_imagetag" description="Just the tag name. `latest` usually.">
+         <b-form-group label="Image Tag" label-for="es_imagetag" description="Input image name first to have proper values">
           <b-form-select id="es_category"
                          v-model="edit_schedule.config.image.tag"
                          required

--- a/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
+++ b/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
@@ -131,7 +131,7 @@
         </b-form-group>
       </b-col>
       <b-col>
-         <b-form-group label="Image Tag" label-for="es_imagetag" description="Input image name first to have proper values">
+         <b-form-group label="Image Tag:" label-for="es_imagetag" description="Input image name first to have proper values">
           <b-form-select id="es_category"
                          v-model="edit_schedule.config.image.tag"
                          required
@@ -140,7 +140,7 @@
         </b-form-group>
       </b-col>
       <b-col>
-         <b-form-group label="Monitoring" label-for="es_monitor" description="Attach a monitoring companion to scraper">
+         <b-form-group label="Monitoring:" label-for="es_monitor" description="Attach a monitoring companion to scraper">
           <SwitchButton v-model="edit_schedule.config.monitor">{{ edit_schedule.config.monitor|yes_no("Enabled", "Disabled") }}</SwitchButton>
         </b-form-group>
       </b-col>

--- a/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
+++ b/dispatcher/frontend-ui/src/components/ScheduleEditor.vue
@@ -131,7 +131,7 @@
         </b-form-group>
       </b-col>
       <b-col>
-         <b-form-group label="Image Tag:" label-for="es_imagetag" description="Input image name first to have proper values">
+         <b-form-group label="Image Tag:" label-for="es_imagetag" description="Set image name first to get existing values">
           <b-form-select id="es_category"
                          v-model="edit_schedule.config.image.tag"
                          required

--- a/dispatcher/frontend-ui/src/constants.js
+++ b/dispatcher/frontend-ui/src/constants.js
@@ -113,7 +113,15 @@ function image_url(config) {
 }
 
 function logs_url(task) {
-  let url = new URL(task.upload.logs.upload_uri);
+  return upload_url(task.upload.logs.upload_uri, task.container.log)
+}
+
+function artifacts_url(task) {
+  return upload_url(task.upload.artifacts.upload_uri, task.container.artifacts)
+}
+
+function upload_url(uri, filename) {
+  let url = new URL(uri);
   let scheme = url.protocol.replace(/:$/, "");
 
   if (["http", "https"].indexOf(scheme) == -1)
@@ -124,10 +132,10 @@ function logs_url(task) {
     let bucketName = url.searchParams.get("bucketName");
     if (bucketName)
       log_url += bucketName + "/";
-    return log_url + task.container.log;
+    return log_url + filename;
   }
 
-  return task.container.log;
+  return filename;
 }
 
 function build_command_without(config, secret_fields) {
@@ -520,6 +528,7 @@ export default {
   image_human: image_human,
   image_url: image_url,
   logs_url: logs_url,
+  artifacts_url: artifacts_url,
   build_docker_command: build_docker_command,
   build_command_without: build_command_without,
   trim_command: trim_command,

--- a/dispatcher/frontend-ui/src/views/ScheduleView.vue
+++ b/dispatcher/frontend-ui/src/views/ScheduleView.vue
@@ -131,6 +131,7 @@
               <span class="badge badge-warning mr-2" v-if="config.monitor || false"><font-awesome-icon icon="bug" size="sm" /> monitored</span>
             </td>
           </tr>
+          <tr v-if="schedule.config.artifacts_globs" ><th>Artifacts</th><td><code>{{ schedule.config.artifacts_globs }}</code></td></tr>
           <tr><th>Config</th><td><FlagsList :flags="config.flags" :secret_fields="secret_fields" /></td></tr>
           <tr><th>Command <button class="btn btn-light btn-sm" @click.prevent="copyCommand(command)"><font-awesome-icon icon="copy" size="sm" /> Copy</button></th><td><code class="command">{{ command }}</code></td></tr>
           <tr><th>Offliner Command <button class="btn btn-light btn-sm" @click.prevent="copyCommand(offliner_command)"><font-awesome-icon icon="copy" size="sm" /> Copy</button></th><td><code class="command">{{ offliner_command }}</code></td></tr>

--- a/dispatcher/frontend-ui/src/views/TaskView.vue
+++ b/dispatcher/frontend-ui/src/views/TaskView.vue
@@ -127,6 +127,7 @@
             </th>
             <td><pre class="stderr">{{ task_container.stderr }}</pre></td></tr>
           <tr v-if="task_container.log"><th>Scraper&nbsp;Log</th><td><a class="btn btn-secondary btn-sm" target="_blank" :href="zimfarm_logs_url">Download log</a></td></tr>
+          <tr v-if="task_container.artifacts"><th>Scraper&nbsp;Artifacts</th><td><a class="btn btn-secondary btn-sm" target="_blank" :href="zimfarm_artifacts_url">Download artifacts</a></td></tr>
           <tr v-if="task_debug.exception"><th>Exception</th><td><pre>{{ task_debug.exception }}</pre></td></tr>
           <tr v-if="task_debug.traceback"><th>Traceback</th><td><pre>{{ task_debug.traceback }}</pre></td></tr>
           <tr v-if="task_debug.log"><th>Task-worker Log</th><td><pre>{{ task_debug.log }}</pre></td></tr>
@@ -210,6 +211,7 @@
       secret_fields() { return Constants.secret_fields_for(this.offliner_def); },
       pipe_duration() { return Constants.format_duration_between(this.task.timestamp.requested, this.task.timestamp.started); },
       zimfarm_logs_url() { return Constants.logs_url(this.task); },
+      zimfarm_artifacts_url() { return Constants.artifacts_url(this.task); },
       kiwix_download_url() { return Constants.kiwix_download_url; },
       webapi_url() { return Constants.zimfarm_webapi; },
       command() { return this.task_container.command.join(" "); },

--- a/watcher/watcher.py
+++ b/watcher/watcher.py
@@ -563,9 +563,9 @@ def entrypoint():
         "Defaults to 1 inside Docker as we can't guess available CPUs",
         dest="nb_threads",
         type=int,
-        default=1
-        if is_running_inside_container()
-        else multiprocessing.cpu_count() - 1 or 1,
+        default=(
+            1 if is_running_inside_container() else multiprocessing.cpu_count() - 1 or 1
+        ),
     )
 
     parser.add_argument(

--- a/workers/app/common/docker.py
+++ b/workers/app/common/docker.py
@@ -252,13 +252,12 @@ def get_scraper_container_name(task):
     )
 
 
-def upload_container_name(task_id, filename, unique):
-    ident = "zimup" if filename.endswith(".zim") else "logup"
+def upload_container_name(task_id, filename, kind, unique):
     if unique:
         filename = f"{uuid.uuid4().hex}{pathlib.Path(filename).suffix}"
     else:
         filename = re.sub(r"[^a-zA-Z0-9_.-]", "_", filename)
-    return f"{short_id(task_id)}_{ident}_{filename}"
+    return f"{short_id(task_id)}_{kind}up_{filename}"
 
 
 def get_ip_address(docker_client, name):
@@ -562,7 +561,7 @@ def start_uploader(
     resume,
     watch=False,
 ):
-    container_name = upload_container_name(task["_id"], filename, False)
+    container_name = upload_container_name(task["_id"], filename, kind, False)
 
     # remove container should it exists (should not)
     try:

--- a/workers/app/common/worker.py
+++ b/workers/app/common/worker.py
@@ -144,10 +144,10 @@ class BaseWorker:
                     options={"verify_signature": False},
                 )
                 self.connections[webapi_uri][authenticated_on] = datetime.datetime.now()
-                self.connections[webapi_uri][
-                    authentication_expires_on
-                ] = datetime.datetime.fromtimestamp(
-                    self.connections[webapi_uri][token_payload]["exp"]
+                self.connections[webapi_uri][authentication_expires_on] = (
+                    datetime.datetime.fromtimestamp(
+                        self.connections[webapi_uri][token_payload]["exp"]
+                    )
                 )
                 return True
             except Exception as exc:

--- a/workers/app/task/worker.py
+++ b/workers/app/task/worker.py
@@ -479,21 +479,21 @@ class TaskWorker(BaseWorker):
         logger.debug("Creating a tar of requested artifacts")
         filename = f"{self.task['_id']}_{self.task['config']['task_name']}.tar"
         try:
-            files_to_tar = [
+            files_to_archive = [
                 file
                 for pattern in artifacts_globs
                 for file in self.task_workdir.glob(pattern)
             ]
-            if len(files_to_tar) == 0:
+            if len(files_to_archive) == 0:
                 logger.debug("No files found to archive")
                 return
 
             fpath = self.task_workdir / filename
             with tarfile.open(fpath, "w") as tar:
-                for file in files_to_tar:
+                for file in files_to_archive:
                     tar.add(file, arcname=file.relative_to(self.task_workdir))
                     try:
-                        file.unlink()
+                        file.unlink(missing_ok=True)
                     except Exception as exc:
                         logger.debug(
                             "Unable to delete file after archiving", exc_info=exc
@@ -501,7 +501,7 @@ class TaskWorker(BaseWorker):
         except Exception as exc:
             logger.error(f"Unable to archive artifacts to {fpath}")
             logger.exception(exc)
-            return False
+            return
 
         logger.debug("Starting artifacts uploader container…")
         self.artifacts_uploader = start_uploader(

--- a/workers/app/task/worker.py
+++ b/workers/app/task/worker.py
@@ -469,9 +469,11 @@ class TaskWorker(BaseWorker):
                     {
                         fpath.name: {
                             UP: PENDING,
-                            CHK: PENDING
-                            if self.task["upload"]["zim"]["zimcheck"]
-                            else SKIPPED,
+                            CHK: (
+                                PENDING
+                                if self.task["upload"]["zim"]["zimcheck"]
+                                else SKIPPED
+                            ),
                         }
                     }
                 )

--- a/workers/app/task/worker.py
+++ b/workers/app/task/worker.py
@@ -8,6 +8,7 @@ import pathlib
 import shutil
 import signal
 import sys
+import tarfile
 import time
 from typing import Any, Dict
 
@@ -104,6 +105,7 @@ class TaskWorker(BaseWorker):
 
         self.scraper = None  # scraper container
         self.log_uploader = None  # scraper log uploader container
+        self.artifacts_uploader = None  # scraper artifacts uploader container
         self.host_logsdir = None  # path on host where logs are stored
         self.scraper_succeeded = None  # whether scraper succeeded
 
@@ -338,6 +340,7 @@ class TaskWorker(BaseWorker):
             "dnscache",
             "scraper",
             "log_uploader",
+            "artifacts_uploader",
             "uploader",
             "checker",
         ):
@@ -458,6 +461,87 @@ class TaskWorker(BaseWorker):
             {
                 "event": "update",
                 "payload": {"log": filename},
+            }
+        )
+
+    def upload_scraper_artifacts(self):
+        if not self.scraper:
+            logger.error("No scraper to upload its artifacts…")
+            return  # scraper gone, we can't access artifacts
+
+        artifacts_globs = self.task["config"].get("artifacts_globs", None)
+        if not artifacts_globs:
+            logger.debug("No artifacts configured for upload")
+            return
+        else:
+            logger.debug(f"Archiving files matching {artifacts_globs}")
+
+        logger.debug("Creating a tar of requested artifacts")
+        filename = f"{self.task['_id']}_{self.task['config']['task_name']}.tar"
+        try:
+            files_to_tar = [
+                file
+                for pattern in artifacts_globs
+                for file in self.task_workdir.glob(pattern)
+            ]
+            if len(files_to_tar) == 0:
+                logger.debug("No files found to archive")
+                return
+
+            fpath = self.task_workdir / filename
+            with tarfile.open(fpath, "w") as tar:
+                for file in files_to_tar:
+                    tar.add(file, arcname=file.relative_to(self.task_workdir))
+                    try:
+                        file.unlink()
+                    except Exception as exc:
+                        logger.debug(
+                            "Unable to delete file after archiving", exc_info=exc
+                        )
+        except Exception as exc:
+            logger.error(f"Unable to archive artifacts to {fpath}")
+            logger.exception(exc)
+            return False
+
+        logger.debug("Starting artifacts uploader container…")
+        self.artifacts_uploader = start_uploader(
+            self.docker,
+            self.task,
+            "artifacts",
+            self.username,
+            host_workdir=self.host_task_workdir,
+            upload_dir="",
+            filename=filename,
+            move=False,
+            delete=True,
+            compress=True,
+            resume=True,
+        )
+
+    def check_scraper_artifacts_upload(self):
+        if not self.artifacts_uploader or self.container_running("artifacts_uploader"):
+            return
+
+        try:
+            self.artifacts_uploader.reload()
+            exit_code = self.artifacts_uploader.attrs["State"]["ExitCode"]
+            filename = self.artifacts_uploader.labels["filename"]
+        except docker.errors.NotFound:
+            # prevent race condition if re-entering between this and container removal
+            return
+        logger.info(f"Scraper artifacts upload complete: {exit_code}")
+        if exit_code != 0:
+            logger.error(
+                f"Artifacts Uploader:: "
+                f"{get_container_logs(self.docker, self.artifacts_uploader.name)}"
+            )
+        self.stop_container("artifacts_uploader")
+
+        logger.info(f"Sending scraper artifacts filename: {filename}")
+        self.patch_task(
+            {
+                "event": "update",
+                "payload": {"artifacts": filename},
             }
         )
 
@@ -619,6 +703,7 @@ class TaskWorker(BaseWorker):
         self.mark_scraper_completed(exit_code, stdout, stderr)
         self.scraper_succeeded = exit_code == 0
         self.upload_scraper_log()
+        self.upload_scraper_artifacts()
 
     def sleep(self):
         time.sleep(1)
@@ -670,6 +755,7 @@ class TaskWorker(BaseWorker):
             or self.container_running("uploader")
             or self.container_running("checker")
             or self.container_running("log_uploader")
+            or self.container_running("artifacts_uploader")
         ):
             now = datetime.datetime.now()
             if (now - last_check).total_seconds() < SLEEP_INTERVAL:
@@ -679,10 +765,12 @@ class TaskWorker(BaseWorker):
             last_check = now
             self.handle_files()
             self.check_scraper_log_upload()
+            self.check_scraper_artifacts_upload()
 
         # make sure we submit upload status for last zim and scraper log
         self.handle_files()
         self.check_scraper_log_upload()
+        self.check_scraper_artifacts_upload()
 
         # done with processing, cleaning-up and exiting
         self.shutdown("succeeded" if self.scraper_succeeded else "failed")

--- a/workers/app/task/worker.py
+++ b/workers/app/task/worker.py
@@ -469,6 +469,10 @@ class TaskWorker(BaseWorker):
             logger.error("No scraper to upload its artifacts…")
             return  # scraper gone, we can't access artifacts
 
+        if not self.task["upload"]["artifacts"]["upload_uri"]:
+            logger.debug("No artifacts upload URI configured")
+            return
+
         artifacts_globs = self.task["config"].get("artifacts_globs", None)
         if not artifacts_globs:
             logger.debug("No artifacts configured for upload")


### PR DESCRIPTION
## Rationale

- Fix #913 
- Fix what has been found to not be relevant around this change

Remark: 
- there are many changes, I suggest to review them commit by commit to gain a better understanding since commits are meant to provide meaning to the change made
- I did not included any upgrade of other frontend or backend dependencies, I prefer to do it in a separate PR (but I did not omit this is needed as well)

## Changes

- Always add `--keep` to zimit offliner command
  - Needed if we want to archive these artifacts (e.g. warc.gz files)
  - We do not mind since the container is deleted almost right after anyway
  - Exposing the parameter in Zimfarm adds no value for the end user and there is significant risk of mistake (very frustrating to restart a recipe with artifacts globs configured ... only to realize after multiple hours you forgot to also activate the `--keep` setting)
- Update QA tools and fix code accordingly
- Add artifacts functionality
  - Add a `artifacts_globs` configuration which is a list of strings
  - Modify API and UI to manipulate this new configuration
  - Modify task worker to check if `artifacts_globs` is configured after scraper has completed, and if so:
    - tar the files matching any of the globs in a single tar file
      - in-tar hierarchy match the original filesystem hierarchy to avoid to have to deal with conflicting file names
    - as files are added to the tar archive, delete them from the filesystem
    - start an upload container to upload the tar file
    - configuration is done through two new environment variables (needed to be set at task request, values are saved in task afterwards to be pushed to the worker): `ARTIFACTS_UPLOAD_URI` and `ARTIFACTS_EXPIRATION`
- Enhance checks at recipe creation to avoid inconsistencies between selected offliner and image name
- Enhance recipe config patching to delete keys which can be unset (`platform` and new `artifacts_globs`)
- Enhance secrets removal: always remove what looks like an S3 secret in what looks like a URL, in any key of the response, no matter where it is in the structure
- Fix tests around recipe patching:
  - in good patch tests, the assertions made were not checking the configuration content ... which is the main part modified by the patch
  - in bad patch tests fixture, many data was not needed and confusing, patch request was reduced to the strict minimum to make the test fail (i.e. changing a single dict value in test fixture make the test fail because data becomes valid)
  - add lots of comment to ensure we know what we are testing (so that it is easier to fix when an issue in encountered)
- Small cosmetic changes to recipe configuration UI:
  - Enhance descriptions of Docker image name and tag, and do not suggest "latest" as default value (this is not always a good idea, and not our usage anymore in none of our instances)
  - Add missing semicolons

## Screenshots

Recipe configuration (view)

![image](https://github.com/openzim/zimfarm/assets/7102089/6349c687-c5d4-49fa-9c1a-96bfd5f2d8cc)

Recipe configuration (edit)

![image](https://github.com/openzim/zimfarm/assets/7102089/41185dcb-c180-42cd-82da-d1de124e10eb)

New button in task debug screen to download artifacts:

![image](https://github.com/openzim/zimfarm/assets/7102089/c77023fe-0eea-4923-b86b-9266cf09bbdf)

Result tar content:

![image](https://github.com/openzim/zimfarm/assets/7102089/8b4afc39-451b-43b0-a397-6f96b23b45d3)

