### PR TITLE
Upgrade watcher dependencies

### DIFF
--- a/watcher/CONTRIBUTING.md
+++ b/watcher/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+# Contributing
+
+In order to test this component, you need:
+- a test Zimfarm instance with a username + password
+- a test S3 bucket  (compliance must NOT be activated on this bucket)
+- credentials to access this bucket (keyId and secretAccessKey suggested below)
+- Docker
+
+Rebuild the Docker image:
+
+```
+docker build -t local-zf-watcher .
+```
+
+Export the secret `S3_URL` as environment variable. Note that the S3 URL starts with `https`.
+
+
+On Bash/Zsh shells (replace `<your_s3_host_name>`, `<your_key_id>`, `<your_secret_access_key>` and `<your_bucket>` with proper values):
+
+```
+ export S3_URL="https://<your_s3_host_name>/?keyId=<your_key_id>&secretAccessKey=<your_secret_access_key>&bucketName=<your_bucket>"
+```
+
+Run a test (here my zimfarm is running in docker on a container `backend` in network `zimfarm_default`, adapt command to your local setup):
+```
+docker run -it --rm -e ZIMFARM_API_URL=http://backend:8000/v1 -e S3_URL=$S3_URL --network zimfarm_default local-zf-watcher watcher --zimfarm-username admin --zimfarm-password admin --only tezos.stackexchange.com --runonce
+```

--- a/watcher/Dockerfile
+++ b/watcher/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10-alpine
+FROM python:3.12-alpine
 
 LABEL zimfarm=true
 LABEL org.opencontainers.image.source https://github.com/openzim/zimfarm

--- a/watcher/requirements.txt
+++ b/watcher/requirements.txt
@@ -1,6 +1,6 @@
 pif==0.8.2
-requests>=2.26,<3.0
-humanfriendly>=9.2,<10.0
-PyJWT>=2.4.0,<3.0
-kiwixstorage>=0.8.2,<0.9
-xml-to-dict>=0.1.6,<0.2
+requests==2.31.0
+humanfriendly==10.0
+PyJWT==2.8.0
+kiwixstorage==0.8.3
+xml-to-dict==0.1.6

--- a/watcher/watcher.py
+++ b/watcher/watcher.py
@@ -506,7 +506,7 @@ class WatcherRunner:
 
         checked_on = datetime.datetime.now()
         self.check_and_go()
-        while self.running:
+        while self.running and not self.runonce:
             if datetime.datetime.now() > checked_on + self.duration:
                 checked_on = datetime.datetime.now()
                 self.check_and_go()
@@ -582,6 +582,13 @@ def entrypoint():
     )
     parser.add_argument(
         "--debug", help="Enable verbose output", action="store_true", default=False
+    )
+
+    parser.add_argument(
+        "--runonce",
+        help="Run only one check and stops",
+        action="store_true",
+        default=False,
     )
 
     parser.add_argument(

--- a/watcher/watcher.py
+++ b/watcher/watcher.py
@@ -26,7 +26,6 @@ import concurrent.futures as cf
 import datetime
 import json
 import logging
-import multiprocessing
 import os
 import pathlib
 import re
@@ -62,21 +61,6 @@ logger = logging.getLogger("watcher")
 # disable boto3's verbose logging
 for logger_name in set(["urllib3", "boto3", "botocore", "s3transfer"]):
     logging.getLogger(logger_name).setLevel(logging.WARNING)
-
-
-def is_running_inside_container():
-    """whether running inside a Docker container"""
-    fpath = pathlib.Path("/proc/self/cgroup")
-    if not fpath.exists():
-        return False
-    try:
-        with open(fpath, "r") as fh:
-            for line in fh.readlines():
-                if line.strip().rsplit(":", 1)[-1] != "/":
-                    return True
-    finally:
-        pass
-    return False
 
 
 def get_version_for(url):
@@ -559,13 +543,10 @@ def entrypoint():
     )
     parser.add_argument(
         "--threads",
-        help="How many threads to run to parallelize download/upload? "
-        "Defaults to 1 inside Docker as we can't guess available CPUs",
+        help="How many threads to run to parallelize download/upload? Defaults to 1",
         dest="nb_threads",
         type=int,
-        default=(
-            1 if is_running_inside_container() else multiprocessing.cpu_count() - 1 or 1
-        ),
+        default=1,
     )
 
     parser.add_argument(


### PR DESCRIPTION
## Rationale
Maintenance

## Changes
All related to the watcher:
- Upgrade to python:3.12-alpine and upgrade and pin all Python dependencies
- Add `--runonce` argument (boolean flag) to run the watch only once, typically useful for testing (manually for now, but also automatically one day)
- Add CONTRIBUTING.md
- Simplify `--threads` default value (logic to detect if we are running inside Docker is not working anymore / does not provides lots of value)

## Testing

Call below succeeds to upload file to S3 and schedule recipe on first call, and to check file is still OK on second call.
```
docker run -it --rm -e ZIMFARM_API_URL=http://backend:8000/v1 -e S3_URL=$S3_URL --network zimfarm_default local-zf-watcher watcher --zimfarm-username admin --zimfarm-password admin --only tezos.stackexchange.com --runonce
```

First call:

```
[2024-02-26 09:22:42,876::INFO] 
  __                                         _       _
 / _| __ _ _ __ _ __ ___      __      ____ _| |_ ___| |__   ___ _ __
| |_ / _` | '__| '_ ` _ \ ____\ \ /\ / / _` | __/ __| '_ \ / _ \ '__|
|  _| (_| | |  | | | | | |_____\ V  V / (_| | || (__| | | |  __/ |
|_|  \__,_|_|  |_| |_| |_|      \_/\_/ \__,_|\__\___|_| |_|\___|_|


[2024-02-26 09:22:42,876::INFO] Testing S3 credentials
[2024-02-26 09:22:43,915::INFO] Testing Zimfarm credentials with http://backend:8000/v1…
[2024-02-26 09:22:44,116::INFO] Starting watcher:
  with zimfarm username: admin
  using cache: s3.eu-central-2.wasabisys.com
  with bucket: org-kiwix-dev-benoit
  only for:
   - tezos.stackexchange.com
[2024-02-26 09:22:44,116::INFO] Checking StackExchange version…
[2024-02-26 09:22:46,668::INFO] Latest online version: 2023-12. Comparing with S3…
[2024-02-26 09:22:46,707::INFO]  [+] tezos.stackexchange.com.7z
[2024-02-26 09:22:46,707::INFO]  [tezos.stackexchange.com] Getting recipes depending on it
[2024-02-26 09:22:46,766::INFO]  [tezos.stackexchange.com] Removed requested task on Zimfarm.
[2024-02-26 09:22:46,805::INFO]  [tezos.stackexchange.com] Downloading…
[2024-02-26 09:22:50,753::INFO]  [tezos.stackexchange.com] Download completed
[2024-02-26 09:22:50,753::INFO]  [tezos.stackexchange.com] Uploading to S3…
[2024-02-26 09:22:51,099::INFO]  [tezos.stackexchange.com] Uploaded
[2024-02-26 09:22:51,100::INFO]  [tezos.stackexchange.com] Local file removed
[2024-02-26 09:22:51,100::INFO]  [tezos.stackexchange.com] Scheduling recipe on Zimfarm
[2024-02-26 09:22:51,131::INFO]  [tezos.stackexchange.com] scheduled: 32f587bb-1f43-47f1-9dd2-1c679c30499e
[2024-02-26 09:22:51,132::INFO] Done.
```

Second call:
```
[2024-02-26 09:22:54,117::INFO] 
  __                                         _       _
 / _| __ _ _ __ _ __ ___      __      ____ _| |_ ___| |__   ___ _ __
| |_ / _` | '__| '_ ` _ \ ____\ \ /\ / / _` | __/ __| '_ \ / _ \ '__|
|  _| (_| | |  | | | | | |_____\ V  V / (_| | || (__| | | |  __/ |
|_|  \__,_|_|  |_| |_| |_|      \_/\_/ \__,_|\__\___|_| |_|\___|_|


[2024-02-26 09:22:54,117::INFO] Testing S3 credentials
[2024-02-26 09:22:55,236::INFO] Testing Zimfarm credentials with http://backend:8000/v1…
[2024-02-26 09:22:55,435::INFO] Starting watcher:
  with zimfarm username: admin
  using cache: s3.eu-central-2.wasabisys.com
  with bucket: org-kiwix-dev-benoit
  only for:
   - tezos.stackexchange.com
[2024-02-26 09:22:55,435::INFO] Checking StackExchange version…
[2024-02-26 09:22:57,934::INFO] Latest online version: 2023-12. Comparing with S3…
[2024-02-26 09:22:57,972::INFO] All synced up.
[2024-02-26 09:22:57,973::INFO] Done.
```