### PR TITLE
Zimit keep flag was set but not declared in Offliner definition

### DIFF
--- a/dispatcher/backend/src/common/schemas/offliners/zimit.py
+++ b/dispatcher/backend/src/common/schemas/offliners/zimit.py
@@ -432,6 +432,17 @@ class ZimitFlagsSchema(SerializableSchema):
         required=False,
     )
 
+    keep = fields.Boolean(
+        truthy=[True],
+        falsy=[False],
+        metadata={
+            "label": "Keep",
+            "description": "Should be True. Developer option: must be True if we want "
+            "to keep the WARC files for artifacts archiving.",
+        },
+        required=False,
+    )
+
     output = String(
         metadata={
             "label": "Output folder",

--- a/dispatcher/backend/src/utils/offliners.py
+++ b/dispatcher/backend/src/utils/offliners.py
@@ -78,7 +78,9 @@ def command_for(offliner, flags, mount_point):
     if offliner == Offliner.zimit:
         if "adminEmail" not in flags:
             flags["adminEmail"] = "contact+zimfarm@kiwix.org"
-        flags["keep"] = True  # always keep temporary files, they will be deleted anyway
+        if "keep" not in flags:
+            # always keep temporary files, they will be deleted anyway
+            flags["keep"] = True
 
     _command_for_set_default_publisher(flags, offliner_def)
 


### PR DESCRIPTION
## Rationale

Since the introduction of a default `keep` flag defaulting "True" for Zimit, we can't update a recipe anymore.

![image](https://github.com/openzim/zimfarm/assets/7102089/5496b5b3-135d-4104-a632-b40ba167dfbe)

## Changes

- declare `keep` flag in Zimit
- force the default `True` value only if not already set (after all, a developer might need to disable this for some reason)
