### PR TITLE
Fix #936 adjust css for std to show config value

### DIFF
--- a/dispatcher/frontend-ui/src/views/TaskView.vue
+++ b/dispatcher/frontend-ui/src/views/TaskView.vue
@@ -306,6 +306,6 @@
   .stdout, .stderr {
     max-height: 9rem;
     overflow: scroll;
-    max-width: 120rem;
+    max-width: 40rem;
   }
 </style>

--- a/dispatcher/frontend-ui/src/views/TaskView.vue
+++ b/dispatcher/frontend-ui/src/views/TaskView.vue
@@ -306,5 +306,6 @@
   .stdout, .stderr {
     max-height: 9rem;
     overflow: scroll;
+    max-width: 120rem;
   }
 </style>


### PR DESCRIPTION
## Issue: #936 
## Rationale

The row `Scraper stdout` can sometimes be too long, pushing the value of `Config` to the far right side of the table, which makes user think they are invisible. So I add max width constrain to the stdout row.

## Changes

Add max width constrain to the stdout row
