### PR TITLE
StackExchange watcher: sync dumps whenever they are modified

### DIFF
--- a/dev/README.md
+++ b/dev/README.md
@@ -41,6 +41,10 @@ This container is the main worker container, responsible to start tasks. It is c
 
 This container is a sample task executor. It is commented by default.
 
+### watcher
+
+This container is a StackExchange dumps watcher.
+
 ## Instructions
 
 First start the Docker-Compose stack:
@@ -170,3 +174,13 @@ docker exec -it zf_receiver /contrib/create-warehouse-paths.sh
 You can start a task manager manually simply by requesting a task in the UI and starting it manually (see above).
 
 Once the task is reserved for the `test_worker`, you can modify the `task_worker` container `command` in `docker-compose.yml` with this ID, uncomment the `task_worker` section and start it.
+
+### start a StackExchange dumps watcher
+
+Uncomment the watcher configuration in docker-compose.yml
+
+Setup a proper S3 url to a test bucket (including credentials in the URL)
+
+By default, only beer.stackexchange.com domain dump is considered
+
+Task are scheduled as in prod when a new dump is downloaded

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -95,6 +95,19 @@ services:
     depends_on:
       - backend
 
+  # # uncomment this only if you want to run a StackExchange dumps watcher
+  # watcher:
+  #   build: ../watcher
+  #   container_name: zf_watcher
+  #   command: watcher --only beer.stackexchange.com --debug
+  #   environment:
+  #     - ZIMFARM_API_URL=http://backend:8000/v1
+  #     - ZIMFARM_USERNAME=admin
+  #     - ZIMFARM_PASSWORD=admin
+  #     - S3_URL=https://s3.us-west-1.wasabisys.com/?keyId=<your_key_id>&secretAccessKey=<your_secret_access_key>&bucketName=org-kiwix-dev-stackexchange
+  #   depends_on:
+  #     - backend
+
   # # uncomment this only if you want to run a worker manager
   # worker_mgr:
   #   build:


### PR DESCRIPTION
## Rationale

Fix #963 

## Changes

- do not parse anymore the "Last-Modified" header of the 7z dump, store it as-is in S3 metadata
- consider the "Last-Modified" date of every individual 7z file instead of the one of "Site.xml"
  - probably a bit slower since we need to do a `HEAD` request on every file, but who cares, this is supposed to run only once a day
- S3 metadata is renamed from `version` to `lastmodified` (all lower-case, no dash because upper-case with dash wasn't working properly)
- Logs have been adapted and we now log systematically the new "Last-Modified" on a file-by-file basis
- Add a docker-compose dev container for the watcher + instructions

## Tests

This has been tested "locally" with the docker-compose container + a newly created org-kiwix-dev-stackexchange S3 bucket in Wasabi:
- run previous code from `main` branch
  - file is uploaded since bucket was empty
- run again previous code from `main` branch
  - nothing to do
- run new code from `watcher_last_modified`
  - previous file is removed, new file is uploaded since metadata has changed
- run new code from `watcher_last_modified`
  - nothing to do
- delete file from S3 bucket and run new code from `watcher_last_modified`
  - file is uploaded since bucket was empty
- tweak last-modified value in source code and run new code from `watcher_last_modified`
  - file is uploaded since last-modified value has changed
- run real new code from `watcher_last_modified`
  - file is uploaded since last-modified value has changed
- run real new code from `watcher_last_modified`
  - nothing to do