### PR TITLE
Fix zimit lang vs zim-lang confusion

### DIFF
--- a/dispatcher/backend/src/common/schemas/offliners/zimit.py
+++ b/dispatcher/backend/src/common/schemas/offliners/zimit.py
@@ -156,9 +156,17 @@ class ZimitFlagsSchema(SerializableSchema):
 
     lang = String(
         metadata={
-            "label": "Language",
-            "description": "ISO-639-3 (3 chars) language code of content. "
-            "If unspecified, will attempt to detect from main page, or use 'eng'",
+            "label": "Browser Language",
+            "description": "If set, sets the language used by the browser, should be"
+            "ISO 639 language[-country] code, e.g. `en` or `en-GB`",
+        }
+    )
+
+    zim_lang = String(
+        metadata={
+            "label": "ZIM Language",
+            "description": "Language metadata of ZIM (warc2zim --lang param). "
+            "ISO-639-3 code. Retrieved from homepage if found, fallback to `eng`",
         }
     )
 


### PR DESCRIPTION
## Rationale

Fix #894 

## Changes

- add new `zim_lang` parameter in zimit offliner definition + fix description of `lang` parameter

NOTA: rework of DB will be done at the same time this is merged.