### PR TITLE
Do not fail with 500 error when unknown HTTP verb is sent

### DIFF
--- a/dispatcher/backend/src/routes/base.py
+++ b/dispatcher/backend/src/routes/base.py
@@ -16,8 +16,11 @@ class BaseRoute:
             "PATCH": self.patch,
             "DELETE": self.delete,
         }
-        handler = handlers[request.method]
+        handler = handlers.get(request.method, self.unknown)
         return handler(*args, **kwargs)
+
+    def unknown(self, *args, **kwargs):
+        return Response(status=HTTPStatus.METHOD_NOT_ALLOWED)
 
     def get(self, *args, **kwargs):
         return Response(status=HTTPStatus.METHOD_NOT_ALLOWED)


### PR DESCRIPTION
## Rationale

Fix #838

## Changes

- simply handle the fact that HTTP verb might be unknown in `BaseRoute` class