### PR TITLE
Rework/fixes for zimit-frontend

### DIFF
--- a/dispatcher/backend/docs/openapi_v1.yaml
+++ b/dispatcher/backend/docs/openapi_v1.yaml
@@ -261,7 +261,9 @@ paths:
       - public
       summary: dump schedules
       operationId: dumpSchedules
-      description: Dump all Schedules (without `most_recent_task`) in a single request. (Notfication is removed and Secrets in config are replaced by ****** for unauthenticated requests and authenticated requests from users without schedules.update permission)
+      description: Dump all Schedules (without `most_recent_task`) in a single request (notification details are removed and secrets are replaced by ------ for requests without sufficient permissions)
+      parameters:
+        - $ref: '#/components/parameters/HideSecretsParameter'
       responses:
         200:
           description: Complete list of Schedules
@@ -277,9 +279,10 @@ paths:
       - public
       summary: list schedules
       operationId: getSchedule
-      description: Retrieve a Schedule's details (Notfication is removed and Secrets in config are replaced by ****** for unauthenticated requests and authenticated requests from users without schedules.update permission)
+      description: Retrieve a Schedule's details (notification details are removed and secrets are replaced by ------ for requests without sufficient permissions)
       parameters:
         - $ref: '#/components/parameters/ScheduleNameParameter'
+        - $ref: '#/components/parameters/HideSecretsParameter'
       responses:
         200:
           description: Schedule details
@@ -660,9 +663,10 @@ paths:
       - public
       summary: get requested-tasks details
       operationId: getRequestedTask
-      description: Retrieve a RequestedTask details
+      description: Retrieve a RequestedTask details (notification details are removed and secrets are replaced by ------ for requests without sufficient permissions)
       parameters:
       - $ref: '#/components/parameters/TaskIdParameter'
+      - $ref: '#/components/parameters/HideSecretsParameter'
       responses:
         200:
           description: RequestedTask Created
@@ -782,9 +786,10 @@ paths:
       - public
       summary: get task detail
       operationId: getTask
-      description: Retrieve a Task's details (Secrets in config are replaced by ****** for unauthenticated requests and authenticated requests from users without tasks.create permission)
+      description: Retrieve a Task's details (notification details are removed and secrets are replaced by ------ for requests without sufficient permissions)
       parameters:
       - $ref: '#/components/parameters/TaskIdParameter'
+      - $ref: '#/components/parameters/HideSecretsParameter'
       responses:
         200:
           description: Task record
@@ -1595,6 +1600,13 @@ components:
       required: true
       schema:
         type: string
+    HideSecretsParameter:
+      in: query
+      name: hide_secrets
+      required: false
+      schema:
+        type: boolean
+      allowEmptyValue: true
     StatusParameter:
       in: query
       name: status

--- a/dispatcher/backend/src/common/schemas/orms.py
+++ b/dispatcher/backend/src/common/schemas/orms.py
@@ -120,6 +120,7 @@ class RequestedTaskFullSchema(RequestedTaskLightSchema):
     upload = mf.Dict()
     schedule_name = mf.Function(serialize=get_schedule_name)  # override base
     worker = mf.Function(serialize=get_worker_name)
+    notification = mf.Dict()
 
 
 class MostRecentTaskSchema(m.Schema):

--- a/dispatcher/backend/src/routes/requested_tasks/requested_task.py
+++ b/dispatcher/backend/src/routes/requested_tasks/requested_task.py
@@ -290,10 +290,15 @@ class RequestedTaskRoute(BaseRoute):
         requested_task = dbm.RequestedTask.get(session, requested_task_id, TaskNotFound)
         resp = RequestedTaskFullSchema().dump(requested_task)
 
+        # exclude notification to not expose private information (privacy)
+        # on anonymous requests and requests for users without schedules_update
+        if not token or not token.get_permission("schedules", "update"):
+            resp["notification"] = None
+
         request_args = request.args.to_dict()
         hide_secrets = "hide_secrets" in request_args
 
-        if hide_secrets or not token or not token.get_permission("tasks", "create"):
+        if hide_secrets or not token or not token.get_permission("schedules", "update"):
             remove_secrets_from_response(resp)
 
         return jsonify(resp)

--- a/dispatcher/backend/src/routes/requested_tasks/requested_task.py
+++ b/dispatcher/backend/src/routes/requested_tasks/requested_task.py
@@ -25,6 +25,7 @@ from errors.http import HTTPBase, InvalidRequestJSON, TaskNotFound, WorkerNotFou
 from routes import auth_info_if_supplied, authenticate, require_perm, url_uuid
 from routes.base import BaseRoute
 from routes.errors import NotFound
+from routes.utils import remove_secrets_from_response
 from utils.scheduling import find_requested_task_for, request_a_schedule
 from utils.token import AccessToken
 
@@ -277,11 +278,24 @@ class RequestedTaskRoute(BaseRoute):
     name = "requested_task"
     methods = ["GET", "PATCH", "DELETE"]
 
+    @auth_info_if_supplied
     @url_uuid("requested_task_id")
     @dbsession
-    def get(self, session: so.Session, requested_task_id: UUID):
+    def get(
+        self,
+        session: so.Session,
+        requested_task_id: UUID,
+        token: AccessToken.Payload = None,
+    ):
         requested_task = dbm.RequestedTask.get(session, requested_task_id, TaskNotFound)
         resp = RequestedTaskFullSchema().dump(requested_task)
+
+        request_args = request.args.to_dict()
+        hide_secrets = "hide_secrets" in request_args
+
+        if hide_secrets or not token or not token.get_permission("tasks", "create"):
+            remove_secrets_from_response(resp)
+
         return jsonify(resp)
 
     @authenticate

--- a/dispatcher/backend/src/routes/schedules/schedule.py
+++ b/dispatcher/backend/src/routes/schedules/schedule.py
@@ -181,7 +181,14 @@ class SchedulesBackupRoute(BaseRoute):
             if not token or not token.get_permission("schedules", "update"):
                 payload["notification"] = None
 
-            if not token or not token.get_permission("schedules", "update"):
+            request_args = request.args.to_dict()
+            hide_secrets = "hide_secrets" in request_args
+
+            if (
+                hide_secrets
+                or not token
+                or not token.get_permission("schedules", "update")
+            ):
                 remove_secrets_from_response(payload)
             return payload
 
@@ -220,7 +227,10 @@ class ScheduleRoute(BaseRoute):
         if not token or not token.get_permission("schedules", "update"):
             schedule["notification"] = None
 
-        if not token or not token.get_permission("schedules", "update"):
+        request_args = request.args.to_dict()
+        hide_secrets = "hide_secrets" in request_args
+
+        if hide_secrets or not token or not token.get_permission("schedules", "update"):
             remove_secrets_from_response(schedule)
 
         return jsonify(schedule)

--- a/dispatcher/backend/src/routes/tasks/task.py
+++ b/dispatcher/backend/src/routes/tasks/task.py
@@ -130,12 +130,15 @@ class TaskRoute(BaseRoute):
 
         task = TaskFullSchema().dump(task)
 
+        request_args = request.args.to_dict()
+        hide_secrets = "hide_secrets" in request_args
+
         # exclude notification to not expose private information (privacy)
         # on anonymous requests and requests for users without schedules_update
         if not token or not token.get_permission("schedules", "update"):
             task["notification"] = None
 
-        if not token or not token.get_permission("tasks", "create"):
+        if hide_secrets or not token or not token.get_permission("tasks", "create"):
             remove_secrets_from_response(task)
 
         return jsonify(task)

--- a/dispatcher/backend/src/tests/integration/routes/requested_tasks/test_requested_task.py
+++ b/dispatcher/backend/src/tests/integration/routes/requested_tasks/test_requested_task.py
@@ -151,9 +151,17 @@ class TestRequestedTaskGet:
         response_json = response.get_json()
         assert "error" in response_json
 
-    def test_get(self, client, requested_task):
+    @pytest.mark.parametrize("authenticated", [True, False])
+    def test_get(self, client, requested_task, access_token, authenticated):
         url = "/requested-tasks/{}".format(requested_task["_id"])
-        headers = {"Content-Type": "application/json"}
+        headers = (
+            {
+                "Authorization": access_token,
+                "Content-Type": "application/json",
+            }
+            if authenticated
+            else {"Content-Type": "application/json"}
+        )
         response = client.get(url, headers=headers)
         assert response.status_code == 200
 
@@ -165,6 +173,11 @@ class TestRequestedTaskGet:
         assert data["original_schedule_name"] == requested_task["schedule_name"]
         assert "timestamp" in data
         assert "events" in data
+        assert "notification" in data
+        if authenticated:
+            assert data["notification"] is not None
+        else:
+            assert data["notification"] is None
 
 
 class TestRequestedTaskCreate:

--- a/dispatcher/backend/src/tests/integration/routes/tasks/test_task.py
+++ b/dispatcher/backend/src/tests/integration/routes/tasks/test_task.py
@@ -138,9 +138,17 @@ class TestTaskGet:
         response_json = response.get_json()
         assert "error" in response_json
 
-    def test_get(self, client, task):
+    @pytest.mark.parametrize("authenticated", [True, False])
+    def test_get(self, client, task, access_token, authenticated):
         url = "/tasks/{}".format(task["_id"])
-        headers = {"Content-Type": "application/json"}
+        headers = (
+            {
+                "Authorization": access_token,
+                "Content-Type": "application/json",
+            }
+            if authenticated
+            else {"Content-Type": "application/json"}
+        )
         response = client.get(url, headers=headers)
         assert response.status_code == 200
 
@@ -151,6 +159,11 @@ class TestTaskGet:
         assert data["original_schedule_name"] == task["schedule_name"]
         assert "timestamp" in data
         assert "events" in data
+        assert "notification" in data
+        if authenticated:
+            assert data["notification"] is not None
+        else:
+            assert data["notification"] is None
 
 
 class TestTaskCancel:


### PR DESCRIPTION
- Fix #1013 
- Also hide secret flags on `GET /requested-tasks/{id}` endpoint (was forgotten previously, probably because it is not used in the UI)
- Add `notification` property on `GET /requested-tasks/{id}` endpoint

Remark: 
- `?hide_secrets=` tested locally, works well, complex to test in automated end-to-end