### PR TITLE
Make URL secrets removal more resilient

### DIFF
--- a/dispatcher/backend/src/routes/utils.py
+++ b/dispatcher/backend/src/routes/utils.py
@@ -103,7 +103,13 @@ def remove_url_secrets(response: dict):
             if not isinstance(response[key], str) or "://" not in response[key]:
                 continue
             for url in [word for word in response[key].split() if "://" in word]:
-                urlparts = urlsplit(url)
+                try:
+                    urlparts = urlsplit(url)
+                except Exception as exc:
+                    logger.warning(
+                        f"Ignoring bad URL in remove_url_secrets: {url}", exc_info=exc
+                    )
+                    continue
                 newquery = urlencode(
                     {
                         key: (


### PR DESCRIPTION
Fix #1012 

When we do not achieve to parse the URL, then we are probably not dealing with a URL so we can keep it as-is and avoid to crash.

We should probably check once per month if there is something sensible which has been ignored by this code thanks to logs in grafana.