### PR TITLE
Enhance youtube API key reporting

### DIFF
--- a/dispatcher/backend/maint-scripts/report_youtube_api_keys.txt
+++ b/dispatcher/backend/maint-scripts/report_youtube_api_keys.txt
@@ -5,9 +5,9 @@ Please review this report, take appropriate action if needed and close the issue
 **{{ report_data.nb_schedules }}** recipes using an API key have been found.
 
 {% for key in report_data["keys"] %}
-{% if key.name != "unknown" %}## {{ key.name }}{% else %}## Unknown Key{% endif %}
+{% if key.name != "unknown" %}## {{ key.name }} ({{ key.total_media }} total medias){% else %}## Unknown Key{% endif %}
 {% for schedule in key["schedules"] %}
-- {{ schedule }}{% endfor %}
+- {{ schedule.name }} {% if schedule.media_count != 0 %}({{ schedule.media_count }} medias){% else %}(unknown amount of media){% endif %}{% endfor %}
 {% if key["schedules"] | length == 0 %}*Key is not used*{% endif %}
 {% endfor %}
 *This report has been automatically generated at {{report_data.datetime}} UTC*


### PR DESCRIPTION
## Rationale

Display number of medias in last successful task, and sum it up per keys, so that we have a rough estimate of API key usage

Sample new report below

```
This is the monthly report of API Keys usage across recipes in farm.openzim.org

Please review this report, take appropriate action if needed and close the issue once done.

**172** recipes using an API key have been found.


## large-crashcourse-1 (4951 total medias)

- biologycourses_en_all (117 medias)
- crashcourse_en_all (3239 medias)
- genomicseducation_en_all (1134 medias)
- quickguidesformedicine_en_all (115 medias)
- s2underground_en_all (272 medias)
- scalewaywebinars_fr_all (74 medias)


## large-mathtiques-1 (0 total medias)

*Key is not used*

## large-mathtiques-2 (3629 total medias)

- la_chaine_de_maths_et_tiques (3629 medias)


## large-sorcier-1 (8043 total medias)

- cest-pas-sorcier_fr_agronomie (128 medias)
- cest-pas-sorcier_fr_all (4134 medias)
- cest-pas-sorcier_fr_arts (52 medias)
- cest-pas-sorcier_fr_astronomie (62 medias)
- cest-pas-sorcier_fr_botanique (48 medias)
- cest-pas-sorcier_fr_corps-humain (74 medias)
- cest-pas-sorcier_fr_defense (82 medias)
- cest-pas-sorcier_fr_ecologie (170 medias)
- cest-pas-sorcier_fr_economie (108 medias)
- cest-pas-sorcier_fr_energie (86 medias)
- cest-pas-sorcier_fr_faune (218 medias)
- cest-pas-sorcier_fr_geographie (198 medias)
- cest-pas-sorcier_fr_geologie (64 medias)
- cest-pas-sorcier_fr_histoire (138 medias)
- cest-pas-sorcier_fr_medecine (114 medias)
- cest-pas-sorcier_fr_physique-chimie (80 medias)
- cest-pas-sorcier_fr_sport (74 medias)
- cest-pas-sorcier_fr_technologie (188 medias)
- cest-pas-sorcier_fr_transports (190 medias)
- cest-pas-sorcier_fr_zapping-sauvage (142 medias)
- voa_learning_en_all (1693 medias)


## large-teded-1 (1303 total medias)

- ubongo_sw (1303 medias)


## large-univers-1 (7270 total medias)

- universcience-tv_fr_all (7270 medias)


## madrasa-playlists-1 (0 total medias)

*Key is not used*

## madrasa-playlists-2 (6608 total medias)

- madrasa_ar_arabic (190 medias)
- madrasa_ar_astronomy (118 medias)
- madrasa_ar_biology (1780 medias)
- madrasa_ar_chemistry (76 medias)
- madrasa_ar_electeng (334 medias)
- madrasa_ar_futureencyclopedia (76 medias)
- madrasa_ar_gasinteraction (76 medias)
- madrasa_ar_magnets (20 medias)
- madrasa_ar_math (2900 medias)
- madrasa_ar_physics (520 medias)
- madrasa_ar_poetry (84 medias)
- madrasa_ar_scientists (76 medias)
- madrasa_ar_songs (106 medias)
- madrasa_ar_stories (252 medias)


## medium-youtubes-1 (314 total medias)

- lrnselfreliance_en_all (314 medias)


## medium-youtubes-2 (665 total medias)

- canadian_prepper_bugoutconcepts (292 medias)
- canadian_prepper_bugoutroll_en (96 medias)
- canadian_prepper_preppingfood_en (169 medias)
- canadian_prepper_winterprepping (108 medias)


## small-youtubes-1 (9551 total medias)

- astrolabe_fr_all (286 medias)
- biologie-tout-compris_fr_all (380 medias)
- deus-ex-silicium_fr_all (282 medias)
- dirtybiology_fr_all (331 medias)
- dse_ladakh_lbj (644 medias)
- e-penser_fr_all (342 medias)
- francais-avec-pierre_fr_all (154 medias)
- hygiene-mentale_fr_all (134 medias)
- jamy_all (706 medias)
- keylearning_en (83 medias)
- les-fondamentaux_fr_all (52 medias)
- litterature-audio-poetry_fr (200 medias)
- mali-pour-les-nuls (22 medias)
- micmaths (407 medias)
- mondial_tissus (639 medias)
- mooc-energie-climat (36 medias)
- nota_bene (1960 medias)
- oer4schools (487 medias)
- premiers_pas_avec_python_fr (18 medias)
- project-fuel_en (82 medias)
- scienceinthebath_en (115 medias)
- skin-of-color-society_en_all (96 medias)
- slam-out-loud_hi (67 medias)
- studio.blender.org_en_open-movies (37 medias)
- telmidtice1_ar_all (377 medias)
- telmidtice_ar_all (59 medias)
- telmidtice_fr_all (48 medias)
- test-delf-dalf_fr_all (150 medias)
- thaki_tech_tricks (28 medias)
- tutorial-wikipedia_id (24 medias)
- ubongo_fr (436 medias)
- urban-prepper (241 medias)
- us-army-rotc-tactics (56 medias)
- voa_am_all (40 medias)
- voa_bm_all (76 medias)
- voa_fr_all (66 medias)
- voa_ko_all (80 medias)
- voa_ln_all (56 medias)
- voa_uzb_all (78 medias)
- voa_vi_all (74 medias)
- wikimooc (102 medias)


## small-youtubes-2 (4232 total medias)

- avanti - trigonometry (33 medias)
- avanti-3dimensional-geometry (27 medias)
- avanti-ac-circuits (45 medias)
- avanti-alcohol-phenol-ether (65 medias)
- avanti-alkyhalide (57 medias)
- avanti-amines (61 medias)
- avanti-atomic-structure (43 medias)
- avanti-binomial-theorem (57 medias)
- avanti-biomolecules (53 medias)
- avanti-capacitors (27 medias)
- avanti-carbonyl-compounds (51 medias)
- avanti-carborylic-acid (47 medias)
- avanti-chemical-bonding (93 medias)
- avanti-chemical-equilibrium (47 medias)
- avanti-chemical-kinetics (53 medias)
- avanti-complex-numbers (85 medias)
- avanti-concepts-of-chemistry (89 medias)
- avanti-conics1 (63 medias)
- avanti-conics2 (57 medias)
- avanti-continuity (51 medias)
- avanti-coordination-compounds (61 medias)
- avanti-current-electricity (67 medias)
- avanti-definite-integration (61 medias)
- avanti-df-blocks-elements (21 medias)
- avanti-differential-equations (37 medias)
- avanti-dynamics-of-motion (67 medias)
- avanti-electrochemistry (31 medias)
- avanti-electromagnetic-induction (41 medias)
- avanti-electromagnetic-waves (15 medias)
- avanti-electrostatic (109 medias)
- avanti-environmental-chemistry (17 medias)
- avanti-functions2 (73 medias)
- avanti-fundamentals-of-mathematics (59 medias)
- avanti-goc (113 medias)
- avanti-gravitation (55 medias)
- avanti-hydrocarbons (115 medias)
- avanti-hydrogen (27 medias)
- avanti-indefinite-integration (89 medias)
- avanti-inequalities (39 medias)
- avanti-inverse-trigonometry (27 medias)
- avanti-ionic-equilibrium (83 medias)
- avanti-limit (17 medias)
- avanti-magnetic-effect (45 medias)
- avanti-magnetism-matter (39 medias)
- avanti-mathematical-induction (17 medias)
- avanti-mathematical-reasoning (21 medias)
- avanti-matrices-determinants (33 medias)
- avanti-metallurgy (25 medias)
- avanti-modern-physics (41 medias)
- avanti-motion-in-2d (29 medias)
- avanti-motion-in-straight-line (39 medias)
- avanti-oscillations (51 medias)
- avanti-p-block-elements (27 medias)
- avanti-p-blocks-elements2 (25 medias)
- avanti-periodic-properties (23 medias)
- avanti-permutations (89 medias)
- avanti-probability (29 medias)
- avanti-properties-of-fluids (89 medias)
- avanti-properties-of-solids (19 medias)
- avanti-quadratic equations (57 medias)
- avanti-ray-optics (41 medias)
- avanti-redox-reactions (39 medias)
- avanti-rotation (95 medias)
- avanti-s-block-elements (31 medias)
- avanti-semiconductor-electronics (47 medias)
- avanti-sequence-series (55 medias)
- avanti-sets-functions (55 medias)
- avanti-solid-state (27 medias)
- avanti-solutions (31 medias)
- avanti-states-of-matter (59 medias)
- avanti-statistics (23 medias)
- avanti-straight-lines (69 medias)
- avanti-surface-chemistry (33 medias)
- avanti-thermal-properties (81 medias)
- avanti-thermodynamics (23 medias)
- avanti-thermodynamics-and-kinetic-theory (121 medias)
- avanti-units-and-measurements_hin (57 medias)
- avanti-vector-algebra (31 medias)
- avanti-vector-and-calculus (127 medias)
- avanti-wave-optics (25 medias)
- avanti-waves (83 medias)
- avanti-work-power-energy (53 medias)


## unknown-1 (0 total medias)

*Key is not used*

*This report has been automatically generated at 2024-11-01 10:58:30 UTC*
```