### PR TITLE
Mark task with no files created as failed

### DIFF
--- a/workers/app/task/worker.py
+++ b/workers/app/task/worker.py
@@ -782,4 +782,8 @@ class TaskWorker(BaseWorker):
         self.check_scraper_artifacts_upload()
 
         # done with processing, cleaning-up and exiting
-        self.shutdown("succeeded" if self.scraper_succeeded else "failed")
+        self.shutdown(
+            "succeeded"
+            if (self.scraper_succeeded and len(self.zim_files) > 0)
+            else "failed"
+        )


### PR DESCRIPTION
## Rationale

- would allow to have catched https://github.com/openzim/zimit-frontend/issues/90
- make more sense anyway

## Changes

- when a task has no file, mark it as failed

Nota: not tested, hard to reproduce