### PR TITLE
Log exception when recording IP changes fails

### DIFF
--- a/dispatcher/backend/src/routes/requested_tasks/requested_task.py
+++ b/dispatcher/backend/src/routes/requested_tasks/requested_task.py
@@ -248,10 +248,13 @@ class RequestedTasksForWorkers(BaseRoute):
                     if constants.USES_WORKERS_IPS_WHITELIST:
                         try:
                             record_ip_change(session=session, worker_name=worker_name)
-                        except Exception:
+                        except Exception as exc:
+                            logger.exception(
+                                "Pushing IP changes to Wasabi failed", exc_info=exc
+                            )
                             raise HTTPBase(
                                 status_code=HTTPStatus.SERVICE_UNAVAILABLE,
-                                error="Recording IP changes failed",
+                                error="Pushing IP changes to Wasabi failed",
                             )
 
         request_args = WorkerRequestedTaskSchema().load(request_args)


### PR DESCRIPTION
## Rationale

- When recording the IP change fails, we have no clue in the logs about what happened
- I also changed slightly the message so that it is clearer that the problem is not in our DB (which has been updated) but in pushing the changes to Wasabi