### PR TITLE
Add new role for external testers of the Zimfarm

### DIFF
--- a/dispatcher/backend/src/common/roles.py
+++ b/dispatcher/backend/src/common/roles.py
@@ -41,6 +41,10 @@ ROLES = {
         ),
     },
     "editor": {"schedules": SchedulePermissions.get(create=True, update=True)},
+    "editor-requester": {
+        "tasks": TaskPermissions.get(request=True, unrequest=True, cancel=True),
+        "schedules": SchedulePermissions.get(create=True, update=True),
+    },
     "worker": {
         "tasks": TaskPermissions.get(create=True, update=True, cancel=True),
         "zim": ZimPermissions.get(upload=True),

--- a/dispatcher/frontend-ui/src/constants.js
+++ b/dispatcher/frontend-ui/src/constants.js
@@ -365,7 +365,14 @@ export default {
   ALERT_DEFAULT_DURATION: 5,
   ALERT_LONG_DURATION: 10,
   ALERT_PERMANENT_DURATION: true,
-  ROLES: ["editor", "manager", "admin", "worker", "processor"],
+  ROLES: [
+    "editor",
+    "editor-requester",
+    "manager",
+    "admin",
+    "worker",
+    "processor",
+  ],
   TOKEN_COOKIE_EXPIRY: "180D", // 6 months
   COOKIE_LIFETIME_EXPIRY: "10Y", // 10 years
   TOKEN_COOKIE_NAME: "auth",


### PR DESCRIPTION
## Rationale

Add new role so that persons who are granted access to test the Zimfarm can manipulate tasks as well, and not just configure recipes.

Nota: name of new role is far from perfect ... but at least it is here, suggestions welcomed ^^