### PR TITLE
Add support for requested events so that notifications will be sent

### DIFF
--- a/dispatcher/backend/src/common/schemas/orms.py
+++ b/dispatcher/backend/src/common/schemas/orms.py
@@ -106,13 +106,13 @@ class RequestedTaskLightSchema(m.Schema):
 
 
 class RequestedTaskFullSchema(RequestedTaskLightSchema):
-    def get_worker_name(task: dbm.Task) -> str:
+    def get_worker_name(task: dbm.RequestedTask) -> str:
         if task.worker:
             return task.worker.name
         else:
             return None
 
-    def get_schedule_name(task: dbm.Task) -> str:
+    def get_schedule_name(task: dbm.RequestedTask) -> str:
         return getattr(task.schedule, "name", "none")
 
     config = mf.Dict()  # override base

--- a/dispatcher/backend/src/common/utils.py
+++ b/dispatcher/backend/src/common/utils.py
@@ -40,6 +40,7 @@ def task_event_handler(session: so.Session, task_id: UUID, event: str, payload: 
         TaskStatus.failed_file: task_failed_file_event_handler,
         TaskStatus.checked_file: task_checked_file_event_handler,
         TaskStatus.update: task_update_event_handler,
+        TaskStatus.requested: task_requested_event_handler,
     }
     func = handlers.get(event, None)
     if func is None:
@@ -162,6 +163,10 @@ def save_event(
 
     if code == TaskStatus.scraper_completed and schedule:
         update_schedule_duration(session, schedule)
+
+
+def task_requested_event_handler(session: so.Session, task_id: UUID, payload: dict):
+    logger.info(f"Task Requested: {task_id}")
 
 
 def task_reserved_event_handler(session, task_id, payload):

--- a/dispatcher/backend/src/errors/http.py
+++ b/dispatcher/backend/src/errors/http.py
@@ -45,6 +45,11 @@ class TaskNotFound(ResourceNotFound):
         super().__init__("Task Not Found")
 
 
+class RequestedTaskNotFound(ResourceNotFound):
+    def __init__(self):
+        super().__init__("Requested Task Not Found")
+
+
 class WorkerNotFound(ResourceNotFound):
     def __init__(self):
         super().__init__("Worker Not Found")


### PR DESCRIPTION
## Rationale

Prerequisite to solve https://github.com/openzim/zimit-frontend/issues/74

Currently, "requested" events are passed to the `task_event_handler` just like other events

https://github.com/openzim/zimfarm/blob/360d1b99b6a8bdf341ec60853ab2f75589405564/dispatcher/backend/src/routes/requested_tasks/requested_task.py#L187-L189

Unfortunately, `requested` is not inside the map of events

https://github.com/openzim/zimfarm/blob/360d1b99b6a8bdf341ec60853ab2f75589405564/dispatcher/backend/src/common/utils.py#L27-L43

Consequence is that it is handled by special "fallback code" which does not sends notifications should they be registered

This is confirmed by the presence of these messages in logs:

```
1739788569127	INFO:common.utils:Other event: requested
1739800812060	INFO:common.utils:Other event: requested
```

This PR fix this by adding `requested` to supported events. Event handler is simply a log line (could help debugging) since `requested` event is already stored in DB at `RequestedTask` creation (which is ok/superior to avoid two SQL queries - INSERT then UPDATE - instead of one).

## Changes

- Add support for `requested` events 
  - special handling in notifications:
    - data comes from a distinct table
    - data sent in the notification body is slightly different (it is a requested task and not a task)
- Fix small typing error in `RequestedTaskFullSchema`