### PR TITLE
Change design to indicate a ZIM is partial and update stats at exit

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -1,12 +1,13 @@
 services:
   postgresdb:
-    image: postgres:15.2-bullseye
+    image: postgres:17.3-bookworm
     container_name: zf_postgresdb
     ports:
       - 127.0.0.1:5432:5432
     volumes:
       - pg_data_zimfarm:/var/lib/postgresql/data
       - ./postgres-initdb:/docker-entrypoint-initdb.d
+    # - ./restore/root/.borgmatic/postgresql_databases/api-postgres-db-service/zimfarm:/data/zimfarm
     environment:
       - POSTGRES_DB=zimfarm
       - POSTGRES_USER=zimfarm

--- a/receiver/Dockerfile
+++ b/receiver/Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update -y \
 # build and configure rssh
 # we are keeping source here as it's small and hosted on sourceforge
 WORKDIR /usr/src/
-RUN wget -nv https://download.kiwix.org/dev/rssh-2.3.4.tar.gz
+RUN wget -nv https://dev.kiwix.org/rssh-2.3.4.tar.gz
 RUN tar -xvf rssh-2.3.4.tar.gz
 WORKDIR /usr/src/rssh-2.3.4
 RUN ./configure --prefix=/ && make && make install

--- a/workers/app/task/worker.py
+++ b/workers/app/task/worker.py
@@ -186,17 +186,9 @@ class TaskWorker(BaseWorker):
                         "total": total,
                         "overall": int(done / total * 100),
                     }
-
-                    # limit is optionnal {"max": int, "hint": bool}
-                    if data.get("limit") and isinstance(data["limit"], dict):
-                        progress.update(
-                            {
-                                "limit": {
-                                    "max": int(data["limit"].get("max", 0)),
-                                    "hit": bool(data["limit"].get("hit", False)),
-                                }
-                            }
-                        )
+                    # partialZim is optional
+                    if data.get("partialZim") and isinstance(data["partialZim"], bool):
+                        progress["partialZim"] = data["partialZim"]
             except Exception as exc:
                 logger.warning(f"failed to load progress details: {exc}")
             else:
@@ -753,7 +745,10 @@ class TaskWorker(BaseWorker):
             self.submit_scraper_progress()
             self.handle_files()
 
-        # scraper is done. check files so upload can continue
+        # scraper is done.
+        # submit final progress (especially partialZim property)
+        self.submit_scraper_progress()
+        # check files so upload can continue
         self.handle_stopped_scraper()
 
         self.handle_files()  # rescan folder


### PR DESCRIPTION
## Rationale

Following https://github.com/openzim/zimit/pull/469, we now need to retrieve `partialZim` property which is simply a boolean instead of `limit` dictionary which was too complex / not working with Browsertrix Crawler.

Fix #1061: we also want to update stats one last time at scraper container exit.

Fix #1073

## Changes

- retrieve `partialZim` property in statistics file instead of `limit`
- update stats one last time at scraper container exit
- fix rssh location
- update dev compose to use PG 17 (backups are not readable anymore with PG 15, and it is a good opportunity to test a bit PG 17 support before moving this to prod)

## Tests

This has been tested with a locally build task worker image on https://farm.openzim.org/pipeline/a0e532cf-64cb-4d7a-87ee-0e282464c6d5 / https://api.farm.openzim.org/v1/tasks/a0e532cf-64cb-4d7a-87ee-0e282464c6d5, customized on `ondemand` worker 

![image](https://github.com/user-attachments/assets/88a7e79d-c56e-42ec-923a-f20cb8846d66)
