### PR TITLE
Release constraint on webhook URL

### DIFF
--- a/dispatcher/backend/src/common/schemas/models.py
+++ b/dispatcher/backend/src/common/schemas/models.py
@@ -116,7 +116,7 @@ class ScheduleConfigSchema(SerializableSchema):
 
 class EventNotificationSchema(SerializableSchema):
     mailgun = fields.List(fields.Email(), required=False)
-    webhook = fields.List(fields.Url(), required=False)
+    webhook = fields.List(fields.Url(require_tld=False), required=False)
     slack = fields.List(String(validate=validate_slack_target), required=False)
 
 


### PR DESCRIPTION
We do not need FQDN on webhook URLs, and this requirement is a pain in development where we do not use FQDN in docker-compose setups.