### PR TITLE
Add requested task rank

### DIFF
--- a/dispatcher/backend/src/common/schemas/orms.py
+++ b/dispatcher/backend/src/common/schemas/orms.py
@@ -121,6 +121,7 @@ class RequestedTaskFullSchema(RequestedTaskLightSchema):
     schedule_name = mf.Function(serialize=get_schedule_name)  # override base
     worker = mf.Function(serialize=get_worker_name)
     notification = mf.Dict()
+    rank = mf.Integer()
 
 
 class MostRecentTaskSchema(m.Schema):

--- a/dispatcher/backend/src/routes/requested_tasks/requested_task.py
+++ b/dispatcher/backend/src/routes/requested_tasks/requested_task.py
@@ -21,7 +21,12 @@ from common.schemas.parameters import (
 )
 from common.utils import task_event_handler
 from db import count_from_stmt, dbsession, dbsession_manual
-from errors.http import HTTPBase, InvalidRequestJSON, TaskNotFound, WorkerNotFound
+from errors.http import (
+    HTTPBase,
+    InvalidRequestJSON,
+    RequestedTaskNotFound,
+    WorkerNotFound,
+)
 from routes import auth_info_if_supplied, authenticate, require_perm, url_uuid
 from routes.base import BaseRoute
 from routes.errors import NotFound
@@ -290,7 +295,9 @@ class RequestedTaskRoute(BaseRoute):
         requested_task_id: UUID,
         token: AccessToken.Payload = None,
     ):
-        requested_task = dbm.RequestedTask.get(session, requested_task_id, TaskNotFound)
+        requested_task = dbm.RequestedTask.get(
+            session, requested_task_id, RequestedTaskNotFound
+        )
         resp = RequestedTaskFullSchema().dump(requested_task)
 
         # exclude notification to not expose private information (privacy)
@@ -313,7 +320,9 @@ class RequestedTaskRoute(BaseRoute):
     def patch(
         self, session: so.Session, requested_task_id: UUID, token: AccessToken.Payload
     ):
-        requested_task = dbm.RequestedTask.get(session, requested_task_id, TaskNotFound)
+        requested_task = dbm.RequestedTask.get(
+            session, requested_task_id, RequestedTaskNotFound
+        )
 
         try:
             request_json = UpdateRequestedTaskSchema().load(request.get_json())
@@ -331,7 +340,9 @@ class RequestedTaskRoute(BaseRoute):
     def delete(
         self, session: so.Session, requested_task_id: UUID, token: AccessToken.Payload
     ):
-        requested_task = dbm.RequestedTask.get(session, requested_task_id, TaskNotFound)
+        requested_task = dbm.RequestedTask.get(
+            session, requested_task_id, RequestedTaskNotFound
+        )
         session.delete(requested_task)
 
         return jsonify({"deleted": 1})

--- a/dispatcher/backend/src/tests/integration/routes/conftest.py
+++ b/dispatcher/backend/src/tests/integration/routes/conftest.py
@@ -269,10 +269,10 @@ def make_requested_task(make_event, make_schedule, garbage_collector):
         status=TaskStatus.requested,
         requested_by="someone",
         priority=0,
+        request_date=getnow(),
     ):
         events = [TaskStatus.requested]
-        now = getnow()
-        timestamp = {event: now for event in events}
+        timestamp = {event: request_date for event in events}
         events = [make_event(event, timestamp[event]) for event in events]
 
         config = {
@@ -291,7 +291,7 @@ def make_requested_task(make_event, make_schedule, garbage_collector):
             requested_task = dbm.RequestedTask(
                 status=status,
                 timestamp=timestamp,
-                updated_at=now,
+                updated_at=request_date,
                 events=events,
                 requested_by=requested_by,
                 priority=priority,
@@ -334,6 +334,33 @@ def requested_tasks(make_requested_task):
             make_requested_task(status=TaskStatus.failed),
         ]
     return tasks
+
+
+@pytest.fixture(scope="module")
+def requested_tasks_2(make_requested_task):
+    return [
+        make_requested_task(
+            schedule_name="recipe1",
+            request_date=getnow() - datetime.timedelta(minutes=5),
+        ),
+        make_requested_task(
+            schedule_name="recipe2",
+            request_date=getnow() - datetime.timedelta(minutes=4),
+        ),
+        make_requested_task(
+            schedule_name="recipe3",
+            request_date=getnow() - datetime.timedelta(minutes=10),
+        ),
+        make_requested_task(
+            schedule_name="recipe4",
+            request_date=getnow() - datetime.timedelta(minutes=3),
+            priority=5,
+        ),
+        make_requested_task(
+            schedule_name="recipe5",
+            request_date=getnow() - datetime.timedelta(minutes=1),
+        ),
+    ]
 
 
 @pytest.fixture(scope="module")

--- a/dispatcher/backend/src/tests/integration/routes/requested_tasks/test_requested_task.py
+++ b/dispatcher/backend/src/tests/integration/routes/requested_tasks/test_requested_task.py
@@ -179,6 +179,32 @@ class TestRequestedTaskGet:
         else:
             assert data["notification"] is None
 
+    @pytest.mark.parametrize(
+        "recipename, expected_rank",
+        [
+            pytest.param("recipe1", 2, id="recipe1"),
+            pytest.param("recipe2", 3, id="recipe2"),
+            pytest.param("recipe3", 1, id="recipe3"),
+            pytest.param("recipe4", 0, id="recipe4"),
+            pytest.param("recipe5", 4, id="recipe5"),
+        ],
+    )
+    def test_get_requested_task_rank_ok(
+        self, client, requested_tasks_2, recipename, expected_rank
+    ):
+        requested_task = [
+            requested_task
+            for requested_task in requested_tasks_2
+            if requested_task["schedule_name"] == recipename
+        ][0]
+        url = f'/requested-tasks/{requested_task["_id"]}'
+        headers = {"Content-Type": "application/json"}
+        response = client.get(url, headers=headers)
+        assert response.status_code == 200
+
+        data = json.loads(response.data)
+        assert data["rank"] == expected_rank
+
 
 class TestRequestedTaskCreate:
     @pytest.fixture()


### PR DESCRIPTION
## Rationale

This is a prerequisite for https://github.com/openzim/zimit-frontend/issues/32

## Changes

Add a "rank" property to the requested task endpoint `GET /requested_tasks/{task_id}`. Computation of the rank is deemed to be "cheap enough" since we only need the list of all requested task IDs (not the whole objects) and we do not expect to have thousands of requested tasks in the pipe.

Rank starts at 0 (meaning next task to start).

Also fix a mistake about bad exception being used.

