### PR TITLE
Add phet platform

### DIFF
--- a/dispatcher/backend/src/common/enum.py
+++ b/dispatcher/backend/src/common/enum.py
@@ -285,6 +285,7 @@ class Platform:
     devdocs = "devdocs"
     shamela = "shamela"
     libretexts = "libretexts"
+    phet = "phet"
 
     @classmethod
     def all(cls) -> str:
@@ -297,6 +298,7 @@ class Platform:
             cls.devdocs,
             cls.shamela,
             cls.libretexts,
+            cls.phet,
         ]
 
     @classmethod

--- a/workers/app/common/constants.py
+++ b/workers/app/common/constants.py
@@ -166,6 +166,7 @@ ALL_PLATFORMS = [
     "devdocs",
     "shamela",
     "libretexts",
+    "phet",
 ]
 PLATFORMS_TASKS = {}
 for platform in ALL_PLATFORMS:


### PR DESCRIPTION
## Rationale

Add a `phet` platform so that we can limit the number of concurrent tasks on `phet.colorado.edu`