### PR TITLE
disable clone by default

### DIFF
--- a/dispatcher/backend/src/routes/schedules/schedule.py
+++ b/dispatcher/backend/src/routes/schedules/schedule.py
@@ -421,7 +421,7 @@ class ScheduleCloneRoute(BaseRoute):
             category=schedule.category,
             periodicity=schedule.periodicity,
             tags=schedule.tags,
-            enabled=schedule.enabled,
+            enabled=False,
             config=schedule.config,
             notification=schedule.notification,
             language_code=schedule.language_code,


### PR DESCRIPTION
## Rationale

When clone a new recipe from an existing recipe, the new cloned recipe is disabled by default.

Fixes https://github.com/openzim/zimfarm/issues/898

## Changes

edit field "enabled" with value False in the clone object.
![image](https://github.com/user-attachments/assets/d5ced6eb-a0d2-48b8-ba68-64c4fc48fd1e)

