### PR TITLE
fix(workers): update psutils version for arm compatibility

### DIFF
--- a/workers/manager-requirements.txt
+++ b/workers/manager-requirements.txt
@@ -1,6 +1,6 @@
 requests==2.31.0
 docker==7.0.0
-psutil==5.9.8
+psutil==7.0.0
 humanfriendly==10.0
 PyJWT==2.8.0
 paramiko==2.11.0

--- a/workers/task-requirements.txt
+++ b/workers/task-requirements.txt
@@ -1,6 +1,6 @@
 requests==2.31.0
 docker==7.0.0
-psutil==5.9.8
+psutil==7.0.0
 humanfriendly==10.0
 PyJWT==2.8.0
 kiwixstorage==0.6


### PR DESCRIPTION
## Rationale

While trying to setup dev. environment with workers-manager I received an error about missing gcc (during `pip3 install` step):

```
5.967 Building wheels for collected packages: psutil
5.970   Building wheel for psutil (pyproject.toml): started
6.226   Building wheel for psutil (pyproject.toml): finished with status 'error'
6.231   error: subprocess-exited-with-error
6.231   
6.231   × Building wheel for psutil (pyproject.toml) did not run successfully.
6.231   │ exit code: 1
6.231   ╰─> [55 lines of output]
6.231       /tmp/pip-build-env-vjo4dqs6/overlay/lib/python3.12/site-packages/setuptools/dist.py:759: SetuptoolsDeprecationWarning: License classifiers are deprecated.
6.231       !!
6.231       
6.231               ********************************************************************************
6.231               Please consider removing the following classifiers in favor of a SPDX license expression:
6.231       
6.231               License :: OSI Approved :: BSD License
6.231       
6.231               See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license for details.
6.231               ********************************************************************************
6.231       
6.231       !!
6.231         self._finalize_license_expression()
6.231       running bdist_wheel
6.231       running build
6.231       running build_py
6.231       creating build/lib.linux-aarch64-cpython-312/psutil
6.231       copying psutil/_psbsd.py -> build/lib.linux-aarch64-cpython-312/psutil
6.231       copying psutil/_pswindows.py -> build/lib.linux-aarch64-cpython-312/psutil
6.231       copying psutil/_common.py -> build/lib.linux-aarch64-cpython-312/psutil
6.231       copying psutil/_psaix.py -> build/lib.linux-aarch64-cpython-312/psutil
6.231       copying psutil/__init__.py -> build/lib.linux-aarch64-cpython-312/psutil
6.231       copying psutil/_compat.py -> build/lib.linux-aarch64-cpython-312/psutil
6.231       copying psutil/_psosx.py -> build/lib.linux-aarch64-cpython-312/psutil
6.231       copying psutil/_pssunos.py -> build/lib.linux-aarch64-cpython-312/psutil
6.231       copying psutil/_psposix.py -> build/lib.linux-aarch64-cpython-312/psutil
6.231       copying psutil/_pslinux.py -> build/lib.linux-aarch64-cpython-312/psutil
6.231       creating build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_memleaks.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_connections.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/__init__.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_system.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_testutils.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_process.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_bsd.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_linux.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_misc.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_posix.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_aix.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_windows.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_process_all.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/__main__.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_sunos.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_osx.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_contracts.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/runner.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       copying psutil/tests/test_unicode.py -> build/lib.linux-aarch64-cpython-312/psutil/tests
6.231       running build_ext
6.231       building 'psutil._psutil_linux' extension
6.231       creating build/temp.linux-aarch64-cpython-312/psutil
6.231       creating build/temp.linux-aarch64-cpython-312/psutil/arch/linux
6.231       gcc -fno-strict-overflow -Wsign-compare -DNDEBUG -g -O3 -Wall -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_SIZEOF_PID_T=4 -DPSUTIL_VERSION=598 -DPy_LIMITED_API=0x03060000 -DPSUTIL_ETHTOOL_MISSING_TYPES=1 -DPSUTIL_LINUX=1 -I/usr/local/include/python3.12 -c psutil/_psutil_common.c -o build/temp.linux-aarch64-cpython-312/psutil/_psutil_common.o
6.231       psutil could not be installed from sources because gcc is not installed. Try running:
6.231         sudo apt-get install gcc python3-dev
6.231       error: command 'gcc' failed: No such file or directory
6.231       [end of output]
6.231   
6.231   note: This error originates from a subprocess, and is likely not a problem with pip.
6.231   ERROR: Failed building wheel for psutil
6.231 Failed to build psutil
```

## Changes

I added `gcc` to the docker container and now it works.
