### PR TITLE
Fixed `Public server download` Url in Readme file #1088

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Uploader is very fast and convenient (can watch and resumes files) but works onl
 
 ### receiver
 
-The [receiver](https://ghcr.io/openzim/zimfarm-receiver) is a jailed OpenSSH-server that receives scraper logs and ZIM files and pass the latter through a quarantine via the [zimcheck](https://github.com/openzim/zim-tools) tool which eventually either put them aside (invalid ZIM) or move those to the [public download server](download.kiwix.org/zim/).
+The [receiver](https://ghcr.io/openzim/zimfarm-receiver) is a jailed OpenSSH-server that receives scraper logs and ZIM files and pass the latter through a quarantine via the [zimcheck](https://github.com/openzim/zim-tools) tool which eventually either put them aside (invalid ZIM) or move those to the [public download server](https://download.kiwix.org/zim/).
 
 ### scrapers
 


### PR DESCRIPTION

Closes #1088
## Rationale

[//]: # (Briefly explain the reason behind this change.)
The `Public server Download` link in the README for this Git repository is broken
when clicked it showed this screen 
![image](https://github.com/user-attachments/assets/489e044e-827b-49d9-bfdc-81362343bc0c)


<!--
Issue: closes #1088 
-->

## Changes
added `https://` to the  download link in readme file

