### PR TITLE
Improve Navbar Style For Smaller Devices

### DIFF
--- a/dispatcher/frontend-ui/src/components/NavBar.vue
+++ b/dispatcher/frontend-ui/src/components/NavBar.vue
@@ -1,7 +1,7 @@
 
 <template>
     <header>
-        <nav class="navbar navbar-expand-md navbar-dark ">
+        <nav class="navbar navbar-expand-md navbar-dark">
             <a class="navbar-brand branding">
                 <div class="icon"><img :src="publicPath + 'assets/logo.svg'" />
                 <Loading/></div>
@@ -10,7 +10,7 @@
 
             <b-navbar-toggle target="nav-collapse"></b-navbar-toggle>
              <b-collapse id="nav-collapse" is-nav>
-                <ul class="navbar-nav mr-auto">
+                <ul class="navbar-nav mr-auto text-center mb-md-0 mb-2">
                     <li class="nav-item">
                         <router-link class="nav-link" :to="{ name: 'pipeline' }">Pipeline</router-link>
                     </li>
@@ -26,13 +26,14 @@
                     <li class="nav-item disabled">
                         <span class="nav-link" href="/stats">Stats</span>
                     </li>
-                    <li>
-                        <router-link class="btn btn-light btn-sm mt-1 mb-1" :to="{ name: 'support-us' }">
-                            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" style="color: rgb(234, 74, 170) !important; fill: currentColor;"><path fill-rule="evenodd" d="M4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.565 20.565 0 008 13.393a20.561 20.561 0 003.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.75.75 0 01-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5zM8 14.25l-.345.666-.002-.001-.006-.003-.018-.01a7.643 7.643 0 01-.31-.17 22.075 22.075 0 01-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.08 22.08 0 01-3.744 2.584l-.018.01-.006.003h-.002L8 14.25zm0 0l.345.666a.752.752 0 01-.69 0L8 14.25z"></path></svg> Support us
-                        </router-link>
-                    </li>
                 </ul>
-                <UserButton />
+                <div class="d-flex align-items-center flex-md-row flex-column">
+                    <router-link class="btn btn-light btn-sm mr-md-2 mb-2 mb-md-0" :to="{ name: 'support-us' }">
+                        <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" width="16" height="16" style="color: rgb(234, 74, 170) !important; fill: currentColor;"><path fill-rule="evenodd" d="M4.25 2.5c-1.336 0-2.75 1.164-2.75 3 0 2.15 1.58 4.144 3.365 5.682A20.565 20.565 0 008 13.393a20.561 20.561 0 003.135-2.211C12.92 9.644 14.5 7.65 14.5 5.5c0-1.836-1.414-3-2.75-3-1.373 0-2.609.986-3.029 2.456a.75.75 0 01-1.442 0C6.859 3.486 5.623 2.5 4.25 2.5zM8 14.25l-.345.666-.002-.001-.006-.003-.018-.01a7.643 7.643 0 01-.31-.17 22.075 22.075 0 01-3.434-2.414C2.045 10.731 0 8.35 0 5.5 0 2.836 2.086 1 4.25 1 5.797 1 7.153 1.802 8 3.02 8.847 1.802 10.203 1 11.75 1 13.914 1 16 2.836 16 5.5c0 2.85-2.045 5.231-3.885 6.818a22.08 22.08 0 01-3.744 2.584l-.018.01-.006.003h-.002L8 14.25zm0 0l.345.666a.752.752 0 01-.69 0L8 14.25z"></path></svg>
+                        <span class="ml-1">Support us</span>
+                    </router-link>
+                    <UserButton />
+                </div>
             </b-collapse>
         </nav>
     </header>

--- a/dispatcher/frontend-ui/src/components/UserButton.vue
+++ b/dispatcher/frontend-ui/src/components/UserButton.vue
@@ -35,7 +35,8 @@
   <b-dropdown v-if="isLoggedIn" variant="light" size="sm" right>
 
     <template v-slot:button-content>
-      <font-awesome-icon icon="user-circle" size="sm" /> {{ $store.getters.username }}
+        <font-awesome-icon icon="user-circle" size="sm" />
+        <span class="ml-1">{{ $store.getters.username }}</span>
     </template>
 
     <b-dropdown-item @click.prevent="copyToken">


### PR DESCRIPTION
## Rationale
Currently, in the website's mobile navbar, all items are left-aligned, and the "Support Us" and "Sign In" buttons have inconsistent widths. We can improve this by adjusting the styles.

Fixes #1091 

## Changes
In the mobile view, all links and buttons are centered. The buttons are full width on smaller screens. On larger screens, the "Support Us" button is moved to the right side along with the "Sign In" button.

## Screenshot

### Old
<table>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/22aae862-16fb-462b-9207-1b8cc1e84b4e" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/2f24c7c2-6f8c-4180-87ff-fc130e7e8135" />
</td>
</tr>
</table>


### New
With SignIn
<table>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/feb44ee3-5c0d-4f7b-9930-c2ee7f8da774" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/2e2291a8-adef-45ef-ad6e-e0c3dfa893a1" />
</td>
</tr>
</table>

Without signIn
<table>
<tr>
<td>
<img src="https://github.com/user-attachments/assets/ad322315-7c8c-4ee6-a274-92d1d1e60fab" />
</td>
<td>
<img src="https://github.com/user-attachments/assets/42a3e496-7bc5-4936-9f4a-131e11abdb7f" />
</td>
</tr>
</table>



