### PR TITLE
Added Sortable headers for Pipeline Table

### DIFF
--- a/dispatcher/backend/src/common/schemas/fields.py
+++ b/dispatcher/backend/src/common/schemas/fields.py
@@ -75,3 +75,10 @@ tag_field = fields.List(String(validate=validate_not_empty), required=False)
 offliner_field = String(required=False, validate=validate_offliner)
 email_field = fields.Email(required=False, validate=validate_not_empty)
 username_field = String(required=True, validate=validate_not_empty)
+
+
+def validate_sort_order(value):
+    """Validate that sort order is either 'asc' or 'desc'"""
+    if value not in ["asc", "desc"]:
+        raise ValidationError("Sort order must be either 'asc' or 'desc'")
+    return True

--- a/dispatcher/backend/src/common/schemas/fields.py
+++ b/dispatcher/backend/src/common/schemas/fields.py
@@ -50,6 +50,20 @@ validate_zim_filename = validate.Regexp(
 validate_zim_title = validate.Length(max=30)
 validate_zim_description = validate.Length(max=80)
 validate_zim_longdescription = validate.Length(max=4000)
+validate_sort_order = validate.OneOf(["asc", "desc"])
+validate_sort_by = validate.OneOf(
+    [
+        "schedule_name",
+        "updated_at",
+        "worker",
+        "worker_name",
+        "priority",
+        "status",
+        "requested_by",
+        "timestamp.requested",
+        "timestamp.reserved",
+    ]
+)
 
 
 def validate_multiple_of_100(value):
@@ -75,10 +89,3 @@ tag_field = fields.List(String(validate=validate_not_empty), required=False)
 offliner_field = String(required=False, validate=validate_offliner)
 email_field = fields.Email(required=False, validate=validate_not_empty)
 username_field = String(required=True, validate=validate_not_empty)
-
-
-def validate_sort_order(value):
-    """Validate that sort order is either 'asc' or 'desc'"""
-    if value not in ["asc", "desc"]:
-        raise ValidationError("Sort order must be either 'asc' or 'desc'")
-    return True

--- a/dispatcher/backend/src/common/schemas/parameters.py
+++ b/dispatcher/backend/src/common/schemas/parameters.py
@@ -23,6 +23,7 @@ from common.schemas.fields import (
     validate_role,
     validate_schedule_name,
     validate_sort_order,
+    validate_sort_by,
     validate_status,
     validate_warehouse_path,
     validate_worker_name,
@@ -57,7 +58,7 @@ class RequestedTaskSchema(Schema):
     priority = priority_field
     schedule_name = fields.List(schedule_name_field, required=False)
 
-    sort_by = fields.String(required=False)
+    sort_by = fields.String(required=False, validate=validate_sort_by)
     sort_order = fields.String(required=False, validate=validate_sort_order)
 
     matching_cpu = fields.Integer(required=False, validate=validate_cpu)
@@ -127,7 +128,7 @@ class TasksSchema(Schema):
     limit = limit_field_20_200
     status = fields.List(String(validate=validate_status), required=False)
     schedule_name = schedule_name_field
-    sort_by = fields.String(required=False)
+    sort_by = fields.String(required=False, validate=validate_sort_by)
     sort_order = fields.String(required=False, validate=validate_sort_order)
 
 

--- a/dispatcher/backend/src/common/schemas/parameters.py
+++ b/dispatcher/backend/src/common/schemas/parameters.py
@@ -22,6 +22,7 @@ from common.schemas.fields import (
     validate_priority,
     validate_role,
     validate_schedule_name,
+    validate_sort_order,
     validate_status,
     validate_warehouse_path,
     validate_worker_name,
@@ -55,6 +56,9 @@ class RequestedTaskSchema(Schema):
     worker = worker_field
     priority = priority_field
     schedule_name = fields.List(schedule_name_field, required=False)
+
+    sort_by = fields.String(required=False)
+    sort_order = fields.String(required=False, validate=validate_sort_order)
 
     matching_cpu = fields.Integer(required=False, validate=validate_cpu)
     matching_memory = fields.Integer(required=False, validate=validate_memory)
@@ -123,6 +127,8 @@ class TasksSchema(Schema):
     limit = limit_field_20_200
     status = fields.List(String(validate=validate_status), required=False)
     schedule_name = schedule_name_field
+    sort_by = fields.String(required=False)
+    sort_order = fields.String(required=False, validate=validate_sort_order)
 
 
 # tasks POST

--- a/dispatcher/backend/src/routes/requested_tasks/requested_task.py
+++ b/dispatcher/backend/src/routes/requested_tasks/requested_task.py
@@ -74,8 +74,8 @@ def list_of_requested_tasks(session: so.Session, token: AccessToken.Payload = No
     schedule_names = request_args["schedule_name"]
     priority = request_args.get("priority")
     # Get sorting parameters
-    sort_by = request_args.get("sort_by", "priority")
-    sort_order = request_args.get("sort_order", "desc")
+    sort_by = request_args.get("sort_by")
+    sort_order = request_args.get("sort_order")
 
     # get requested tasks from database
     stmt = (
@@ -98,14 +98,13 @@ def list_of_requested_tasks(session: so.Session, token: AccessToken.Payload = No
         .join(dbm.Schedule, dbm.RequestedTask.schedule, isouter=True)
     )
     join_models = {"Schedule": dbm.Schedule, "Worker": dbm.Worker}
-    default_field = dbm.RequestedTask.priority
     stmt = apply_sort(
-            stmt=stmt,
-            sort_by=sort_by,
-            sort_order=sort_order,
-            model=dbm.RequestedTask,
-            join_models=join_models
-        )
+        stmt=stmt,
+        sort_by=sort_by,
+        sort_order=sort_order,
+        model=dbm.RequestedTask,
+        join_models=join_models,
+    )
 
     if schedule_names:
         stmt = stmt.filter(dbm.Schedule.name.in_(schedule_names))

--- a/dispatcher/backend/src/routes/requested_tasks/requested_task.py
+++ b/dispatcher/backend/src/routes/requested_tasks/requested_task.py
@@ -98,13 +98,22 @@ def list_of_requested_tasks(session: so.Session, token: AccessToken.Payload = No
         .join(dbm.Schedule, dbm.RequestedTask.schedule, isouter=True)
     )
     join_models = {"Schedule": dbm.Schedule, "Worker": dbm.Worker}
-    stmt = apply_sort(
-        stmt=stmt,
-        sort_by=sort_by,
-        sort_order=sort_order,
-        model=dbm.RequestedTask,
-        join_models=join_models,
-    )
+    if sort_by:
+        stmt = apply_sort(
+            stmt=stmt,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            model=dbm.RequestedTask,
+            join_models=join_models,
+        )
+    else:
+        stmt = stmt.order_by(dbm.RequestedTask.priority.desc())
+        stmt = stmt.order_by(
+            dbm.RequestedTask.timestamp["reserved"]["$date"].astext.cast(sa.BigInteger)
+        )
+        stmt = stmt.order_by(
+            dbm.RequestedTask.timestamp["requested"]["$date"].astext.cast(sa.BigInteger)
+        )
 
     if schedule_names:
         stmt = stmt.filter(dbm.Schedule.name.in_(schedule_names))

--- a/dispatcher/backend/src/routes/requested_tasks/requested_task.py
+++ b/dispatcher/backend/src/routes/requested_tasks/requested_task.py
@@ -30,7 +30,7 @@ from errors.http import (
 from routes import auth_info_if_supplied, authenticate, require_perm, url_uuid
 from routes.base import BaseRoute
 from routes.errors import NotFound
-from routes.utils import get_sort_field_and_apply_order, remove_secrets_from_response
+from routes.utils import apply_sort, remove_secrets_from_response
 from utils.scheduling import find_requested_task_for, request_a_schedule
 from utils.token import AccessToken
 
@@ -99,17 +99,12 @@ def list_of_requested_tasks(session: so.Session, token: AccessToken.Payload = No
     )
     join_models = {"Schedule": dbm.Schedule, "Worker": dbm.Worker}
     default_field = dbm.RequestedTask.priority
-    stmt = get_sort_field_and_apply_order(
-        model=dbm.RequestedTask,
-        sort_by=sort_by,
-        sort_order=sort_order,
-        stmt=stmt,
-        join_models=join_models,
-        fallback_field=default_field,
-    )
-    if sort_by == "priority" or not sort_by:
-        stmt = stmt.order_by(
-            dbm.RequestedTask.timestamp["reserved"]["$date"].astext.cast(sa.BigInteger)
+    stmt = apply_sort(
+            stmt=stmt,
+            sort_by=sort_by,
+            sort_order=sort_order,
+            model=dbm.RequestedTask,
+            join_models=join_models
         )
 
     if schedule_names:

--- a/dispatcher/backend/src/routes/tasks/task.py
+++ b/dispatcher/backend/src/routes/tasks/task.py
@@ -23,7 +23,7 @@ from errors.http import InvalidRequestJSON, TaskNotFound, WorkerNotFound
 from routes import auth_info_if_supplied, authenticate, require_perm, url_uuid
 from routes.base import BaseRoute
 from routes.errors import BadRequest
-from routes.utils import get_sort_field_and_apply_order, remove_secrets_from_response
+from routes.utils import apply_sort, remove_secrets_from_response
 from utils.check import raise_if, raise_if_none
 from utils.token import AccessToken
 
@@ -71,13 +71,12 @@ class TasksRoute(BaseRoute):
         )
         join_models = {"Schedule": dbm.Schedule, "Worker": dbm.Worker}
         default_field = dbm.Task.updated_at
-        stmt = get_sort_field_and_apply_order(
-            model=dbm.Task,
+        stmt = apply_sort(
+            stmt=stmt,
             sort_by=sort_by,
             sort_order=sort_order,
-            stmt=stmt,
-            join_models=join_models,
-            fallback_field=default_field,
+            model=dbm.Task,
+            join_models=join_models
         )
 
         # get tasks from database

--- a/dispatcher/backend/src/routes/tasks/task.py
+++ b/dispatcher/backend/src/routes/tasks/task.py
@@ -49,7 +49,7 @@ class TasksRoute(BaseRoute):
         schedule_name = request_args.get("schedule_name")
         # Get sorting parameters
         sort_by = request_args.get("sort_by")
-        sort_order = request_args.get("sort_order", "desc")
+        sort_order = request_args.get("sort_order")
 
         stmt = (
             sa.select(
@@ -68,15 +68,19 @@ class TasksRoute(BaseRoute):
             )
             .join(dbm.Worker, dbm.Task.worker, isouter=True)
             .join(dbm.Schedule, dbm.Task.schedule, isouter=True)
+            .order_by(
+                dbm.RequestedTask.timestamp["requested"]["$date"].astext.cast(
+                    sa.BigInteger
+                )
+            )
         )
         join_models = {"Schedule": dbm.Schedule, "Worker": dbm.Worker}
-        default_field = dbm.Task.updated_at
         stmt = apply_sort(
             stmt=stmt,
             sort_by=sort_by,
             sort_order=sort_order,
             model=dbm.Task,
-            join_models=join_models
+            join_models=join_models,
         )
 
         # get tasks from database

--- a/dispatcher/backend/src/routes/tasks/task.py
+++ b/dispatcher/backend/src/routes/tasks/task.py
@@ -68,20 +68,18 @@ class TasksRoute(BaseRoute):
             )
             .join(dbm.Worker, dbm.Task.worker, isouter=True)
             .join(dbm.Schedule, dbm.Task.schedule, isouter=True)
-            .order_by(
-                dbm.RequestedTask.timestamp["requested"]["$date"].astext.cast(
-                    sa.BigInteger
-                )
-            )
         )
         join_models = {"Schedule": dbm.Schedule, "Worker": dbm.Worker}
-        stmt = apply_sort(
-            stmt=stmt,
-            sort_by=sort_by,
-            sort_order=sort_order,
-            model=dbm.Task,
-            join_models=join_models,
-        )
+        if sort_by:
+            stmt = apply_sort(
+                stmt=stmt,
+                sort_by=sort_by,
+                sort_order=sort_order,
+                model=dbm.Task,
+                join_models=join_models,
+            )
+        else:
+            stmt = stmt.order_by(dbm.Task.updated_at.desc())
 
         # get tasks from database
         if statuses:

--- a/dispatcher/backend/src/routes/utils.py
+++ b/dispatcher/backend/src/routes/utils.py
@@ -143,39 +143,38 @@ def apply_sort(stmt, sort_by, sort_order, model=None, join_models=None):
     """
     Apply sorting based on a sort field name and order.
     """
-    join_models = join_models or {}
-    
+
     def apply_sort_direction(field):
         """Apply sort direction to a field"""
         return field.desc() if sort_order == "desc" else field.asc()
-    
+
     if not sort_by:
         return stmt.order_by(apply_sort_direction(model.updated_at))
-    
+
     try:
         if sort_by == "priority":
             return stmt.order_by(apply_sort_direction(model.priority))
-        
+
         elif sort_by == "updated_at":
             return stmt.order_by(apply_sort_direction(model.updated_at))
-            
+
         elif sort_by == "schedule_name":
             return stmt.order_by(apply_sort_direction(join_models["Schedule"].name))
-            
+
         elif sort_by == "worker" or sort_by == "worker_name":
             return stmt.order_by(apply_sort_direction(join_models["Worker"].name))
-        
+
         elif sort_by == "timestamp.requested":
             field = model.timestamp["requested"]["$date"].astext.cast(sa.BigInteger)
             return stmt.order_by(apply_sort_direction(field))
-            
+
         elif sort_by == "timestamp.reserved":
             field = model.timestamp["reserved"]["$date"].astext.cast(sa.BigInteger)
             return stmt.order_by(apply_sort_direction(field))
         elif model and hasattr(model, sort_by):
             return stmt.order_by(apply_sort_direction(getattr(model, sort_by)))
         logger.warning(f"Unknown sort field: {sort_by}")
-        
+
     except Exception as e:
         logger.error(f"Error applying sorting: {e}")
         return stmt.order_by(apply_sort_direction(model.updated_at))

--- a/dispatcher/frontend-ui/src/components/PipelineTable.vue
+++ b/dispatcher/frontend-ui/src/components/PipelineTable.vue
@@ -13,82 +13,78 @@
       </caption>
       <thead v-if="selectedTable == 'todo'">
         <tr>
-          <th @click="sortBy('schedule_name')" class="sortable">
-            Schedule
-            <span v-if="sortColumn === 'schedule_name'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
-          </th>
-          <th @click="sortBy('timestamp.requested')" class="sortable">
-            Requested
-            <span v-if="sortColumn === 'timestamp.requested'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
-          </th>
-          <th @click="sortBy('requested_by')" class="sortable">
-            By
-            <span v-if="sortColumn === 'requested_by'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
-          </th>
+          <sortable-header column="schedule_name" 
+                         :current-sort-column="sortColumn" 
+                         :current-sort-order="sortOrder" 
+                         @sort="sortBy">Schedule</sortable-header>
+          <sortable-header column="timestamp.requested" 
+                         :current-sort-column="sortColumn" 
+                         :current-sort-order="sortOrder" 
+                         @sort="sortBy">Requested</sortable-header>
+          <sortable-header column="requested_by" 
+                         :current-sort-column="sortColumn" 
+                         :current-sort-order="sortOrder" 
+                         @sort="sortBy">By</sortable-header>
           <th>Resources</th>
-          <th @click="sortBy('worker')" class="sortable">
-            Worker
-            <span v-if="sortColumn === 'worker'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
-          </th>
+          <sortable-header column="worker" 
+                         :current-sort-column="sortColumn" 
+                         :current-sort-order="sortOrder" 
+                         @sort="sortBy">Worker</sortable-header>
           <th v-show="canUnRequestTasks">Remove</th>
         </tr>
       </thead>
       <thead v-if="selectedTable == 'doing'">
         <tr>
-          <th @click="sortBy('schedule_name')" class="sortable">
-            Schedule
-            <span v-if="sortColumn === 'schedule_name'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
-          </th>
-          <th @click="sortBy('timestamp.reserved')" class="sortable">
-            Started
-            <span v-if="sortColumn === 'timestamp.reserved'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
-          </th>
-          <th @click="sortBy('worker')" class="sortable">
-            Worker
-            <span v-if="sortColumn === 'worker'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
-          </th>
+          <sortable-header column="schedule_name" 
+                         :current-sort-column="sortColumn" 
+                         :current-sort-order="sortOrder" 
+                         @sort="sortBy">Schedule</sortable-header>
+          <sortable-header column="timestamp.reserved" 
+                         :current-sort-column="sortColumn" 
+                         :current-sort-order="sortOrder" 
+                         @sort="sortBy">Started</sortable-header>
+          <sortable-header column="worker" 
+                         :current-sort-column="sortColumn" 
+                         :current-sort-order="sortOrder" 
+                         @sort="sortBy">Worker</sortable-header>
         </tr>
       </thead>
       <thead v-if="selectedTable == 'done'">
         <tr>
-          <th @click="sortBy('schedule_name')" class="sortable">
-            Schedule
-            <span v-if="sortColumn === 'schedule_name'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
-          </th>
-          <th @click="sortBy('updated_at')" class="sortable">
-            Completed
-            <span v-if="sortColumn === 'updated_at'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
-          </th>
-          <th @click="sortBy('worker')" class="sortable">
-            Worker
-            <span v-if="sortColumn === 'worker'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
-          </th>
-          <th>
-            Duration
-          </th>
+          <sortable-header column="schedule_name" 
+                         :current-sort-column="sortColumn" 
+                         :current-sort-order="sortOrder" 
+                         @sort="sortBy">Schedule</sortable-header>
+          <sortable-header column="updated_at" 
+                         :current-sort-column="sortColumn" 
+                         :current-sort-order="sortOrder" 
+                         @sort="sortBy">Completed</sortable-header>
+          <sortable-header column="worker" 
+                         :current-sort-column="sortColumn" 
+                         :current-sort-order="sortOrder" 
+                         @sort="sortBy">Worker</sortable-header>
+          <th>Duration</th>
         </tr>
       </thead>
       <thead v-if="selectedTable == 'failed'">
         <tr>
-          <th @click="sortBy('schedule_name')" class="sortable">
-            Schedule
-            <span v-if="sortColumn === 'schedule_name'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
-          </th>
-          <th @click="sortBy('updated_at')" class="sortable">
-            Stopped
-            <span v-if="sortColumn === 'updated_at'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
-          </th>
-          <th @click="sortBy('worker')" class="sortable">
-            Worker
-            <span v-if="sortColumn === 'worker'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
-          </th>
-          <th>
-            Duration
-          </th>
-          <th @click="sortBy('status')" class="sortable">
-            Status
-            <span v-if="sortColumn === 'status'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
-          </th>
+          <sortable-header column="schedule_name" 
+                         :current-sort-column="sortColumn" 
+                         :current-sort-order="sortOrder" 
+                         @sort="sortBy">Schedule</sortable-header>
+          <sortable-header column="updated_at" 
+                         :current-sort-column="sortColumn" 
+                         :current-sort-order="sortOrder" 
+                         @sort="sortBy">Stopped</sortable-header>
+          <sortable-header column="worker" 
+                         :current-sort-column="sortColumn" 
+                         :current-sort-order="sortOrder" 
+                         @sort="sortBy">Worker</sortable-header>
+          <th>Duration</th>
+          <sortable-header column="status" 
+                         :current-sort-column="sortColumn" 
+                         :current-sort-order="sortOrder" 
+                         @sort="sortBy">Status</sortable-header>
           <th>Last Run</th>
         </tr>
       </thead>
@@ -142,11 +138,12 @@
   import RemoveRequestedTaskButton from '../components/RemoveRequestedTaskButton.vue'
   import ResourceBadge from '../components/ResourceBadge.vue'
   import TaskLink from '../components/TaskLink.vue'
+  import SortableHeader from '../components/SortableHeader.vue'
 
   export default {
     name: 'PipelineTable',
     mixins: [ZimfarmMixins],
-    components: {ErrorMessage, RemoveRequestedTaskButton, ResourceBadge, TaskLink},
+    components: {ErrorMessage, RemoveRequestedTaskButton, ResourceBadge, TaskLink, SortableHeader},
     props: {
       selectedTable: String, // applied filter: todo, doing, done, failed
     },
@@ -309,17 +306,3 @@
     }
   };
 </script>
-<style>
-.sortable {
-  cursor: pointer;
-  position: relative;
-  user-select: none;
-}
-.sortable:hover {
-  background-color: rgba(0, 0, 0, 0.05);
-}
-.sort-icon {
-  margin-left: 5px;
-  font-size: 0.8em;
-}
-</style>

--- a/dispatcher/frontend-ui/src/components/PipelineTable.vue
+++ b/dispatcher/frontend-ui/src/components/PipelineTable.vue
@@ -13,22 +13,84 @@
       </caption>
       <thead v-if="selectedTable == 'todo'">
         <tr>
-          <th>Schedule</th>
-          <th>Requested</th>
-          <th>By</th>
+          <th @click="sortBy('schedule_name')" class="sortable">
+            Schedule
+            <span v-if="sortColumn === 'schedule_name'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
+          </th>
+          <th @click="sortBy('timestamp.requested')" class="sortable">
+            Requested
+            <span v-if="sortColumn === 'timestamp.requested'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
+          </th>
+          <th @click="sortBy('requested_by')" class="sortable">
+            By
+            <span v-if="sortColumn === 'requested_by'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
+          </th>
           <th>Resources</th>
-          <th>Worker</th>
+          <th @click="sortBy('worker')" class="sortable">
+            Worker
+            <span v-if="sortColumn === 'worker'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
+          </th>
           <th v-show="canUnRequestTasks">Remove</th>
         </tr>
       </thead>
       <thead v-if="selectedTable == 'doing'">
-        <tr><th>Schedule</th><th>Started</th><th>Worker</th></tr>
+        <tr>
+          <th @click="sortBy('schedule_name')" class="sortable">
+            Schedule
+            <span v-if="sortColumn === 'schedule_name'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
+          </th>
+          <th @click="sortBy('timestamp.reserved')" class="sortable">
+            Started
+            <span v-if="sortColumn === 'timestamp.reserved'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
+          </th>
+          <th @click="sortBy('worker')" class="sortable">
+            Worker
+            <span v-if="sortColumn === 'worker'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
+          </th>
+        </tr>
       </thead>
       <thead v-if="selectedTable == 'done'">
-        <tr><th>Schedule</th><th>Completed</th><th>Worker</th><th>Duration</th></tr>
+        <tr>
+          <th @click="sortBy('schedule_name')" class="sortable">
+            Schedule
+            <span v-if="sortColumn === 'schedule_name'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
+          </th>
+          <th @click="sortBy('updated_at')" class="sortable">
+            Completed
+            <span v-if="sortColumn === 'updated_at'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
+          </th>
+          <th @click="sortBy('worker')" class="sortable">
+            Worker
+            <span v-if="sortColumn === 'worker'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
+          </th>
+          <th>
+            Duration
+          </th>
+        </tr>
       </thead>
       <thead v-if="selectedTable == 'failed'">
-        <tr><th>Schedule</th><th>Stopped</th><th>Worker</th><th>Duration</th><th>Status</th><th>Last Run</th></tr>
+        <tr>
+          <th @click="sortBy('schedule_name')" class="sortable">
+            Schedule
+            <span v-if="sortColumn === 'schedule_name'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
+          </th>
+          <th @click="sortBy('updated_at')" class="sortable">
+            Stopped
+            <span v-if="sortColumn === 'updated_at'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
+          </th>
+          <th @click="sortBy('worker')" class="sortable">
+            Worker
+            <span v-if="sortColumn === 'worker'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
+          </th>
+          <th>
+            Duration
+          </th>
+          <th @click="sortBy('status')" class="sortable">
+            Status
+            <span v-if="sortColumn === 'status'" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
+          </th>
+          <th>Last Run</th>
+        </tr>
       </thead>
       <tbody>
         <tr v-for="task in tasks" :key="task._id">
@@ -97,6 +159,8 @@
         loading: false,
         schedules_last_runs: {}, // last runs for all schedule_names of tasks
         last_runs_loaded: false,  // used to trigger render() on last_run cell
+        sortColumn: null,
+        sortOrder: 'desc',
       };
     },
     computed: {
@@ -128,6 +192,12 @@
         let parent = this;
         parent.toggleLoader("fetching tasks…");
         parent.loading = true;
+        if (this.sortColumn) {
+          params.sort_by = this.sortColumn;
+          params.sort_order = this.sortOrder;
+          if (params.sort) delete params.sort;
+          if (params.order) delete params.order;
+        }
         this.queryAPI('get', url, {params})
           .then(function (response) {
               parent.resetData();
@@ -207,6 +277,15 @@
         parent.last_runs_loaded = true;
         parent.toggleLoader(false);
       },
+      sortBy(column) {
+        if (this.sortColumn === column) {
+          this.sortOrder = this.sortOrder === 'asc' ? 'desc' : 'asc';
+        } else {
+          this.sortColumn = column;
+          this.sortOrder = 'desc';
+        }
+        this.loadData();
+      },
     },
     mounted() {
       this.loadData();
@@ -222,3 +301,17 @@
     }
   };
 </script>
+<style>
+.sortable {
+  cursor: pointer;
+  position: relative;
+  user-select: none;
+}
+.sortable:hover {
+  background-color: rgba(0, 0, 0, 0.05);
+}
+.sort-icon {
+  margin-left: 5px;
+  font-size: 0.8em;
+}
+</style>

--- a/dispatcher/frontend-ui/src/components/PipelineTable.vue
+++ b/dispatcher/frontend-ui/src/components/PipelineTable.vue
@@ -160,7 +160,7 @@
         schedules_last_runs: {}, // last runs for all schedule_names of tasks
         last_runs_loaded: false,  // used to trigger render() on last_run cell
         sortColumn: null,
-        sortOrder: 'desc',
+        sortOrder: null,
       };
     },
     computed: {
@@ -279,11 +279,17 @@
       },
       sortBy(column) {
         if (this.sortColumn === column) {
-          this.sortOrder = this.sortOrder === 'asc' ? 'desc' : 'asc';
+          if (this.sortOrder === 'asc') {
+            this.sortOrder = 'desc';
+          } else {
+            this.sortColumn = null;
+            this.sortOrder = null;
+          }
         } else {
           this.sortColumn = column;
-          this.sortOrder = 'desc';
+          this.sortOrder = 'asc';
         }
+        
         this.loadData();
       },
     },
@@ -296,6 +302,8 @@
     },
     watch: {
       selectedTable() {
+        this.sortColumn = null;
+        this.sortOrder = null;
         this.loadData();
       },
     }

--- a/dispatcher/frontend-ui/src/components/SortableHeader.vue
+++ b/dispatcher/frontend-ui/src/components/SortableHeader.vue
@@ -1,0 +1,59 @@
+<template>
+    <th @click="sort" :class="{ sortable: true, 'active-sort': isActive }">
+      <slot></slot>
+      <span v-if="isActive" class="sort-icon">{{ sortOrder === 'asc' ? '▲' : '▼' }}</span>
+    </th>
+  </template>
+  
+  <script>
+  export default {
+    name: 'SortableHeader',
+    props: {
+      column: {
+        type: String,
+        required: true
+      },
+      currentSortColumn: {
+        type: String,
+        default: null
+      },
+      currentSortOrder: {
+        type: String,
+        default: null
+      },
+      sortable: {
+        type: Boolean,
+        default: true
+      }
+    },
+    computed: {
+      isActive() {
+        return this.sortable && this.currentSortColumn === this.column;
+      },
+      sortOrder() {
+        return this.currentSortOrder;
+      }
+    },
+    methods: {
+      sort() {
+        if (!this.sortable) return;
+        this.$emit('sort', this.column);
+      }
+    }
+  }
+  </script>
+  
+  <style scoped>
+  .sortable {
+    cursor: pointer;
+    position: relative;
+    user-select: none;
+  }
+  .sortable:hover {
+    background-color: rgba(0, 0, 0, 0.05);
+  }
+  .sort-icon {
+    margin-left: 5px;
+    font-size: 0.8em;
+  }
+  </style>


### PR DESCRIPTION
Closes #1092 

Added Sortable Headers for Pipeline Table. Users can click on the column names of the Pipeline Table and see the sorted entries in `asc` or `desc` order, And the order is being indicated via arrows facing upwards for `asc` and downwards for `desc`.

I added click handlers to the column headers in the pipeline table with the visual indication of arrows. Also added css styling to make sortable columns look different from the non-sortable.

In backend i extended schema to accept and validate sort parameters like - added `sort_by` field to find which column to sort; `sort_order` to find the direction (`desc` or `asc`).

I added `get_sort_field_and_apply_order` to handle sorting at the database level. And updated `tasks` and `requested _tasks` to use this sorting functionality.


![Screenshot from 2025-04-14 18-50-03](https://github.com/user-attachments/assets/2c50bce8-fc20-4be8-ab84-2eaa963f316f)
![Screenshot from 2025-04-14 18-50-22](https://github.com/user-attachments/assets/67e9d214-aca6-4dfb-b6ff-0c6f14882b58)
![Screenshot from 2025-04-14 18-50-48](https://github.com/user-attachments/assets/7d83cc05-ae9b-4b01-a698-415d2998b10c)
![Screenshot from 2025-04-14 18-51-03](https://github.com/user-attachments/assets/00f6b9e1-d4e0-40c6-96a0-3221459bbe2e)
