### PR TITLE
unnest name only fields

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/fields.py
+++ b/backend/src/zimfarm_backend/common/schemas/fields.py
@@ -95,7 +95,7 @@ ZIMPlatformValue = Annotated[int, Field(gt=0)]
 
 type OptionalZIMPlatformValue = ZIMPlatformValue | None
 
-ZIMLangCode = Annotated[str, Field(min_length=2, max_length=3)]
+ZIMLangCode = Annotated[str, Field(min_length=2, max_length=8)]
 
 type OptionalZIMLangCode = ZIMLangCode | None
 

--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -92,20 +92,12 @@ class TaskFullSchema(BaseTaskSchema):
     upload: dict[str, Any]
 
 
-class NameOnlySchema(BaseModel):
-    """
-    Schema for reading only a name field from a model
-    """
-
-    name: str
-
-
 class ScheduleAwareTaskFullSchema(TaskFullSchema):
     """
     Schema for reading a task model with all fields and its schedule name
     """
 
-    schedule: NameOnlySchema
+    schedule_name: str
 
 
 class BaseRequestedTaskSchema(BaseModel):
@@ -116,7 +108,7 @@ class BaseRequestedTaskSchema(BaseModel):
     priority: int
     schedule_name: str
     original_schedule_name: str
-    worker: NameOnlySchema
+    worker_name: str
     updated_at: datetime.datetime
 
 
@@ -138,7 +130,7 @@ class RequestedTaskFullSchema(BaseRequestedTaskSchema):
     upload: dict[str, Any]
     notification: ScheduleNotificationSchema | None
     rank: int | None = None
-    schedule: NameOnlySchema
+    schedule_name: str
     schedule_id: UUID | None = Field(exclude=True)
 
 
@@ -186,7 +178,7 @@ class ScheduleDurationSchema(BaseModel):
 
     value: int
     on: datetime.datetime
-    worker: NameOnlySchema | None
+    worker_name: str | None
     default: bool
 
 
@@ -224,7 +216,8 @@ class ScheduleFullSchema(BaseModel):
         )
 
     @computed_field
-    def get_duration(self) -> dict[str, Any]:
+    @property
+    def duration(self) -> dict[str, Any]:
         duration_res: dict[str, Any] = {}
         duration_res["available"] = False
         duration_res["default"] = {}
@@ -234,9 +227,9 @@ class ScheduleFullSchema(BaseModel):
                 duration_res["default"] = ScheduleDurationSchema.model_validate(
                     duration
                 ).model_dump(mode="json")
-            if duration.worker:
+            if duration.worker_name:
                 duration_res["available"] = True
-                duration_res["workers"][duration.worker.name] = (
+                duration_res["workers"][duration.worker_name] = (
                     ScheduleDurationSchema.model_validate(duration).model_dump(
                         mode="json"
                     )

--- a/backend/src/zimfarm_backend/db/schedule.py
+++ b/backend/src/zimfarm_backend/db/schedule.py
@@ -22,7 +22,6 @@ from zimfarm_backend.common.schemas.orms import (
     ConfigOfflinerOnlySchema,
     LanguageSchema,
     MostRecentTaskSchema,
-    NameOnlySchema,
     ScheduleDurationSchema,
     ScheduleFullSchema,
     ScheduleLightSchema,
@@ -43,7 +42,7 @@ from zimfarm_backend.db.models import (
 DEFAULT_SCHEDULE_DURATION = ScheduleDurationSchema(
     value=int(constants.DEFAULT_SCHEDULE_DURATION),
     on=datetime.datetime.now(datetime.UTC).replace(tzinfo=None),
-    worker=None,
+    worker_name=None,
     default=True,
 )
 
@@ -85,7 +84,7 @@ def map_duration(duration: ScheduleDuration) -> ScheduleDurationSchema:
     return ScheduleDurationSchema(
         value=duration.value,
         on=duration.on,
-        worker=NameOnlySchema(name=duration.worker.name) if duration.worker else None,
+        worker_name=duration.worker.name if duration.worker else None,
         default=duration.default,
     )
 
@@ -332,11 +331,7 @@ def create_schedule_full_schema(schedule: Schedule) -> ScheduleFullSchema:
             ScheduleDurationSchema(
                 value=duration.value,
                 on=duration.on,
-                worker=(
-                    NameOnlySchema(name=duration.worker.name)
-                    if duration.worker
-                    else None
-                ),
+                worker_name=duration.worker.name if duration.worker else None,
                 default=duration.default,
             )
             for duration in schedule.durations

--- a/backend/src/zimfarm_backend/routes/requested_tasks/logic.py
+++ b/backend/src/zimfarm_backend/routes/requested_tasks/logic.py
@@ -24,7 +24,6 @@ from zimfarm_backend.common.schemas.models import calculate_pagination_metadata
 from zimfarm_backend.common.schemas.orms import (
     ConfigResourcesSchema,
     ConfigWithOnlyOfflinerAndResourcesSchema,
-    NameOnlySchema,
     RequestedTaskFullSchema,
     RequestedTaskLightSchema,
 )
@@ -252,9 +251,7 @@ def get_requested_tasks_for_worker(
                     requested_by=task.requested_by,
                     priority=task.priority,
                     original_schedule_name=task.original_schedule_name,
-                    worker=NameOnlySchema(
-                        name=task.worker_name,
-                    ),
+                    worker_name=task.worker_name,
                     updated_at=task.updated_at,
                 ),
             ]

--- a/backend/src/zimfarm_backend/routes/users/models.py
+++ b/backend/src/zimfarm_backend/routes/users/models.py
@@ -22,7 +22,7 @@ class UserSchema(BaseUserSchema):
     """
 
     email: str | None
-    scope: dict[str, Any] | None = Field(default=None, exclude=True)
+    scope: dict[str, Any] | None = Field(default=None)
 
     @computed_field
     @property

--- a/backend/tests/db/test_requested_task.py
+++ b/backend/tests/db/test_requested_task.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session as OrmSession
 from zimfarm_backend.common import getnow
 from zimfarm_backend.common.enums import TaskStatus
 from zimfarm_backend.common.schemas.models import ScheduleConfigSchema
-from zimfarm_backend.common.schemas.orms import NameOnlySchema, ScheduleDurationSchema
+from zimfarm_backend.common.schemas.orms import ScheduleDurationSchema
 from zimfarm_backend.db.exceptions import RecordDoesNotExistError
 from zimfarm_backend.db.models import RequestedTask, Schedule, Task, User, Worker
 from zimfarm_backend.db.requested_task import (
@@ -379,7 +379,7 @@ def test_get_requested_tasks(
         assert task.status == requested_task.status
         assert task.requested_by == requested_task.requested_by
         assert (
-            task.worker.name
+            task.worker_name
             == requested_task.worker.name  # pyright: ignore[reportOptionalMemberAccess]
         )
 
@@ -530,7 +530,7 @@ def test_does_platform_allow_worker_to_run(
             value=3600,
             on=getnow(),
             default=True,
-            worker=NameOnlySchema(name=worker.name),
+            worker_name=worker.name,
         ),
         updated_at=getnow(),
     )
@@ -553,7 +553,7 @@ def test_does_platform_allow_worker_to_run(
             value=3600,
             on=getnow(),
             default=True,
-            worker=NameOnlySchema(name=worker.name),
+            worker_name=worker.name,
         ),
         remaining=1800,
         eta=getnow(),

--- a/backend/tests/db/test_schedule.py
+++ b/backend/tests/db/test_schedule.py
@@ -64,7 +64,7 @@ def test_get_schedule_duration_default(dbsession: OrmSession, worker: Worker):
         dbsession, schedule_name="nonexistent", worker=worker
     )
     assert duration.value > 0
-    assert duration.worker is None
+    assert duration.worker_name is None
     assert isinstance(duration.on, datetime.datetime)
 
 
@@ -79,8 +79,8 @@ def test_get_schedule_duration_with_worker(
         dbsession, schedule_name=schedule.name, worker=worker
     )
     assert duration.value == schedule.durations[0].value
-    assert duration.worker is not None
-    assert duration.worker.name == worker.name
+    assert duration.worker_name is not None
+    assert duration.worker_name == worker.name
     assert duration.on == schedule.durations[0].on
 
 

--- a/backend/tests/routes/test_user.py
+++ b/backend/tests/routes/test_user.py
@@ -29,7 +29,7 @@ def test_list_users_no_param(client: TestClient, users: list[User]):
     assert response_json["meta"]["count"] == 5
     assert len(response_json["items"]) == len(users)
     for item in response_json["items"]:
-        assert set(item.keys()) == {"username", "email", "role"}
+        assert set(item.keys()) == {"username", "email", "role", "scope"}
 
 
 @pytest.mark.parametrize("skip, limit, expected", [(0, 1, 1), (1, 10, 4), (0, 100, 5)])


### PR DESCRIPTION
## Changes
- some fields are nested and contain only a `name`. move them to top level where they are defined
- include user scope details in API response as it is used by the frontend
