### PR TITLE
delegate retrieval of service to auth store

### DIFF
--- a/frontend-ui/src/App.vue
+++ b/frontend-ui/src/App.vue
@@ -86,7 +86,7 @@ const navigationItems: NavigationItem[] = [
 ]
 
 const handleSignOut = () => {
-  authStore.removeTokenFromCookie()
+  authStore.logout()
   router.push({ name: 'home' })
 }
 </script>

--- a/frontend-ui/src/stores/language.ts
+++ b/frontend-ui/src/stores/language.ts
@@ -1,31 +1,23 @@
-import type { Config } from '@/config'
-import constants from '@/constants'
 import { useLoadingStore } from '@/stores/loading'
 import type { ListResponse } from '@/types/base'
 import type { ErrorResponse } from '@/types/errors'
 import { type Language } from '@/types/language'
 import { translateErrors } from '@/utils/errors'
-import httpRequest from '@/utils/httpRequest'
 import { defineStore } from 'pinia'
-import { inject, ref } from 'vue'
+import { ref } from 'vue'
+import { useAuthStore } from './auth'
 
 export const useLanguageStore = defineStore('language', () => {
   const languages = ref<Language[]>([])
   const error = ref<string[]>([])
   const loadingStore = useLoadingStore()
-  const config = inject<Config>(constants.config)
+  const authStore = useAuthStore()
 
-  if (!config) {
-    throw new Error('Config is not defined')
-  }
-
-  const service = httpRequest({
-    baseURL: `${config.ZIMFARM_WEBAPI}/languages`,
-  })
 
   const fetchLanguages = async (limit: number = 100) => {
     try {
       loadingStore.startLoading('Fetching languages...')
+      const service = await authStore.getApiService('languages')
       const response = await service.get<null, ListResponse<Language>>('', { params: { limit } })
       languages.value = response.items
     } catch (_error) {

--- a/frontend-ui/src/stores/offliner.ts
+++ b/frontend-ui/src/stores/offliner.ts
@@ -1,28 +1,20 @@
-import type { Config } from '@/config'
-import constants from '@/constants'
 import type { ListResponse } from '@/types/base'
 import type { ErrorResponse } from '@/types/errors'
 import { translateErrors } from '@/utils/errors'
-import httpRequest from '@/utils/httpRequest'
 import { defineStore } from 'pinia'
-import { inject, ref } from 'vue'
+import { ref } from 'vue'
+import { useAuthStore } from './auth'
 
 export const useOfflinerStore = defineStore('offliner', () => {
   const offliners = ref<string[]>([])
   const error = ref<string[]>([])
 
-  const config = inject<Config>(constants.config)
+  const authStore = useAuthStore()
 
-  if (!config) {
-    throw new Error('Config is not defined')
-  }
-
-  const service = httpRequest({
-    baseURL: `${config.ZIMFARM_WEBAPI}/offliners`,
-  })
 
   const fetchOffliners = async (limit: number = 100) => {
     try {
+      const service = await authStore.getApiService('offliners')
       const response = await service.get<null, ListResponse<string>>('', { params: { limit } })
       offliners.value = response.items
     } catch (_error) {

--- a/frontend-ui/src/stores/platform.ts
+++ b/frontend-ui/src/stores/platform.ts
@@ -1,27 +1,19 @@
-import type { Config } from '@/config'
-import constants from '@/constants'
 import { useLoadingStore } from '@/stores/loading'
 import type { ListResponse } from '@/types/base'
-import httpRequest from '@/utils/httpRequest'
 import { defineStore } from 'pinia'
-import { inject, ref } from 'vue'
+import { ref } from 'vue'
+import { useAuthStore } from './auth'
 export const usePlatformStore = defineStore('platform', () => {
   const platforms = ref<string[]>([])
   const error = ref<Error | null>(null)
 
-  const config = inject<Config>(constants.config)
   const loadingStore = useLoadingStore()
-  if (!config) {
-    throw new Error('Config is not defined')
-  }
-
-  const service = httpRequest({
-    baseURL: `${config.ZIMFARM_WEBAPI}/platforms`,
-  })
+  const authStore = useAuthStore()
 
   const fetchPlatforms = async (limit: number = 100) => {
     try {
       loadingStore.startLoading('Fetching platforms...')
+      const service = await authStore.getApiService('platforms')
       const response = await service.get<null, ListResponse<string>>('', { params: { limit } })
       platforms.value = response.items
     } catch (_error) {

--- a/frontend-ui/src/stores/schedule.ts
+++ b/frontend-ui/src/stores/schedule.ts
@@ -1,30 +1,19 @@
-import type { Config } from '@/config'
-import constants from '@/constants'
+import { useAuthStore } from '@/stores/auth'
 import type { ErrorResponse } from '@/types/errors'
 import type { Schedule } from '@/types/schedule'
 import { translateErrors } from '@/utils/errors'
-import httpRequest from '@/utils/httpRequest'
 import { defineStore } from 'pinia'
-import { inject, ref } from 'vue'
-
+import { ref } from 'vue'
 export const useScheduleStore = defineStore('schedule', () => {
   const schedule = ref<Schedule | null>(null)
   const error = ref<string[]>([])
-
-  const config = inject<Config>(constants.config)
-
-  if (!config) {
-    throw new Error('Config is not defined')
-  }
-
-  const service = httpRequest({
-    baseURL: `${config.ZIMFARM_WEBAPI}/schedules`,
-  })
+  const authStore = useAuthStore()
 
   const fetchSchedule = async (
     scheduleName: string,
     forceReload: boolean = false,
   ) => {
+    const service = await authStore.getApiService('schedules')
     // Check if we already have the schedule and don't need to force reload
     if (!forceReload && schedule.value && schedule.value.name === scheduleName) {
       return

--- a/frontend-ui/src/stores/tag.ts
+++ b/frontend-ui/src/stores/tag.ts
@@ -1,29 +1,20 @@
-import type { Config } from '@/config'
-import constants from '@/constants'
+import { useAuthStore } from '@/stores/auth'
 import { useLoadingStore } from '@/stores/loading'
 import type { ListResponse } from '@/types/base'
-import httpRequest from '@/utils/httpRequest'
 import { defineStore } from 'pinia'
-import { inject, ref } from 'vue'
+import { ref } from 'vue'
 
 export const useTagStore = defineStore('tag', () => {
   const tags = ref<string[]>([])
   const error = ref<Error | null>(null)
 
-  const config = inject<Config>(constants.config)
-  if (!config) {
-    throw new Error('Config is not defined')
-  }
-
-  const service = httpRequest({
-    baseURL: `${config.ZIMFARM_WEBAPI}/tags`,
-  })
-
+  const authStore = useAuthStore()
   const loadingStore = useLoadingStore()
 
   const fetchTags = async (limit: number = 100) => {
     try {
       loadingStore.startLoading('Fetching tags...')
+      const service = await authStore.getApiService('tags')
       const response = await service.get<null, ListResponse<string>>('', { params: { limit } })
       tags.value = response.items
     } catch (_error) {


### PR DESCRIPTION
## Changes

- delegate retrieval of api service to auth store. The auth store refreshes the token (if it's expired) before returning the api caller to the caller. This centralizes token management and cookie management to the auth store.
