### PR TITLE
Sotoki recipe name must start with domain name, not only contain it

### DIFF
--- a/watcher/watcher.py
+++ b/watcher/watcher.py
@@ -331,8 +331,11 @@ class WatcherRunner:
             logger.error(f"Can't get `{domain}` schedules from zimfarm")
             return True
 
+        # filter by recipe name exactly starting with domain name, since API call
+        # search for the domain "anywhere" in the recipe name
         return [
-            recipe["name"] for recipe in payload.get("items", []) if recipe["enabled"]
+            recipe["name"] for recipe in payload.get("items", [])
+            if recipe["enabled"] and recipe["name"].startswith(f"{domain}_")
         ]
 
     def blocked_by_zimfarm(self, domain):


### PR DESCRIPTION
When SE dumps is `ai.stackexchange.com`, the watcher is requesting https://farm.openzim.org/recipes/ai.stackexchange.com_en (correct) and https://farm.openzim.org/recipes/genai.stackexchange.com_en (mistake)

This is fixing this situation.