### PR TITLE
Fix v2 API path now that it has moved

### DIFF
--- a/backend/V1_TO_V2_MIGRATION.md
+++ b/backend/V1_TO_V2_MIGRATION.md
@@ -56,7 +56,7 @@ Zimfarm Backend v2 represents a significant modernization of the codebase, migra
 - Accepted a mixture of formats (form, json, headers) for authentication
 
 **v2:**
-- API prefix: `/api/v2`
+- API prefix: `/v2`
 - Accepts json for authentication payload with support for SSH authentication via headers
 - Changed schema to create a schedule (see openAPI docs for change in payload shape)
 


### PR DESCRIPTION
Looks like I forgot to ask you to update documentation.

Did I missed something else?