### PR TITLE
define __init__ for workers

### DIFF
--- a/worker/pyproject.toml
+++ b/worker/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
     "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",
 ]
 dependencies = [
-    "paramiko == 3.5.1",
     "PyJWT == 2.10.1",
     "humanfriendly == 10.0",
     "cryptography == 45.0.3",

--- a/worker/src/common/cryptography.py
+++ b/worker/src/common/cryptography.py
@@ -1,12 +1,13 @@
 import base64
 import datetime
+from base64 import encodebytes
 from dataclasses import dataclass
 from pathlib import Path
 
 from cryptography.exceptions import UnsupportedAlgorithm
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding
-from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
 from cryptography.hazmat.primitives.asymmetric.types import (
     PrivateKeyTypes,
 )
@@ -46,6 +47,14 @@ def load_private_key_from_path(private_key_fpath: Path) -> RSAPrivateKey:
     if not isinstance(private_key, RSAPrivateKey):
         raise ValueError("Key is not an RSA private key")
     return private_key
+
+
+def get_public_key_fingerprint(public_key: RSAPublicKey) -> str:
+    """Compute the SHA256 fingerprint of a public key."""
+    # Modified from: https://github.com/paramiko/paramiko/blob/2af0dd788d8e97dff51212baed2d870abf3b38eb/paramiko/pkey.py#L357-L369
+    hashy = serialization.ssh_key_fingerprint(public_key, hashes.SHA256())
+    cleaned = encodebytes(hashy).decode("utf8").strip().rstrip("=")
+    return f"SHA256:{cleaned}"
 
 
 def get_signature(message: str, private_key: RSAPrivateKey) -> str:


### PR DESCRIPTION
## Changes
- remove paramiko as dependency and compute fingerprint directly
- define `__init__` for workers so it's clear how instance attributes are set
- change annotation for webapi uri's from urllib ParseResult to str as there are lots of calls to `get_uri()` and there are only a couple of places where the attributes of the webapi (like netloc) are used.
- make dataclasses to be `kw_only` so it's obvious how they are constructed.
- move `can_stream_logs` from `BaseWorker` to `TaskWorker` as it relies on attributes set by the `TaskWorker` and not really the `WorkerManager`
