### PR TITLE
use starlette client host as fallback ip when x-forwarded-for missing

### DIFF
--- a/backend/src/zimfarm_backend/common/constants.py
+++ b/backend/src/zimfarm_backend/common/constants.py
@@ -103,8 +103,12 @@ SECRET_REPLACEMENT = "--------"  # nosec
 # using the following, it is possible to automate
 # the update of a whitelist of workers IPs on Wasabi (S3 provider)
 # enable this feature (default is off)
-USES_WORKERS_IPS_WHITELIST = bool(getenv("USES_WORKERS_IPS_WHITELIST", default=False))
-MAX_WORKER_IP_CHANGES_PER_DAY = 4
+USES_WORKERS_IPS_WHITELIST = (
+    getenv("USES_WORKERS_IPS_WHITELIST", default="false").lower() == "true"
+)
+MAX_WORKER_IP_CHANGES_PER_DAY = int(
+    getenv("MAX_WORKER_IP_CHANGES_PER_DAY", default="4")
+)
 # wasabi URL with credentials to update policy
 WASABI_URL = getenv("WASABI_URL", default="")
 # policy ARN such as arn:aws:iam::xxxxxxxxxxxx:policy/yyyyyyyy

--- a/backend/src/zimfarm_backend/common/schemas/models.py
+++ b/backend/src/zimfarm_backend/common/schemas/models.py
@@ -21,7 +21,6 @@ from zimfarm_backend.common.schemas.fields import (
     ZIMDisk,
     ZIMLangCode,
     ZIMMemory,
-    ZIMPlatformValue,
 )
 from zimfarm_backend.common.schemas.offliners import (
     DevDocsFlagsSchema,
@@ -129,15 +128,6 @@ class ScheduleNotificationSchema(BaseModel):
     requested: EventNotificationSchema | None = None
     started: EventNotificationSchema | None = None
     ended: EventNotificationSchema | None = None
-
-
-class PlaftormLimitSchema(BaseModel):
-    platform: PlatformField
-    limit: ZIMPlatformValue
-
-
-class PlatformsLimitSchema(BaseModel):
-    limits: list[PlaftormLimitSchema]
 
 
 class Paginator(BaseModel):

--- a/backend/src/zimfarm_backend/db/worker.py
+++ b/backend/src/zimfarm_backend/db/worker.py
@@ -8,7 +8,6 @@ from sqlalchemy.orm import Session as OrmSession
 from zimfarm_backend.common import getnow
 from zimfarm_backend.common.enums import Offliner
 from zimfarm_backend.common.schemas import BaseModel
-from zimfarm_backend.common.schemas.models import PlatformsLimitSchema
 from zimfarm_backend.common.schemas.orms import ConfigResourcesSchema, WorkerLightSchema
 from zimfarm_backend.db.exceptions import RecordDoesNotExistError
 from zimfarm_backend.db.models import User, Worker
@@ -99,7 +98,7 @@ def check_in_worker(
     disk: int,
     selfish: bool,
     offliners: list[Offliner],
-    platforms: PlatformsLimitSchema | None = None,
+    platforms: dict[str, int] | None = None,
     user_id: UUID,
 ) -> None:
     """Check in a worker."""
@@ -110,7 +109,7 @@ def check_in_worker(
         memory=memory,
         disk=disk,
         offliners=offliners,
-        platforms=platforms.model_dump(mode="json") if platforms else {},
+        platforms=platforms if platforms is not None else {},
         last_ip=None,
         last_seen=getnow(),
         user_id=user_id,

--- a/backend/src/zimfarm_backend/routes/tasks/logic.py
+++ b/backend/src/zimfarm_backend/routes/tasks/logic.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Depends, Path, Query, Response
 from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session
 
+from zimfarm_backend import logger
 from zimfarm_backend.common.constants import ENABLED_SCHEDULER
 from zimfarm_backend.common.enums import TaskStatus
 from zimfarm_backend.common.schemas.fields import LimitFieldMax200, SkipField
@@ -176,6 +177,7 @@ async def update_task(
             db_session, task.id, task_update_schema.event, task_update_schema.payload
         )
     except Exception as exc:
+        logger.exception("Unexpected error while updating task.")
         raise ServerError("Unable to update task.") from exc
 
     return Response(status_code=HTTPStatus.NO_CONTENT)

--- a/backend/src/zimfarm_backend/routes/workers/models.py
+++ b/backend/src/zimfarm_backend/routes/workers/models.py
@@ -5,7 +5,6 @@ from zimfarm_backend.common.schemas.fields import (
     ZIMDisk,
     ZIMMemory,
 )
-from zimfarm_backend.common.schemas.models import PlatformsLimitSchema
 
 
 class WorkerCheckInSchema(BaseModel):
@@ -18,4 +17,4 @@ class WorkerCheckInSchema(BaseModel):
     memory: ZIMMemory
     disk: ZIMDisk
     offliners: list[Offliner]
-    platforms: PlatformsLimitSchema | None = None  # pyright: ignore
+    platforms: dict[str, int] | None = None  # mapping of platforms to max tasks

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -22,8 +22,6 @@ from zimfarm_backend.common.schemas.models import (
     DockerImageName,
     DockerImageSchema,
     LanguageSchema,
-    PlaftormLimitSchema,
-    PlatformsLimitSchema,
     ResourcesSchema,
     ScheduleConfigSchema,
 )
@@ -207,23 +205,15 @@ def create_worker(dbsession: OrmSession, user: User) -> Callable[..., Worker]:
         memory: int = 1024,
         disk: int = 1024,
         offliners: list[str] | None = None,
-        platforms: PlatformsLimitSchema | None = None,
+        platforms: dict[str, int] | None = None,
         last_seen: datetime.datetime | None = None,
         last_ip: IPv4Address | None = None,
         deleted: bool = False,
     ) -> Worker:
-        _platforms = platforms or PlatformsLimitSchema(
-            limits=[
-                PlaftormLimitSchema(
-                    platform=Platform.wikimedia,
-                    limit=100,
-                ),
-                PlaftormLimitSchema(
-                    platform=Platform.youtube,
-                    limit=100,
-                ),
-            ]
-        )
+        _platforms = platforms or {
+            Platform.wikimedia: 100,
+            Platform.youtube: 100,
+        }
 
         _ip = last_ip or IPv4Address("127.0.0.1")
 
@@ -234,7 +224,7 @@ def create_worker(dbsession: OrmSession, user: User) -> Callable[..., Worker]:
             memory=memory,
             disk=disk,
             offliners=offliners or ["mwoffliner", "youtube"],
-            platforms=_platforms.model_dump(mode="json"),
+            platforms=_platforms,
             last_seen=last_seen or getnow(),
             last_ip=_ip,
             deleted=deleted,

--- a/backend/tests/db/test_worker.py
+++ b/backend/tests/db/test_worker.py
@@ -5,7 +5,6 @@ import pytest
 from sqlalchemy.orm import Session as OrmSession
 
 from zimfarm_backend.common.enums import Offliner
-from zimfarm_backend.common.schemas.models import PlatformsLimitSchema
 from zimfarm_backend.db.exceptions import RecordDoesNotExistError
 from zimfarm_backend.db.models import User, Worker
 from zimfarm_backend.db.worker import (
@@ -123,7 +122,7 @@ def test_check_in_worker_update(dbsession: OrmSession, worker: Worker):
         disk=4096,
         selfish=True,
         offliners=[Offliner.mwoffliner, Offliner.youtube],
-        platforms=PlatformsLimitSchema.model_validate(worker.platforms),
+        platforms=worker.platforms,
         user_id=worker.user_id,
     )
     original_last_seen = worker.last_seen

--- a/backend/tests/routes/test_requested_task.py
+++ b/backend/tests/routes/test_requested_task.py
@@ -1,12 +1,16 @@
 from collections.abc import Callable
 from http import HTTPStatus
+from ipaddress import IPv4Address
 
 import pytest
 from fastapi.testclient import TestClient
+from pytest import MonkeyPatch
 from sqlalchemy.orm import Session as OrmSession
 
 from zimfarm_backend.common.roles import RoleEnum
 from zimfarm_backend.db.models import RequestedTask, Schedule, User, Worker
+from zimfarm_backend.db.worker import get_worker
+from zimfarm_backend.routes.requested_tasks import logic
 from zimfarm_backend.utils.token import generate_access_token
 
 
@@ -97,18 +101,14 @@ def test_get_requested_tasks_success(
     assert len(data["items"]) == 5
 
 
-@pytest.mark.skip(
-    reason="The route calls commit on the db session, which is not supported in tests"
-)
-def test_get_requested_tasks_for_worker_success(
+def test_get_requested_tasks_for_worker_scheduler_disabled(
     client: TestClient,
     access_token: str,
-    create_requested_task: Callable[..., RequestedTask],
     worker: Worker,
+    monkeypatch: MonkeyPatch,
 ):
-    """Test successful retrieval of requested tasks for a worker"""
-    # Create a task for the worker
-    create_requested_task(worker=worker)
+    """Test that response is empty when scheduler is disabled"""
+    monkeypatch.setattr(logic, "ENABLED_SCHEDULER", False)
 
     response = client.get(
         f"/v2/requested-tasks/worker?worker_name={worker.name}&avail_cpu={worker.cpu}&avail_memory={worker.memory}&avail_disk={worker.disk}",
@@ -121,9 +121,167 @@ def test_get_requested_tasks_for_worker_success(
     data = response.json()
     assert "items" in data
     assert "meta" in data
-    assert "count" in data["meta"]
-    assert data["meta"]["count"] == 1
-    assert len(data["items"]) == 1
+    assert data["meta"]["count"] == 0
+    assert len(data["items"]) == 0
+
+
+def test_get_requested_tasks_for_worker_worker_not_found(
+    client: TestClient,
+    access_token: str,
+):
+    response = client.get(
+        "/v2/requested-tasks/worker?worker_name=nonexistent-worker&avail_cpu=2&avail_memory=1024&avail_disk=1024",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Forwarded-For": "127.0.0.1",
+        },
+    )
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_get_requested_tasks_for_worker_success_no_ip_change(
+    client: TestClient,
+    access_token: str,
+    dbsession: OrmSession,
+    create_requested_task: Callable[..., RequestedTask],
+    worker: Worker,
+    monkeypatch: MonkeyPatch,
+):
+    """Test successful retrieval of requested tasks for a worker with no IP change"""
+    # Create a task for the worker
+    create_requested_task(worker=worker)
+
+    # Mock record_ip_change to avoid external service calls
+    def mock_record_ip_change(session: OrmSession, worker_name: str) -> None:
+        pass
+
+    monkeypatch.setattr(
+        logic,
+        "record_ip_change",
+        mock_record_ip_change,
+    )
+
+    worker.last_ip = IPv4Address("127.0.0.1")
+    dbsession.add(worker)
+    dbsession.flush()
+
+    response = client.get(
+        f"/v2/requested-tasks/worker?worker_name={worker.name}&avail_cpu={worker.cpu}&avail_memory={worker.memory}&avail_disk={worker.disk}",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Forwarded-For": str(worker.last_ip) if worker.last_ip else "127.0.0.1",
+        },
+    )
+    assert response.status_code == HTTPStatus.OK
+    dbsession.expire(worker)
+    worker = get_worker(dbsession, worker_name=worker.name)
+    assert worker.last_ip == IPv4Address("127.0.0.1")
+
+
+def test_get_requested_tasks_for_worker_success_with_ip_change(
+    client: TestClient,
+    access_token: str,
+    create_requested_task: Callable[..., RequestedTask],
+    worker: Worker,
+    dbsession: OrmSession,
+    monkeypatch: MonkeyPatch,
+):
+    """Test successful retrieval of requested tasks for a worker with IP change"""
+    # Create a task for the worker
+    create_requested_task(worker=worker)
+
+    # Mock record_ip_change to avoid external service calls
+    def mock_record_ip_change(session: OrmSession, worker_name: str) -> None:
+        pass
+
+    monkeypatch.setattr(
+        logic,
+        "record_ip_change",
+        mock_record_ip_change,
+    )
+    monkeypatch.setattr(logic, "USES_WORKERS_IPS_WHITELIST", True)
+
+    new_ip = "192.168.1.100"
+    response = client.get(
+        f"/v2/requested-tasks/worker?worker_name={worker.name}&avail_cpu={worker.cpu}&avail_memory={worker.memory}&avail_disk={worker.disk}",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Forwarded-For": new_ip,
+        },
+    )
+    assert response.status_code == HTTPStatus.OK
+    dbsession.expire(worker)
+    worker = get_worker(dbsession, worker_name=worker.name)
+    assert str(worker.last_ip) == new_ip
+
+
+def test_get_requested_tasks_for_worker_ip_change_exception(
+    client: TestClient,
+    access_token: str,
+    create_requested_task: Callable[..., RequestedTask],
+    worker: Worker,
+    dbsession: OrmSession,
+    monkeypatch: MonkeyPatch,
+):
+    """Test that get_requested_tasks_for_worker handles IP change exceptions properly"""
+    # Create a task for the worker
+    create_requested_task(worker=worker)
+
+    # Mock record_ip_change to raise an exception
+    def mock_record_ip_change(session: OrmSession, worker_name: str) -> None:  #  noqa
+        raise Exception("Wasabi connection failed")
+
+    monkeypatch.setattr(
+        logic,
+        "record_ip_change",
+        mock_record_ip_change,
+    )
+    monkeypatch.setattr(logic, "USES_WORKERS_IPS_WHITELIST", True)
+
+    new_ip = "192.168.1.100"
+    response = client.get(
+        f"/v2/requested-tasks/worker?worker_name={worker.name}&avail_cpu={worker.cpu}&avail_memory={worker.memory}&avail_disk={worker.disk}",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Forwarded-For": new_ip,
+        },
+    )
+    assert response.status_code == HTTPStatus.SERVICE_UNAVAILABLE
+    # Even though exception was raised, assert that the new ip was recorded
+    dbsession.expire(worker)
+    worker = get_worker(dbsession, worker_name=worker.name)
+    assert str(worker.last_ip) == new_ip
+
+
+def test_get_requested_tasks_for_worker_no_tasks_available(
+    client: TestClient,
+    access_token: str,
+    worker: Worker,
+    monkeypatch: MonkeyPatch,
+):
+    # Mock record_ip_change to avoid external service calls
+    def mock_record_ip_change(session: OrmSession, worker_name: str) -> None:
+        pass
+
+    monkeypatch.setattr(
+        logic,
+        "record_ip_change",
+        mock_record_ip_change,
+    )
+
+    response = client.get(
+        f"/v2/requested-tasks/worker?worker_name={worker.name}&avail_cpu={worker.cpu}&avail_memory={worker.memory}&avail_disk={worker.disk}",
+        headers={
+            "Authorization": f"Bearer {access_token}",
+            "X-Forwarded-For": "127.0.0.1",
+        },
+    )
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    assert "items" in data
+    assert "meta" in data
+    assert data["meta"]["count"] == 0
+    assert len(data["items"]) == 0
 
 
 @pytest.mark.parametrize("hide_secrets", ["true", "false"])


### PR DESCRIPTION
## Changes

- use client host from starlette in case x-forwarded-for header is missing
- remove session.commit() and catch exception instead if exception is thrown while updating ip on wasabi

