### PR TITLE
Relax language schema validation while reading from db

### DIFF
--- a/backend/src/zimfarm_backend/db/language.py
+++ b/backend/src/zimfarm_backend/db/language.py
@@ -32,16 +32,22 @@ def get_languages(
 
     return LanguageListResult(
         nb_languages=count_from_stmt(session, query),
-        languages=[
-            LanguageSchema(
-                code=language_code,
-                name_en=language_name_en,
-                name_native=language_name_native,
-            )
-            for (
-                language_code,
-                language_name_en,
-                language_name_native,
-            ) in session.execute(query.offset(skip).limit(limit)).all()
-        ],
+        languages=sorted(
+            [
+                LanguageSchema.model_validate(
+                    {
+                        "code": language_code,
+                        "name_en": language_name_en,
+                        "name_native": language_name_native,
+                    },
+                    context={"skip_validation": True},
+                )
+                for (
+                    language_code,
+                    language_name_en,
+                    language_name_native,
+                ) in session.execute(query.offset(skip).limit(limit)).all()
+            ],
+            key=lambda language: (language.name_en, language.code),
+        ),
     )

--- a/frontend-ui/src/stores/language.ts
+++ b/frontend-ui/src/stores/language.ts
@@ -12,7 +12,7 @@ export const useLanguageStore = defineStore('language', () => {
   const authStore = useAuthStore()
 
 
-  const fetchLanguages = async (limit: number = 100) => {
+  const fetchLanguages = async (limit: number = 400) => {
     if (languages.value.length > 0) {
       return languages.value
     }


### PR DESCRIPTION
## Changes
- skip language schema validation while reading from db
- sort by language name in english so frontend dropdown language list is ordered. can not sort in the db as the `distinct on` requires the first column to be the same as that used in `order_by`
- change frontend limit to 400 (same as original limit used by old UI)
