### PR TITLE
serialize datetime with Z suffix for naive datetimes

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/__init__.py
+++ b/backend/src/zimfarm_backend/common/schemas/__init__.py
@@ -1,11 +1,23 @@
+import datetime
+
 import pydantic
 from pydantic import ConfigDict
 from pydantic.alias_generators import to_camel
 
 
+def serialize_datetime(value: datetime.datetime) -> str:
+    """Serialize datetime with 'Z' suffix for naive datetimes"""
+    if value.tzinfo is None:
+        return value.isoformat() + "Z"
+    return value.isoformat()
+
+
 class BaseModel(pydantic.BaseModel):
     model_config = ConfigDict(
-        use_enum_values=True, from_attributes=True, populate_by_name=True
+        use_enum_values=True,
+        from_attributes=True,
+        populate_by_name=True,
+        json_encoders={datetime.datetime: serialize_datetime},
     )
 
 
@@ -15,6 +27,7 @@ class CamelModel(pydantic.BaseModel):
         populate_by_name=True,
         from_attributes=True,
         alias_generator=to_camel,
+        json_encoders={datetime.datetime: serialize_datetime},
     )
 
 
@@ -27,4 +40,5 @@ class DashModel(pydantic.BaseModel):
         populate_by_name=True,
         alias_generator=to_kebab_case,
         use_enum_values=True,
+        json_encoders={datetime.datetime: serialize_datetime},
     )

--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -83,7 +83,7 @@ class TaskFullSchema(BaseTaskSchema):
     """
 
     config: ExpandedScheduleConfigSchema
-    events: list[dict[str, Any]]
+    events: list[dict[str, str | datetime.datetime]]
     debug: dict[str, Any]
     requested_by: str
     canceled_by: str | None
@@ -126,7 +126,7 @@ class RequestedTaskFullSchema(BaseRequestedTaskSchema):
     """
 
     config: ExpandedScheduleConfigSchema
-    events: list[dict[str, Any]]
+    events: list[dict[str, str | datetime.datetime]]
     upload: dict[str, Any]
     notification: ScheduleNotificationSchema | None
     rank: int | None = None
@@ -209,10 +209,13 @@ class ScheduleFullSchema(BaseModel):
     @computed_field
     @property
     def language(self) -> LanguageSchema:
-        return LanguageSchema(
-            code=self.language_code,
-            name_en=self.language_name_en,
-            name_native=self.language_name_native,
+        return LanguageSchema.model_validate(
+            {
+                "code": self.language_code,
+                "name_en": self.language_name_en,
+                "name_native": self.language_name_native,
+            },
+            context={"skip_validation": True},
         )
 
     @computed_field

--- a/backend/src/zimfarm_backend/db/schedule.py
+++ b/backend/src/zimfarm_backend/db/schedule.py
@@ -277,10 +277,13 @@ def get_schedules(
                 name=schedule_name,
                 category=category,
                 enabled=enabled,
-                language=LanguageSchema(
-                    code=language_code,
-                    name_en=language_name_en,
-                    name_native=language_name_native,
+                language=LanguageSchema.model_validate(
+                    {
+                        "code": language_code,
+                        "name_en": language_name_en,
+                        "name_native": language_name_native,
+                    },
+                    context={"skip_validation": True},
                 ),
                 config=ConfigOfflinerOnlySchema(
                     offliner=config["offliner"]["offliner_id"],


### PR DESCRIPTION
## Changes
 - add `Z` suffix to datetime naive objects during serialization. This mimicks the same functionality provided by the `ZimfarmJSONEncoder` at  https://github.com/openzim/zimfarm/blob/200daaec43207519f9ebbf9b6bc6a14d3f5294df/dispatcher/backend/src/main.py#L36
 
 - relax language validation constraints  while reading schedules from db
 
 This closes #1201 as part of the zimfarm upgrade