### PR TITLE
use vuetify server side tables to render data from API

### DIFF
--- a/frontend-ui/src/App.vue
+++ b/frontend-ui/src/App.vue
@@ -28,6 +28,8 @@ onBeforeMount(async () => {
 })
 
 onMounted(async () => {
+  loadingStore.startLoading('Loading application data...')
+
   await languageStore.fetchLanguages()
   await tagStore.fetchTags()
   await platformStore.fetchPlatforms()
@@ -39,6 +41,7 @@ onMounted(async () => {
   })
   await Promise.all(offlinerDefinitionRequests)
 
+  loadingStore.stopLoading()
 })
 
 // Navigation items logic

--- a/frontend-ui/src/main.ts
+++ b/frontend-ui/src/main.ts
@@ -1,22 +1,22 @@
 import '@mdi/font/css/materialdesignicons.css'; // Ensure you are using css-loader
 
-import { createApp } from 'vue'
+import { createApp } from 'vue';
 // Vuetify
-import { createVuetify } from 'vuetify'
-import * as components from 'vuetify/components'
-import * as directives from 'vuetify/directives'
-import 'vuetify/styles'
+import { createVuetify } from 'vuetify';
+import * as components from 'vuetify/components';
+import * as directives from 'vuetify/directives';
+import 'vuetify/styles';
 
-import { createPinia } from 'pinia'
-import VueCookies from 'vue-cookies'
+import { createPinia } from 'pinia';
+import VueCookies from 'vue-cookies';
 
 // config
-import getConfig, { configPlugin } from './config'
+import getConfig, { configPlugin } from '@/config';
 
-import router from '@/router'
+import router from '@/router';
 
-import App from '@/App.vue'
-import constants from '@/constants'
+import App from '@/App.vue';
+import constants from '@/constants';
 
 const app = createApp(App)
 

--- a/frontend-ui/src/router/index.ts
+++ b/frontend-ui/src/router/index.ts
@@ -9,6 +9,7 @@ import TaskDetailView from '@/views/TaskDetailView.vue'
 import UsersView from '@/views/UsersView.vue'
 import UserView from '@/views/UserView.vue'
 import WorkersView from '@/views/WorkersView.vue'
+import type { RouteLocationNormalized } from 'vue-router'
 import { createRouter, createWebHistory } from 'vue-router'
 
 const routes = [
@@ -21,28 +22,35 @@ const routes = [
     path: '/pipeline',
     name: 'pipeline',
     component: PipelineView,
+    meta: { title: 'Zimfarm | Pipeline' }
   },
   {
     path: '/support-us',
     name: 'support',
     component: SupportUsView,
+    meta: { title: 'Zimfarm | Support Us' }
   },
   {
     path: '/sign-in',
     name: 'sign-in',
     component: SignInView,
+    meta: { title: 'Zimfarm | Sign In' }
   },
   {
     path: '/change-password',
     name: 'change-password',
     component: ChangePasswordView,
+    meta: { title: 'Zimfarm | Change Password' }
   },
 
   {
-    path: '/tasks/:id',
+    path: '/pipeline/:id',
     name: 'task-detail',
     component: TaskDetailView,
     props: true,
+    meta: {
+      title: (to: RouteLocationNormalized) => `Zimfarm | Task • ${to.params.id}`
+    }
   },
 
   {
@@ -50,6 +58,9 @@ const routes = [
     name: 'task-detail-tab',
     component: TaskDetailView,
     props: true,
+    meta: {
+      title: (to: RouteLocationNormalized) => `Zimfarm | Task • ${to.params.id}`
+    }
   },
 
   {
@@ -57,50 +68,83 @@ const routes = [
     name: 'schedule-detail',
     component: ScheduleDetailView,
     props: true,
+    meta: {
+      title: (to: RouteLocationNormalized) => `Zimfarm | Recipe • ${to.params.scheduleName}`
+    }
   },
   {
     path: '/recipes/:scheduleName/:selectedTab',
     name: 'schedule-detail-tab',
     component: ScheduleDetailView,
     props: true,
+    meta: {
+      title: (to: RouteLocationNormalized) => `Zimfarm | Recipe • ${to.params.scheduleName}`
+    }
   },
   {
     path: '/recipes',
     name: 'schedules-list',
     component: SchedulesView,
+    meta: { title: 'Zimfarm | Recipes' }
   },
   {
     path: '/users/:username',
     name: 'user-detail',
     component: UserView,
     props: true,
+    meta: {
+      title: (to: RouteLocationNormalized) => `Zimfarm | User • ${to.params.username}`
+    }
   },
   {
     path: '/users/:username/:selectedTab',
     name: 'user-detail-tab',
     component: UserView,
     props: true,
+    meta: {
+      title: (to: RouteLocationNormalized) => `Zimfarm | User • ${to.params.username}`
+    }
   },
   {
     path: '/users',
     name: 'users-list',
     component: UsersView,
+    meta: { title: 'Zimfarm | Users' }
   },
   {
     path: '/workers',
     name: 'workers',
     component: WorkersView,
+    meta: { title: 'Zimfarm | Workers' }
   },
   {
     path: '/:pathMatch(.*)*',
     name: '404',
     component: NotFoundView,
+    meta: { title: 'Zimfarm | Page Not Found' }
   },
 ]
 
 const router = createRouter({
   history: createWebHistory(),
   routes,
+})
+
+// Add global navigation guard to update title
+router.beforeEach((to, from, next) => {
+  // Update document title
+  if (to.meta.title) {
+    if (typeof to.meta.title === 'function') {
+      // Handle dynamic titles with route parameters
+      document.title = to.meta.title(to)
+    } else {
+      // Handle static titles
+      document.title = to.meta.title as string
+    }
+  } else {
+    document.title = 'Zimfarm' // fallback
+  }
+  next()
 })
 
 export default router

--- a/frontend-ui/src/stores/platform.ts
+++ b/frontend-ui/src/stores/platform.ts
@@ -1,4 +1,3 @@
-import { useLoadingStore } from '@/stores/loading'
 import type { ListResponse } from '@/types/base'
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
@@ -7,7 +6,6 @@ export const usePlatformStore = defineStore('platform', () => {
   const platforms = ref<string[]>([])
   const error = ref<Error | null>(null)
 
-  const loadingStore = useLoadingStore()
   const authStore = useAuthStore()
 
   const fetchPlatforms = async (limit: number = 100) => {
@@ -15,7 +13,6 @@ export const usePlatformStore = defineStore('platform', () => {
       return platforms.value
     }
     try {
-      loadingStore.startLoading('Fetching platforms...')
       const service = await authStore.getApiService('platforms')
       const response = await service.get<null, ListResponse<string>>('', { params: { limit } })
       platforms.value = response.items
@@ -24,8 +21,6 @@ export const usePlatformStore = defineStore('platform', () => {
       console.error('Failed to fetch platforms', _error)
       error.value = _error as Error
       return null
-    } finally {
-      loadingStore.stopLoading()
     }
   }
 

--- a/frontend-ui/src/stores/schedule.ts
+++ b/frontend-ui/src/stores/schedule.ts
@@ -1,5 +1,4 @@
 import { useAuthStore } from '@/stores/auth'
-import { useLoadingStore } from '@/stores/loading'
 import type { ListResponse, Paginator } from '@/types/base'
 import type { ErrorResponse } from '@/types/errors'
 import type { Schedule, ScheduleLight, ScheduleUpdateSchema } from '@/types/schedule'
@@ -19,7 +18,6 @@ export const useScheduleStore = defineStore('schedule', () => {
     count: 0,
   })
   const authStore = useAuthStore()
-  const loadingStore = useLoadingStore()
 
   const fetchSchedule = async (
     scheduleName: string,
@@ -72,7 +70,6 @@ export const useScheduleStore = defineStore('schedule', () => {
       .filter(([, value]) => !!value)
     )
     try {
-      loadingStore.startLoading('Fetching schedules...')
       const response = await service.get<null, ListResponse<ScheduleLight>>("", { params: cleanedParams  })
       schedules.value = response.items
       paginator.value = response.meta
@@ -82,8 +79,6 @@ export const useScheduleStore = defineStore('schedule', () => {
       console.error('Failed to fetch schedules', _error)
       errors.value = translateErrors(_error as ErrorResponse)
       return null
-    } finally {
-      loadingStore.stopLoading()
     }
   }
 

--- a/frontend-ui/src/views/TaskDetailView.vue
+++ b/frontend-ui/src/views/TaskDetailView.vue
@@ -516,7 +516,7 @@ const cancel = async () => {
 }
 
 const refreshData = async () => {
-  loadingStore.startLoading("fetching task…")
+  loadingStore.startLoading("Fetching task...")
   const response = await tasksStore.fetchTask(props.id, !canCreateTasks.value)
   if (response) {
     task.value = response

--- a/frontend-ui/src/views/UserView.vue
+++ b/frontend-ui/src/views/UserView.vue
@@ -5,156 +5,165 @@
 
 <template>
   <v-container>
-    <v-row>
-      <v-col cols="12">
-        <h2 class="text-h4 mb-4">
-          <code>{{ username }}</code>
-          <span v-if="user"> (<code>{{ user.role }}</code>)</span>
-        </h2>
+    <!-- Loading state when data hasn't been loaded yet -->
+    <div v-if="!dataLoaded && loadingStore.isLoading" class="text-center pa-8">
+      <v-progress-circular indeterminate size="64" />
+      <div class="mt-4 text-body-1">{{ loadingStore.loadingText }}</div>
+    </div>
 
-        <div v-if="!error && user">
-          <!-- Tabs -->
-          <v-tabs
-            v-model="selectedTab"
-            color="primary"
-            class="mb-4"
-          >
-            <v-tab
-              value="details"
-              :to="{ name: 'user-detail', params: { username: username } }"
+    <!-- Content only shown when data is loaded -->
+    <div v-if="dataLoaded">
+      <v-row>
+        <v-col cols="12">
+          <h2 class="text-h4 mb-4">
+            <code>{{ username }}</code>
+            <span v-if="user"> (<code>{{ user.role }}</code>)</span>
+          </h2>
+
+          <div v-if="!error && user">
+            <!-- Tabs -->
+            <v-tabs
+              v-model="selectedTab"
+              color="primary"
+              class="mb-4"
             >
-              Profile
-            </v-tab>
-            <v-tab
-              value="edit"
-              :to="{ name: 'user-detail-tab', params: { username: username, selectedTab: 'edit' } }"
-            >
-              Edit
-            </v-tab>
-            <v-tab
-              v-if="canDeleteUser"
-              value="delete"
-              :to="{ name: 'user-detail-tab', params: { username: username, selectedTab: 'delete' } }"
-              color="error"
-            >
-              Delete
-            </v-tab>
-          </v-tabs>
+              <v-tab
+                value="details"
+                :to="{ name: 'user-detail', params: { username: username } }"
+              >
+                Profile
+              </v-tab>
+              <v-tab
+                value="edit"
+                :to="{ name: 'user-detail-tab', params: { username: username, selectedTab: 'edit' } }"
+              >
+                Edit
+              </v-tab>
+              <v-tab
+                v-if="canDeleteUser"
+                value="delete"
+                :to="{ name: 'user-detail-tab', params: { username: username, selectedTab: 'delete' } }"
+                color="error"
+              >
+                Delete
+              </v-tab>
+            </v-tabs>
 
-          <!-- Tab Content -->
-          <v-window v-model="selectedTab">
-            <!-- Details Tab -->
-            <v-window-item value="details">
-              <v-card flat>
-                <v-card-text>
-                  <!-- Email -->
-                  <p v-if="user.email" class="mb-4">
-                    <a :href="'mailto:' + user.email" class="text-decoration-none text-primary">
-                      {{ user.email }}
-                    </a>
-                  </p>
+            <!-- Tab Content -->
+            <v-window v-model="selectedTab">
+              <!-- Details Tab -->
+              <v-window-item value="details">
+                <v-card flat>
+                  <v-card-text>
+                    <!-- Email -->
+                    <p v-if="user.email" class="mb-4">
+                      <a :href="'mailto:' + user.email" class="text-decoration-none text-primary">
+                        {{ user.email }}
+                      </a>
+                    </p>
 
-                  <!-- Permissions Table -->
-                  <v-card class="mb-4" variant="outlined">
-                    <v-card-title class="text-subtitle-1">
-                      <v-icon class="mr-2">mdi-shield-account</v-icon>
-                      Permissions
-                    </v-card-title>
-                    <v-card-text>
-                      <v-table density="compact">
-                        <thead>
-                          <tr>
-                            <th>Permission</th>
-                            <th v-for="header in scopeMainHeaders" :key="header" class="text-center">
-                              {{ header }}
-                            </th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          <tr v-for="row in sortedScope" :key="row.name">
-                            <th>{{ row.name }}</th>
-                            <td v-for="(perm, name) in row.perms" :key="name" class="text-center">
-                              <v-icon v-if="perm" color="success" size="small">
-                                mdi-check
-                              </v-icon>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </v-table>
-                    </v-card-text>
-                  </v-card>
+                    <!-- Permissions Table -->
+                    <v-card class="mb-4" variant="outlined">
+                      <v-card-title class="text-subtitle-1">
+                        <v-icon class="mr-2">mdi-shield-account</v-icon>
+                        Permissions
+                      </v-card-title>
+                      <v-card-text>
+                        <v-table density="compact">
+                          <thead>
+                            <tr>
+                              <th>Permission</th>
+                              <th v-for="header in scopeMainHeaders" :key="header" class="text-center">
+                                {{ header }}
+                              </th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr v-for="row in sortedScope" :key="row.name">
+                              <th>{{ row.name }}</th>
+                              <td v-for="(perm, name) in row.perms" :key="name" class="text-center">
+                                <v-icon v-if="perm" color="success" size="small">
+                                  mdi-check
+                                </v-icon>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </v-table>
+                      </v-card-text>
+                    </v-card>
 
-                  <!-- SSH Keys Table -->
-                  <v-card v-if="user.ssh_keys && user.ssh_keys.length" variant="outlined">
-                    <v-card-title class="text-subtitle-1">
-                      <v-icon class="mr-2">mdi-key</v-icon>
-                      SSH Keys
-                    </v-card-title>
-                    <v-card-text>
-                      <v-table density="compact">
-                        <thead>
-                          <tr>
-                            <th>SSH Key</th>
-                            <th>Fingerprint</th>
-                            <th v-if="canSSHKeyUsers">Actions</th>
-                          </tr>
-                        </thead>
-                        <tbody>
-                          <tr v-for="sshKey in user.ssh_keys" :key="sshKey.name">
-                            <td>{{ sshKey.name }}</td>
-                            <td>
-                              <code>{{ sshKey.fingerprint }}</code>
-                            </td>
-                            <td v-if="canSSHKeyUsers">
-                              <v-btn
-                                color="error"
-                                size="small"
-                                variant="outlined"
-                                @click="confirmDelete(sshKey)"
-                              >
-                                <v-icon size="small" class="mr-1">mdi-delete</v-icon>
-                                Delete
-                              </v-btn>
-                            </td>
-                          </tr>
-                        </tbody>
-                      </v-table>
-                    </v-card-text>
-                  </v-card>
-                </v-card-text>
-              </v-card>
-            </v-window-item>
+                    <!-- SSH Keys Table -->
+                    <v-card v-if="user.ssh_keys && user.ssh_keys.length" variant="outlined">
+                      <v-card-title class="text-subtitle-1">
+                        <v-icon class="mr-2">mdi-key</v-icon>
+                        SSH Keys
+                      </v-card-title>
+                      <v-card-text>
+                        <v-table density="compact">
+                          <thead>
+                            <tr>
+                              <th>SSH Key</th>
+                              <th>Fingerprint</th>
+                              <th v-if="canSSHKeyUsers">Actions</th>
+                            </tr>
+                          </thead>
+                          <tbody>
+                            <tr v-for="sshKey in user.ssh_keys" :key="sshKey.name">
+                              <td>{{ sshKey.name }}</td>
+                              <td>
+                                <code>{{ sshKey.fingerprint }}</code>
+                              </td>
+                              <td v-if="canSSHKeyUsers">
+                                <v-btn
+                                  color="error"
+                                  size="small"
+                                  variant="outlined"
+                                  @click="confirmDelete(sshKey)"
+                                >
+                                  <v-icon size="small" class="mr-1">mdi-delete</v-icon>
+                                  Delete
+                                </v-btn>
+                              </td>
+                            </tr>
+                          </tbody>
+                        </v-table>
+                      </v-card-text>
+                    </v-card>
+                  </v-card-text>
+                </v-card>
+              </v-window-item>
 
-            <!-- Edit Tab -->
-            <v-window-item value="edit">
-              <UpdateUser :user="user" v-if="user" @update-user="updateUser" @change-password="changePassword" @add-key="addKey" />
-            </v-window-item>
+              <!-- Edit Tab -->
+              <v-window-item value="edit">
+                <UpdateUser :user="user" v-if="user" @update-user="updateUser" @change-password="changePassword" @add-key="addKey" />
+              </v-window-item>
 
-            <!-- Delete Tab -->
-            <v-window-item value="delete">
-              <DeleteItem :name="user.username" description="user account" property="username" @delete-item="deleteUser" />
-            </v-window-item>
-          </v-window>
-        </div>
+              <!-- Delete Tab -->
+              <v-window-item value="delete">
+                <DeleteItem :name="user.username" description="user account" property="username" @delete-item="deleteUser" />
+              </v-window-item>
+            </v-window>
+          </div>
 
-        <!-- Error Message -->
-        <ErrorMessage :message="error" v-if="error" />
-      </v-col>
-    </v-row>
+          <!-- Error Message -->
+          <ErrorMessage :message="error" v-if="error" />
+        </v-col>
+      </v-row>
 
-    <!-- Confirmation Dialog -->
-    <ConfirmDialog
-      v-model="showConfirmDialog"
-      :title="confirmDialogTitle"
-      :message="confirmDialogMessage"
-      confirm-text="DELETE"
-      cancel-text="CANCEL"
-      confirm-color="error"
-      icon="mdi-delete"
-      icon-color="error"
-      @confirm="handleConfirmDelete"
-      @cancel="handleCancelDelete"
-    />
+      <!-- Confirmation Dialog -->
+      <ConfirmDialog
+        v-model="showConfirmDialog"
+        :title="confirmDialogTitle"
+        :message="confirmDialogMessage"
+        confirm-text="DELETE"
+        cancel-text="CANCEL"
+        confirm-color="error"
+        icon="mdi-delete"
+        icon-color="error"
+        @confirm="handleConfirmDelete"
+        @cancel="handleCancelDelete"
+      />
+    </div>
   </v-container>
 </template>
 
@@ -200,6 +209,7 @@ let pendingSshKey: { name: string; fingerprint: string } | null = null
 const error = ref<string | null>(null)
 const user = ref<UserWithSshKeys | null>(null)
 const selectedTab = ref(props.selectedTab)
+const dataLoaded = ref(false)
 
 // Computed properties
 const scope = computed(() => user.value?.scope || {})
@@ -357,6 +367,7 @@ const loadUser = async () => {
     if (userData) {
       error.value = null
       user.value = userData
+      dataLoaded.value = true
     } else {
       error.value = 'Failed to load user data'
       for (const err of userStore.errors) {
@@ -379,7 +390,9 @@ watch(() => route.params.selectedTab, (newTab) => {
 }, { immediate: true })
 
 // Lifecycle
-onMounted(() => {
-  loadUser()
+onMounted(async () => {
+  loadingStore.startLoading('Fetching user...')
+  await loadUser()
+  loadingStore.stopLoading()
 })
 </script>

--- a/frontend-ui/src/views/UsersView.vue
+++ b/frontend-ui/src/views/UsersView.vue
@@ -74,12 +74,12 @@
         </v-card-text>
       </v-card>
 
-      <!-- Users Table -->
       <UsersTable
         :headers="headers"
         :users="users"
         :paginator="paginator"
         :loading="loadingStore.isLoading"
+        :loading-text="loadingStore.loadingText"
         :errors="userStore.errors"
         @limit-changed="handleLimitChange"
         @load-data="loadData"
@@ -225,6 +225,7 @@ const loadData = async (limit: number, skip: number) => {
   if (response) {
     users.value = response
     paginator.value = userStore.paginator
+    $cookies?.set('users-table-limit', limit, constants.COOKIE_LIFETIME_EXPIRY)
   } else {
     for (const error of userStore.errors) {
       notificationStore.showError(error)
@@ -235,7 +236,6 @@ const loadData = async (limit: number, skip: number) => {
 
 const handleLimitChange = async (newLimit: number) => {
   $cookies?.set('users-table-limit', newLimit, constants.COOKIE_LIFETIME_EXPIRY)
-  await loadData(newLimit, 0)
 }
 
 // Lifecycle
@@ -244,6 +244,5 @@ onMounted(async () => {
     error.value = 'You do not have permission to view users.'
     return
   }
-  await loadData(paginator.value.limit, paginator.value.skip)
 })
 </script>


### PR DESCRIPTION
## Changes

- use [Vuetify Server Side Tables](https://vuetifyjs.com/en/components/data-tables/server-side-tables/#api) to render data from the API
- delegate loading of data to the server side tables and remove from `onMounted` lifecycle to avoid duplicate API calls as it is called by the server side table
- remove calls to fetch data when limit changed on table as calls were duplicated
- use loading store to communicate loading state and text
- add slots for empty data from api and loading status in server tables
- update page title on route change
- 
