### PR TITLE
rename s3optimizationcache to secreturl

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/fields.py
+++ b/backend/src/zimfarm_backend/common/schemas/fields.py
@@ -144,18 +144,16 @@ Percentage = Annotated[int, AfterValidator(between(low=1, high=100))]
 OptionalPercentage = Percentage | None
 
 
-def validate_optimization_cache(v: ZIMSecretStr | str) -> ZIMSecretStr:
+def validate_secret_url(v: ZIMSecretStr | str) -> ZIMSecretStr:
     url = v.get_secret_value() if isinstance(v, SecretStr) else v
     AnyUrl(url)
 
     return SecretStr(url)
 
 
-S3OptimizationCache = Annotated[
-    ZIMSecretStr, AfterValidator(validate_optimization_cache)
-]
+SecretUrl = Annotated[ZIMSecretStr, AfterValidator(validate_secret_url)]
 
-OptionalS3OptimizationCache = S3OptimizationCache | None
+OptionalSecretUrl = SecretUrl | None
 
 ZIMLongDescription = Annotated[str, AfterValidator(length_between(low=1, high=4000))]
 

--- a/backend/src/zimfarm_backend/common/schemas/offliners/gutenberg.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/gutenberg.py
@@ -6,7 +6,7 @@ from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
     OptionalField,
     OptionalNotEmptyString,
-    OptionalS3OptimizationCache,
+    OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMTitle,
 )
@@ -84,7 +84,7 @@ class GutenbergFlagsSchema(DashModel):
         description="Browse by bookshelves feature",
     )
 
-    optimization_cache: OptionalS3OptimizationCache = OptionalField(
+    optimization_cache: OptionalSecretUrl = OptionalField(
         title="Optimization Cache URL",
         description="S3 Storage URL including credentials and bucket",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/ifixit.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/ifixit.py
@@ -8,7 +8,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalField,
     OptionalNotEmptyString,
     OptionalPercentage,
-    OptionalS3OptimizationCache,
+    OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMOutputFolder,
@@ -79,7 +79,7 @@ class IFixitFlagsSchema(DashModel):
         "Include {period} to insert date period dynamically",
     )
 
-    optimization_cache: OptionalS3OptimizationCache = OptionalField(
+    optimization_cache: OptionalSecretUrl = OptionalField(
         title="Optimization Cache URL",
         description="S3 Storage URL including credentials and bucket",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/kolibri.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/kolibri.py
@@ -7,7 +7,7 @@ from zimfarm_backend.common.schemas.fields import (
     NotEmptyString,
     OptionalField,
     OptionalNotEmptyString,
-    OptionalS3OptimizationCache,
+    OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMLongDescription,
@@ -146,7 +146,7 @@ class KolibriFlagsSchema(DashModel):
         "Default: 1",
     )
 
-    optimization_cache: OptionalS3OptimizationCache = OptionalField(
+    optimization_cache: OptionalSecretUrl = OptionalField(
         title="Optimization Cache URL",
         description="S3 Storage URL including credentials and bucket",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/mindtouch.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/mindtouch.py
@@ -7,7 +7,7 @@ from zimfarm_backend.common.schemas.fields import (
     NotEmptyString,
     OptionalField,
     OptionalNotEmptyString,
-    OptionalS3OptimizationCache,
+    OptionalSecretUrl,
     OptionalZIMLongDescription,
     OptionalZIMOutputFolder,
     OptionalZIMProgressFile,
@@ -104,7 +104,7 @@ class MindtouchFlagsSchema(DashModel):
         description="URL to illustration to use for ZIM illustration and favicon",
     )
 
-    optimization_cache: OptionalS3OptimizationCache = OptionalField(
+    optimization_cache: OptionalSecretUrl = OptionalField(
         title="Optimization Cache URL",
         description="S3 Storage URL including credentials and bucket",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/mwoffliner.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/mwoffliner.py
@@ -8,7 +8,7 @@ from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
     OptionalField,
     OptionalNotEmptyString,
-    OptionalS3OptimizationCache,
+    OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMLongDescription,
     OptionalZIMOutputFolder,
@@ -142,7 +142,7 @@ class MWOfflinerFlagsSchema(DashModel):
         "(see extensions/*.js)",
     )
 
-    optimisationCacheUrl: OptionalS3OptimizationCache = OptionalField(
+    optimisationCacheUrl: OptionalSecretUrl = OptionalField(
         title="Optimisation Cache URL",
         description="S3 Storage URL including credentials and bucket",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/nautilus.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/nautilus.py
@@ -7,6 +7,7 @@ from zimfarm_backend.common.schemas.fields import (
     NotEmptyString,
     OptionalField,
     OptionalNotEmptyString,
+    OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMOutputFolder,
@@ -21,7 +22,7 @@ class NautilusFlagsSchema(DashModel):
         title="Archive",
         description="URL to a ZIP archive containing all the documents",
     )
-    collection: AnyUrl | None = OptionalField(
+    collection: OptionalSecretUrl = OptionalField(
         title="Custom Collection",
         description=(
             "Different collection JSON URL. Otherwise using `collection.json` "

--- a/backend/src/zimfarm_backend/common/schemas/offliners/openedx.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/openedx.py
@@ -8,7 +8,7 @@ from zimfarm_backend.common.schemas.fields import (
     NotEmptyString,
     OptionalField,
     OptionalNotEmptyString,
-    OptionalS3OptimizationCache,
+    OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMOutputFolder,
@@ -142,7 +142,7 @@ class OpenedxFlagsSchema(DashModel):
         ),
     )
 
-    optimization_cache: OptionalS3OptimizationCache = OptionalField(
+    optimization_cache: OptionalSecretUrl = OptionalField(
         title="Optimization Cache URL",
         description="URL with credentials and bucket name to S3 Optimization Cache",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/sotoki.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/sotoki.py
@@ -7,7 +7,7 @@ from zimfarm_backend.common.schemas.fields import (
     NotEmptyString,
     OptionalField,
     OptionalNotEmptyString,
-    OptionalS3OptimizationCache,
+    OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMOutputFolder,
@@ -129,7 +129,7 @@ class SotokiFlagsSchema(DashModel):
         "Include {period} to insert date period dynamically",
     )
 
-    optimization_cache: OptionalS3OptimizationCache = OptionalField(
+    optimization_cache: OptionalSecretUrl = OptionalField(
         title="Optimization Cache URL",
         description="S3 Storage URL including credentials and bucket",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/ted.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/ted.py
@@ -8,7 +8,7 @@ from zimfarm_backend.common.schemas.fields import (
     NotEmptyString,
     OptionalField,
     OptionalNotEmptyString,
-    OptionalS3OptimizationCache,
+    OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMLongDescription,
@@ -130,7 +130,7 @@ class TedFlagsSchema(DashModel):
         ),
     )
 
-    optimization_cache: OptionalS3OptimizationCache = OptionalField(
+    optimization_cache: OptionalSecretUrl = OptionalField(
         title="Optimization Cache URL",
         description=("URL with credentials and bucket name to S3 Optimization Cache"),
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/wikihow.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/wikihow.py
@@ -7,7 +7,7 @@ from zimfarm_backend.common.schemas.fields import (
     NotEmptyString,
     OptionalField,
     OptionalNotEmptyString,
-    OptionalS3OptimizationCache,
+    OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMOutputFolder,
@@ -109,7 +109,7 @@ class WikihowFlagsSchema(DashModel):
         "Include {period} to insert date period dynamically",
     )
 
-    optimization_cache: OptionalS3OptimizationCache = OptionalField(
+    optimization_cache: OptionalSecretUrl = OptionalField(
         title="Optimization Cache URL",
         description="S3 Storage URL including credentials and bucket",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/youtube.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/youtube.py
@@ -7,7 +7,7 @@ from zimfarm_backend.common.schemas.fields import (
     NotEmptyString,
     OptionalField,
     OptionalNotEmptyString,
-    OptionalS3OptimizationCache,
+    OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMLongDescription,
@@ -21,7 +21,7 @@ from zimfarm_backend.common.schemas.fields import (
 class YoutubeFlagsSchema(DashModel):
     offliner_id: Literal["youtube"] = Field(alias="offliner_id")
 
-    optimization_cache: OptionalS3OptimizationCache = OptionalField(
+    optimization_cache: OptionalSecretUrl = OptionalField(
         title="Optimization Cache URL",
         description="Technical Flag: S3 Storage URL including credentials and bucket",
     )

--- a/backend/tests/test_offliner_serializer.py
+++ b/backend/tests/test_offliner_serializer.py
@@ -6,13 +6,13 @@ from pydantic import AnyUrl, EmailStr, SecretStr
 from zimfarm_backend.common.enums import TaskStatus
 from zimfarm_backend.common.schemas.fields import (
     OptionalNotEmptyString,
-    OptionalS3OptimizationCache,
+    OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMLongDescription,
     OptionalZIMOutputFolder,
     OptionalZIMSecretStr,
     OptionalZIMTitle,
-    S3OptimizationCache,
+    SecretUrl,
 )
 from zimfarm_backend.common.schemas.offliners.mwoffliner import (
     MWOfflinerFlagsSchema,
@@ -82,10 +82,8 @@ def test_get_enum_choices(field_type: Any, expected_choices: list[str]):
             OptionalZIMLongDescription, False, id="OptionalZIMLongDescription"
         ),
         pytest.param(OptionalZIMTitle, False, id="OptionalZIMTitle"),
-        pytest.param(
-            OptionalS3OptimizationCache, True, id="OptionalS3OptimizationCache"
-        ),
-        pytest.param(S3OptimizationCache, True, id="S3OptimizationCache"),
+        pytest.param(OptionalSecretUrl, True, id="OptionalSecretUrl"),
+        pytest.param(SecretUrl, True, id="SecretUrl"),
     ),
 )
 def test_is_secret(field: Any, *, is_secret_field: bool):


### PR DESCRIPTION
## Rationale
By changing `S3OptimizationCache` and `OptionalS3OptimizationCache` custom types to `SecretUrl` and `OptionalSecretUrl` respectively, the name becomes more informative when using it in other places that aren't actually S3 urls. Besides, it doesn't do any check to see if it's an S3 URL, just that it's a URL.

This was done while introducing a fix for #795 and it became clear there were other fields that could benefit from this generalization of the type name.

## Changes
- Set nautilus collection field to be a secret field
- Rename S3OptimizationCache types to SecretUrl to better capture it's intent.

This closes #795 
