### PR TITLE
change token expires_in to isoformat string

### DIFF
--- a/backend/V1_TO_V2_MIGRATION.md
+++ b/backend/V1_TO_V2_MIGRATION.md
@@ -11,11 +11,13 @@ Zimfarm Backend v2 represents a significant modernization of the codebase, migra
 ### 1. Web Framework Migration
 
 **v1 (Flask):**
+
 - Uses Flask
 - Traditional WSGI application
 - Manual error handling with custom exception classes
 
 **v2 (FastAPI):**
+
 - Uses FastAPI
 - ASGI application with uvicorn server
 - Automatic request validation and error handling with Pydantic
@@ -23,18 +25,22 @@ Zimfarm Backend v2 represents a significant modernization of the codebase, migra
 ### 2. Python Version Upgrade
 
 **v1:**
+
 - Python 3.8
 
 **v2:**
+
 - Python 3.13
 
 ### 3. Dependency Management
 
 **v1:**
+
 - Uses `requirements.txt` with loose version constraints
 - Manual dependency specification
 
 **v2:**
+
 - Uses `pyproject.toml` with modern Python packaging standards
 - Strict version pinning for all dependencies
 - Optional dependency groups (dev, test, lint, check)
@@ -42,20 +48,21 @@ Zimfarm Backend v2 represents a significant modernization of the codebase, migra
 
 ### 4. Key Dependency Updates
 
-| Dependency | v1 | v2 | Notes |
-|------------|----|----|-------|
-| Web Framework | Flask 2.3.x | FastAPI 0.115.2 | Complete framework change |
-| Validation | Marshmallow 3.19.x | Pydantic 2.11.4 | Modern type validation |
-| MongoDB (for JSONB marshalling) | pymongo 3.12.0 | pymongo 4.13.0 | Major version upgrade |
-
+| Dependency                      | v1                 | v2              | Notes                     |
+| ------------------------------- | ------------------ | --------------- | ------------------------- |
+| Web Framework                   | Flask 2.3.x        | FastAPI 0.115.2 | Complete framework change |
+| Validation                      | Marshmallow 3.19.x | Pydantic 2.11.4 | Modern type validation    |
+| MongoDB (for JSONB marshalling) | pymongo 3.12.0     | pymongo 4.13.0  | Major version upgrade     |
 
 ### 5. API Changes
 
 **v1:**
+
 - API prefix: `/v1`
 - Accepted a mixture of formats (form, json, headers) for authentication
 
 **v2:**
+
 - API prefix: `/v2`
 - Accepts json for authentication payload with support for SSH authentication via headers
 - Changed schema to create a schedule (see openAPI docs for change in payload shape)
@@ -65,37 +72,45 @@ Zimfarm Backend v2 represents a significant modernization of the codebase, migra
 ### 6. Authentication & Authorization
 
 **v1:**
+
 - Custom authentication decorators
 - Uses subprocess to invoke openssl for cryptographic functions
 - Only supports SSH keys in the RSA format
+- Token payload contains `expires_in` which is a float
 
 **v2:**
+
 - FastAPI dependency injection for authentication
 - Uses `cryptography` library for cryptographic functions
 - Supports SSH keys in RSA and PEM formats
-
+- Token payload `expires_in` renamed to `expires_time` and is a datetime isoformat string
 
 ### 7. Models
 
 **v1:**
+
 - Uses `Dict`, `List`, `Optional` from typing
 
 **v2:**
+
 - Uses modern type annotations (`dict`, `list`, `|` union syntax)
 
 ### 8. Containerization
 
 **v1:**
+
 - Uses `rgaudin/uwsgi-nginx:python3.8` base image
 - uWSGI + Nginx setup
 
 **v2:**
+
 - Uses `python:3.13-slim-bookworm` base image
 - uvicorn ASGI server
 
 ### 9. Development Tools
 
 **v2 New Features:**
+
 - Black code formatter
 - Ruff linter
 - Pyright type checker

--- a/backend/src/zimfarm_backend/common/schemas/__init__.py
+++ b/backend/src/zimfarm_backend/common/schemas/__init__.py
@@ -8,8 +8,8 @@ from pydantic.alias_generators import to_camel
 def serialize_datetime(value: datetime.datetime) -> str:
     """Serialize datetime with 'Z' suffix for naive datetimes"""
     if value.tzinfo is None:
-        return value.isoformat() + "Z"
-    return value.isoformat()
+        return value.isoformat(timespec="seconds") + "Z"
+    return value.isoformat(timespec="seconds")
 
 
 class BaseModel(pydantic.BaseModel):

--- a/backend/src/zimfarm_backend/routes/auth/logic.py
+++ b/backend/src/zimfarm_backend/routes/auth/logic.py
@@ -43,9 +43,11 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 def _access_token_response(db_session: OrmSession, db_user: User, response: Response):
     response.headers["Cache-Control"] = "no-store"
     response.headers["Pragma"] = "no-cache"
+    issue_time = getnow()
     return Token(
         access_token=generate_access_token(
             user_id=str(db_user.id),
+            issue_time=issue_time,
             username=db_user.username,
             scope=db_user.scope,
             email=db_user.email,
@@ -53,7 +55,8 @@ def _access_token_response(db_session: OrmSession, db_user: User, response: Resp
         refresh_token=str(
             create_refresh_token(session=db_session, user_id=db_user.id).token
         ),
-        expires_in=constants.JWT_TOKEN_EXPIRY_DURATION,
+        expires_time=issue_time
+        + datetime.timedelta(seconds=constants.JWT_TOKEN_EXPIRY_DURATION),
     )
 
 

--- a/backend/src/zimfarm_backend/routes/auth/models.py
+++ b/backend/src/zimfarm_backend/routes/auth/models.py
@@ -1,3 +1,4 @@
+import datetime
 from typing import Literal
 from uuid import UUID
 
@@ -26,5 +27,5 @@ class Token(BaseModel):
 
     access_token: str
     token_type: str = "Bearer"
-    expires_in: float
+    expires_time: datetime.datetime
     refresh_token: str

--- a/backend/src/zimfarm_backend/utils/token.py
+++ b/backend/src/zimfarm_backend/utils/token.py
@@ -19,7 +19,6 @@ from cryptography.hazmat.primitives.serialization import (
     load_ssh_public_key,
 )
 
-from zimfarm_backend.common import getnow
 from zimfarm_backend.common.constants import (
     JWT_SECRET,
     JWT_TOKEN_EXPIRY_DURATION,
@@ -32,12 +31,12 @@ def generate_access_token(
     *,
     user_id: str,
     username: str,
+    issue_time: datetime.datetime,
     email: str | None = None,
     scope: dict[str, Any] | None = None,
 ) -> str:
     """Generate a JWT access token for the given user ID with configured expiry."""
 
-    issue_time = getnow()
     expire_time = issue_time + datetime.timedelta(seconds=JWT_TOKEN_EXPIRY_DURATION)
     payload = {
         "iss": JWT_TOKEN_ISSUER,  # issuer

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -117,6 +117,7 @@ def rsa_x_sshauth_signature(rsa_private_key: RSAPrivateKey, auth_message: str) -
 @pytest.fixture
 def access_token(user: User) -> str:
     return generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,

--- a/backend/tests/routes/test_requested_task.py
+++ b/backend/tests/routes/test_requested_task.py
@@ -7,6 +7,7 @@ from fastapi.testclient import TestClient
 from pytest import MonkeyPatch
 from sqlalchemy.orm import Session as OrmSession
 
+from zimfarm_backend.common import getnow
 from zimfarm_backend.common.roles import RoleEnum
 from zimfarm_backend.db.models import RequestedTask, Schedule, User, Worker
 from zimfarm_backend.db.worker import get_worker
@@ -21,6 +22,7 @@ def test_create_request_task_no_permission(
     """Test that create_request_task raises ForbiddenError without permission"""
     user = create_user(permission=RoleEnum.PROCESSOR)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,
@@ -320,6 +322,7 @@ def test_update_requested_task_no_permission(
     """Test that update_requested_task raises ForbiddenError without permission"""
     user = create_user(permission=RoleEnum.EDITOR)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,
@@ -343,6 +346,7 @@ def test_update_requested_task_success(
     """Test successful update of requested task priority"""
     user = create_user(permission=RoleEnum.ADMIN)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,
@@ -367,6 +371,7 @@ def test_delete_requested_task_no_permission(
     """Test that delete_requested_task raises ForbiddenError without permission"""
     user = create_user(permission=RoleEnum.EDITOR)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,
@@ -388,6 +393,7 @@ def test_delete_requested_task_success(
     """Test successful deletion of requested task"""
     user = create_user(permission=RoleEnum.ADMIN)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,

--- a/backend/tests/routes/test_schedules.py
+++ b/backend/tests/routes/test_schedules.py
@@ -6,6 +6,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session as OrmSession
 
+from zimfarm_backend.common import getnow
 from zimfarm_backend.common.enums import ScheduleCategory, SchedulePeriodicity
 from zimfarm_backend.common.roles import RoleEnum
 from zimfarm_backend.common.schemas.models import ScheduleConfigSchema
@@ -48,6 +49,7 @@ def test_get_schedules(
     """Test that get_schedules raises ForbiddenError without permission"""
     user = create_user(permission=RoleEnum.PROCESSOR)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,
@@ -101,6 +103,7 @@ def test_create_schedule(
     """Test that create_schedule raises ForbiddenError without permission"""
     user = create_user(permission=permission)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,
@@ -150,6 +153,7 @@ def test_get_schedule(
     """Test that get_schedule raises ForbiddenError without permission"""
     user = create_user(permission=permission)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,
@@ -185,6 +189,7 @@ def test_update_schedule_unauthorized(
     """Test that update_schedule raises ForbiddenError without permission"""
     user = create_user(permission=RoleEnum.PROCESSOR)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,
@@ -282,6 +287,7 @@ def test_update_schedule(
 ):
     user = create_user(permission=RoleEnum.ADMIN)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,
@@ -317,6 +323,7 @@ def test_delete_schedule(
 ):
     user = create_user(permission=permission)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,
@@ -361,6 +368,7 @@ def test_clone_schedule(
 ):
     user = create_user(permission=RoleEnum.ADMIN)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,

--- a/backend/tests/routes/test_task.py
+++ b/backend/tests/routes/test_task.py
@@ -7,6 +7,7 @@ import pytest
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session as OrmSession
 
+from zimfarm_backend.common import getnow
 from zimfarm_backend.common.enums import TaskStatus
 from zimfarm_backend.common.roles import RoleEnum
 from zimfarm_backend.db.models import RequestedTask, Task, User, Worker
@@ -94,6 +95,7 @@ def test_create_task_no_permission(
     """Test that create_task raises ForbiddenError without permission"""
     user = create_user(permission=RoleEnum.PROCESSOR)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,
@@ -163,6 +165,7 @@ def test_update_task_no_permission(
     """Test that update_task raises ForbiddenError without permission"""
     user = create_user(permission=RoleEnum.EDITOR)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,
@@ -200,6 +203,7 @@ def test_update_task_success(
     """Test successful update of task"""
     user = create_user(permission=RoleEnum.ADMIN)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,
@@ -223,6 +227,7 @@ def test_cancel_task_no_permission(
     """Test that cancel_task raises ForbiddenError without permission"""
     user = create_user(permission=RoleEnum.EDITOR)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,
@@ -274,6 +279,7 @@ def test_cancel_task_success(
     """Test successful cancellation of task"""
     user = create_user(permission=RoleEnum.ADMIN)
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         email=user.email,

--- a/backend/tests/routes/test_user.py
+++ b/backend/tests/routes/test_user.py
@@ -6,6 +6,7 @@ from cryptography.hazmat.primitives.asymmetric import rsa
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session as OrmSession
 
+from zimfarm_backend.common import getnow
 from zimfarm_backend.db.models import User
 from zimfarm_backend.utils.token import generate_access_token
 
@@ -19,6 +20,7 @@ def test_list_users_no_auth(client: TestClient):
 def test_list_users_no_param(client: TestClient, users: list[User]):
     user = users[0]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -49,6 +51,7 @@ def test_list_users_with_param(
 ):
     user = users[0]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -73,6 +76,7 @@ def test_skip_deleted_users(
 ):
     user = users[0]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -99,6 +103,7 @@ def test_get_user_by_username(client: TestClient, users: list[User]):
     url = f"/v2/users/{users[0].username}"
     user = users[0]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -119,6 +124,7 @@ def test_get_user_by_username_not_found(
     url = f"/v2/users/{users[0].username}1"
     user = users[0]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -133,6 +139,7 @@ def test_patch_user_email(client: TestClient, users: list[User]):
     user = users[0]
     url = f"/v2/users/{user.username}"
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -151,6 +158,7 @@ def test_delete_user(client: TestClient, users: list[User]):
     user = users[0]
     url = f"/v2/users/{user.username}"
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -162,6 +170,7 @@ def test_delete_user(client: TestClient, users: list[User]):
     # We still shouldn't be able to create a user with same username
     user = users[1]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -185,6 +194,7 @@ def test_create_user(client: TestClient, users: list[User]):
     url = "/v2/users/"
     user = users[0]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -208,6 +218,7 @@ def test_create_user_duplicate(client: TestClient, users: list[User]):
     url = "/v2/users/"
     user = users[0]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -231,6 +242,7 @@ def test_list_user_keys(client: TestClient, users: list[User]):
     """Test listing a user's SSH keys"""
     user = users[0]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -259,6 +271,7 @@ def test_list_user_keys_unauthorized(client: TestClient, users: list[User]):
     """Test listing another user's SSH keys without permission"""
     user = users[0]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -274,6 +287,7 @@ def test_create_user_key(client: TestClient, users: list[User]):
     """Test creating a new SSH key for a user"""
     user = users[0]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -305,6 +319,7 @@ def test_create_user_key_invalid(client: TestClient, users: list[User]):
     """Test creating an invalid SSH key"""
     user = users[0]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -323,6 +338,7 @@ def test_create_user_key_duplicate(client: TestClient, users: list[User]):
     """Test creating a duplicate SSH key"""
     user = users[0]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -341,6 +357,7 @@ def test_get_user_key(client: TestClient, users: list[User]):
     """Test getting a specific SSH key"""
     user = users[0]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -363,6 +380,7 @@ def test_get_user_key_not_found(client: TestClient, users: list[User]):
     """Test getting a non-existent SSH key"""
     user = users[0]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -378,6 +396,7 @@ def test_delete_user_key(client: TestClient, users: list[User]):
     """Test deleting a user's SSH key"""
     user = users[0]
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,
@@ -399,6 +418,7 @@ def test_delete_user_key_unauthorized(client: TestClient, users: list[User]):
     user = users[0]
     url = f"/v2/users/{users[1].username}/keys/some-fingerprint"
     access_token = generate_access_token(
+        issue_time=getnow(),
         user_id=str(user.id),
         username=user.username,
         scope=user.scope,

--- a/frontend-ui/src/types/user.ts
+++ b/frontend-ui/src/types/user.ts
@@ -22,7 +22,7 @@ export interface User extends JWTUser {
 export interface Token {
   access_token: string
   refresh_token: string
-  expires_in: number
+  expires_time: string
 }
 
 export interface BaseSshKey {
@@ -37,10 +37,7 @@ export interface SshKeyRead extends BaseSshKey {
   pkcs8_key: string
 }
 
-export interface BaseUserWithSshKeys extends BaseUser, BaseSshKey
-{
-}
-
+export interface BaseUserWithSshKeys extends BaseUser, BaseSshKey {}
 
 export interface SshKeyList {
   ssh_keys: SshKeyRead[]


### PR DESCRIPTION
## Rationale

While working on the changes required to make WP1 conform to the spec of the new API, it became clear that the `expires_in` of the token response needs to be changed to datetime string. This keeps the response similar to the previous API response and is also more informative than the constant I had been returning in the sense that clients can know when it would expire.

## Changes
- strip out microseconds from the datetime isoformat string to keep response compatible with older API
- use the same `issue_time` to create the access token and setting the `expires_in`. This reduces minor offsets in `exp` of access token and `expires_in` top-level field.
