### PR TITLE
show uploaded pub key filename in ui

### DIFF
--- a/frontend-ui/src/components/UpdateUser.vue
+++ b/frontend-ui/src/components/UpdateUser.vue
@@ -83,7 +83,6 @@
           <v-row>
             <v-col cols="8" sm="8" md="6">
               <v-file-input
-                ref="keyFile"
                 v-model="keyFile"
                 label="RSA Public Key"
                 placeholder="Select an RSA public key file (.pub)"


### PR DESCRIPTION
## Changes
- remove `ref` on v-file-input for uploaded pub key. this was preventing the filename from showing in the ui after being uploaded
