### PR TITLE
use show_secrets context while fetching requested task

### DIFF
--- a/backend/src/zimfarm_backend/routes/tasks/logic.py
+++ b/backend/src/zimfarm_backend/routes/tasks/logic.py
@@ -85,13 +85,15 @@ async def get_task(
     ):
         task.notification = None
 
-    if hide_secrets or not (
+    # if the user does not have the appropriate permission, then their flag does
+    # not matter
+    if not (
         current_user
         and check_user_permission(current_user, namespace="tasks", name="create")
     ):
         show_secrets = False
     else:
-        show_secrets = True
+        show_secrets = not hide_secrets
 
     return JSONResponse(
         content=task.model_dump(

--- a/backend/tests/routes/test_requested_task.py
+++ b/backend/tests/routes/test_requested_task.py
@@ -289,7 +289,7 @@ def test_get_requested_task_success(
     client: TestClient,
     access_token: str,
     requested_task: RequestedTask,
-    hide_secrets: bool,  # noqa: FBT001
+    hide_secrets: str,
 ):
     """Test successful retrieval of a single requested task"""
     response = client.get(
@@ -304,7 +304,7 @@ def test_get_requested_task_success(
     assert "offliner_id" in config["offliner"]
     assert "mwPassword" in config["offliner"]
 
-    if hide_secrets:
+    if hide_secrets == "true":
         for char in config["offliner"]["mwPassword"]:
             assert char == "*"
     else:

--- a/backend/tests/routes/test_task.py
+++ b/backend/tests/routes/test_task.py
@@ -40,7 +40,7 @@ def test_get_tasks(
 def test_get_task_no_auth(
     client: TestClient,
     task: Task,
-    hide_secrets: bool,  # noqa: FBT001
+    hide_secrets: str,
 ):
     """Test successful retrieval of a single task"""
     response = client.get(


### PR DESCRIPTION
## Changes
- determine whether to show secrets while fetching requested task based on query param and permissions
- consider `hide_secrets` flag only if user has required permission