### PR TITLE
Enforce metadata conventions

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/fields.py
+++ b/backend/src/zimfarm_backend/common/schemas/fields.py
@@ -170,7 +170,9 @@ OptionalZIMDescription = ZIMDescription | None
 ZIMFileName = Annotated[
     str,
     AfterValidator(
-        pattern(r"^(.+?_)([a-z\-]{2,3}?_)(.+_|)([\d]{4}-[\d]{2}|\{period\}).zim$")
+        pattern(
+            r"^([a-z0-9\-\.]+_)([a-z\-]{2,3}?_)([a-z0-9\-\.]+_|)([\d]{4}-[\d]{2}|\{period\}).zim$"
+        )
     ),
 ]
 
@@ -184,7 +186,7 @@ ZIMPlatformValue = Annotated[int, AfterValidator(between(low=1))]
 
 OptionalZIMPlatformValue = ZIMPlatformValue | None
 
-ZIMLangCode = Annotated[str, AfterValidator(length_between(low=2, high=8))]
+ZIMLangCode = Annotated[str, AfterValidator(length_between(low=3, high=3))]
 
 OptionalZIMLangCode = ZIMLangCode | None
 

--- a/backend/src/zimfarm_backend/common/schemas/fields.py
+++ b/backend/src/zimfarm_backend/common/schemas/fields.py
@@ -171,12 +171,19 @@ ZIMFileName = Annotated[
     str,
     AfterValidator(
         pattern(
-            r"^([a-z0-9\-\.]+_)([a-z\-]{2,3}?_)([a-z0-9\-\.]+_|)([\d]{4}-[\d]{2}|\{period\}).zim$"
+            r"^([a-z0-9\-\.]+_)([a-z\-]+_)([a-z0-9\-\.]+_)([a-z0-9\-\.]+_|)([\d]{4}-[\d]{2}|\{period\}).zim$"
         )
     ),
 ]
 
 OptionalZIMFileName = ZIMFileName | None
+
+ZIMName = Annotated[
+    str,
+    AfterValidator(pattern(r"^([a-z0-9\-\.]+_)([a-z\-]+_)([a-z0-9\-\.]+)$")),
+]
+
+OptionalZIMName = ZIMName | None
 
 SlackTarget = Annotated[str, AfterValidator(pattern(r"^[#|@].+$"))]
 

--- a/backend/src/zimfarm_backend/common/schemas/offliners/freecodecamp.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/freecodecamp.py
@@ -10,8 +10,9 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalNotEmptyString,
     OptionalZIMFileName,
     OptionalZIMLongDescription,
+    OptionalZIMOutputFolder,
     ZIMDescription,
-    ZIMOutputFolder,
+    ZIMName,
     ZIMTitle,
     enum_member,
 )
@@ -47,7 +48,7 @@ class FreeCodeCampFlagsSchema(DashModel):
         title="Language", description="Language of zim file and curriculum."
     )
 
-    name: NotEmptyString = Field(
+    name: ZIMName = Field(
         title="Name",
         description="ZIM name",
     )
@@ -82,7 +83,7 @@ class FreeCodeCampFlagsSchema(DashModel):
         description="Enable verbose output",
     )
 
-    output: ZIMOutputFolder = Field(
+    output: OptionalZIMOutputFolder = Field(
         title="Output folder",
         description="Output folder for ZIM file(s). Leave it as `/output`",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/ifixit.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/ifixit.py
@@ -11,6 +11,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
+    OptionalZIMName,
     OptionalZIMOutputFolder,
     OptionalZIMProgressFile,
     OptionalZIMTitle,
@@ -25,7 +26,7 @@ class IFixitFlagsSchema(DashModel):
         description="iFixIt website to build from",
     )
 
-    name: OptionalNotEmptyString = OptionalField(
+    name: OptionalZIMName = OptionalField(
         title="Name",
         description="ZIM name. Used as identifier and filename "
         "(date will be appended). Constructed from language if not supplied",

--- a/backend/src/zimfarm_backend/common/schemas/offliners/kolibri.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/kolibri.py
@@ -13,6 +13,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalZIMLongDescription,
     OptionalZIMOutputFolder,
     OptionalZIMTitle,
+    ZIMName,
 )
 
 
@@ -36,7 +37,7 @@ class KolibriFlagsSchema(DashModel):
         "If unspecified, will attempt to detect from main page, or use 'eng'",
     )
 
-    name: NotEmptyString = Field(
+    name: ZIMName = Field(
         title="Name",
         description="ZIM name. Used as identifier and filename (date will be appended)",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/mindtouch.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/mindtouch.py
@@ -12,6 +12,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalZIMOutputFolder,
     OptionalZIMProgressFile,
     ZIMDescription,
+    ZIMName,
     ZIMTitle,
 )
 
@@ -42,7 +43,7 @@ class MindtouchFlagsSchema(DashModel):
         "will be automatically added. Defaults to {name}_{period}",
     )
 
-    name: NotEmptyString = Field(
+    name: ZIMName = Field(
         title="ZIM name",
         description="Name of the ZIM.",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/nautilus.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/nautilus.py
@@ -4,7 +4,6 @@ from pydantic import AnyUrl, Field
 
 from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
-    NotEmptyString,
     OptionalField,
     OptionalNotEmptyString,
     OptionalSecretUrl,
@@ -12,6 +11,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalZIMFileName,
     OptionalZIMOutputFolder,
     OptionalZIMTitle,
+    ZIMName,
 )
 
 
@@ -30,7 +30,7 @@ class NautilusFlagsSchema(DashModel):
         ),
     )
 
-    name: NotEmptyString = Field(
+    name: ZIMName = Field(
         title="ZIM Name",
         description="Used as identifier and filename (date will be appended)",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/openedx.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/openedx.py
@@ -5,7 +5,6 @@ from pydantic import AnyUrl, EmailStr, Field, WrapValidator
 
 from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
-    NotEmptyString,
     OptionalField,
     OptionalNotEmptyString,
     OptionalSecretUrl,
@@ -13,6 +12,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalZIMFileName,
     OptionalZIMOutputFolder,
     OptionalZIMTitle,
+    ZIMName,
     ZIMSecretStr,
     enum_member,
 )
@@ -107,7 +107,7 @@ class OpenedxFlagsSchema(DashModel):
         ),
     )
 
-    name: NotEmptyString = Field(
+    name: ZIMName = Field(
         title="Name",
         description=(
             "ZIM name. Used as identifier and filename (date will be appended)"

--- a/backend/src/zimfarm_backend/common/schemas/offliners/sotoki.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/sotoki.py
@@ -10,6 +10,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
+    OptionalZIMName,
     OptionalZIMOutputFolder,
     OptionalZIMTitle,
 )
@@ -23,7 +24,7 @@ class SotokiFlagsSchema(DashModel):
         description="Domain name from StackExchange to scrape.",
     )
 
-    name: OptionalNotEmptyString = OptionalField(
+    name: OptionalZIMName = OptionalField(
         title="Name",
         description="ZIM name. Used as identifier and filename "
         "(date will be appended). Constructed from domain if not supplied",

--- a/backend/src/zimfarm_backend/common/schemas/offliners/ted.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/ted.py
@@ -5,7 +5,6 @@ from pydantic import Field, WrapValidator
 
 from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
-    NotEmptyString,
     OptionalField,
     OptionalNotEmptyString,
     OptionalSecretUrl,
@@ -14,6 +13,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalZIMLongDescription,
     OptionalZIMOutputFolder,
     OptionalZIMTitle,
+    ZIMName,
     enum_member,
 )
 
@@ -88,7 +88,7 @@ class TedFlagsSchema(DashModel):
         ),
     )
 
-    name: NotEmptyString = Field(
+    name: ZIMName = Field(
         title="Name",
         description=(
             "ZIM name. Used as identifier and filename (date will be appended)"

--- a/backend/src/zimfarm_backend/common/schemas/offliners/wikihow.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/wikihow.py
@@ -10,6 +10,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
+    OptionalZIMName,
     OptionalZIMOutputFolder,
     OptionalZIMProgressFile,
     OptionalZIMTitle,
@@ -24,7 +25,7 @@ class WikihowFlagsSchema(DashModel):
         description="wikiHow website to build from. 2-letters language code.",
     )
 
-    name: OptionalNotEmptyString = OptionalField(
+    name: OptionalZIMName = OptionalField(
         title="Name",
         description="ZIM name. Used as identifier and filename "
         "(date will be appended). Constructed from language if not supplied",

--- a/backend/src/zimfarm_backend/common/schemas/offliners/youtube.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/youtube.py
@@ -14,6 +14,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalZIMOutputFolder,
     OptionalZIMProgressFile,
     OptionalZIMTitle,
+    ZIMName,
     ZIMSecretStr,
 )
 
@@ -44,7 +45,7 @@ class YoutubeFlagsSchema(DashModel):
         description="ISO-639-3 (3 chars) language code of content",
     )
 
-    name: NotEmptyString = Field(
+    name: ZIMName = Field(
         title="ZIM Name",
         description="Used as identifier and filename (date will be appended)",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/zimit.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/zimit.py
@@ -5,7 +5,6 @@ from pydantic import AnyUrl, Field, WrapValidator
 
 from zimfarm_backend.common.schemas import CamelModel
 from zimfarm_backend.common.schemas.fields import (
-    NotEmptyString,
     OptionalField,
     OptionalNotEmptyString,
     OptionalPercentage,
@@ -15,6 +14,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalZIMOutputFolder,
     OptionalZIMProgressFile,
     OptionalZIMTitle,
+    ZIMName,
     enum_member,
 )
 
@@ -181,7 +181,7 @@ class ZimitFlagsFullSchema(CamelModel):
         description="If set, read a list of seed urls, one per line. HTTPS URL"
         " to an online file.",
     )
-    name: NotEmptyString = Field(
+    name: ZIMName = Field(
         title="Name",
         description="Name of the ZIM. "
         "Used to compose filename if not otherwise defined",

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -263,7 +263,7 @@ def schedule_duration(
 @pytest.fixture
 def language() -> LanguageSchema:
     return LanguageSchema(
-        code="en",
+        code="eng",
         name_en="English",
         name_native="English",
     )

--- a/backend/tests/db/test_language.py
+++ b/backend/tests/db/test_language.py
@@ -16,7 +16,7 @@ def test_get_languages_empty(dbsession: OrmSession):
 def english_schedule(dbsession: OrmSession):
     """Create a test schedule with English language code."""
     schedule = Schedule(
-        language_code="en",
+        language_code="eng",
         language_name_en="English",
         language_name_native="English",
         name="test",
@@ -47,7 +47,7 @@ def test_get_languages_duplicate(dbsession: OrmSession):
     """Test getting languages with duplicate language codes but different names."""
     # Create test schedules with same language code but different names
     schedule1 = Schedule(
-        language_code="en",
+        language_code="eng",
         language_name_en="English",
         language_name_native="English",
         name="test",
@@ -59,7 +59,7 @@ def test_get_languages_duplicate(dbsession: OrmSession):
         notification={"test": "test"},
     )
     schedule2 = Schedule(
-        language_code="en",
+        language_code="eng",
         language_name_en="English (US)",
         language_name_native="English (US)",
         name="test2",

--- a/backend/tests/db/test_schedule.py
+++ b/backend/tests/db/test_schedule.py
@@ -103,7 +103,7 @@ def test_create_schedule(
         session=dbsession,
         name="test_schedule",
         category=ScheduleCategory.other,
-        language=LanguageSchema(code="en", name_en="English", name_native="English"),
+        language=LanguageSchema(code="eng", name_en="English", name_native="English"),
         config=schedule_config,
         tags=["test"],
         enabled=True,
@@ -112,7 +112,7 @@ def test_create_schedule(
     )
     assert schedule.name == "test_schedule"
     assert schedule.category == ScheduleCategory.other
-    assert schedule.language_code == "en"
+    assert schedule.language_code == "eng"
     assert schedule.language_name_en == "English"
     assert schedule.language_name_native == "English"
     assert schedule.config == schedule_config.model_dump(
@@ -186,8 +186,8 @@ def test_delete_schedule_not_found(dbsession: OrmSession):
     "name,lang,categories,tags,expected_count",
     [
         pytest.param(None, None, None, None, 30, id="all"),
-        pytest.param("wiki", ["en"], None, None, 10, id="wiki_en"),
-        pytest.param("wiki", ["en", "fr"], None, None, 20, id="wiki_en_fr"),
+        pytest.param("wiki", ["eng"], None, None, 10, id="wiki_eng"),
+        pytest.param("wiki", ["eng", "fra"], None, None, 20, id="wiki_eng_fra"),
         pytest.param(
             "schedule",
             None,
@@ -196,15 +196,15 @@ def test_delete_schedule_not_found(dbsession: OrmSession):
             0,
             id="schedule_wikipedia",
         ),
-        pytest.param(None, ["en"], None, ["important"], 10, id="en_important"),
+        pytest.param(None, ["eng"], None, ["important"], 10, id="eng_important"),
         pytest.param("nonexistent", None, None, None, 0, id="nonexistent"),
         pytest.param(
             "schedule",
-            ["en"],
+            ["eng"],
             [ScheduleCategory.other],
             ["test"],
             10,
-            id="schedule_en_other_test",
+            id="schedule_eng_other_test",
         ),
     ],
 )
@@ -222,10 +222,10 @@ def test_get_schedules(
     """Test that get_schedules works correctly with combined filters"""
     for i in range(10):
         schedule = create_schedule(
-            name=f"wiki_en_{i}",
+            name=f"wiki_eng_{i}",
             category=ScheduleCategory.wikipedia,
             language=LanguageSchema(
-                code="en", name_en="English", name_native="English"
+                code="eng", name_en="English", name_native="English"
             ),
             tags=["important"],
         )
@@ -237,10 +237,10 @@ def test_get_schedules(
 
     for i in range(10):
         schedule = create_schedule(
-            name=f"wiki_fr_{i}",
+            name=f"wiki_fra_{i}",
             category=ScheduleCategory.wikipedia,
             language=LanguageSchema(
-                code="fr", name_en="French", name_native="Français"
+                code="fra", name_en="French", name_native="Français"
             ),
             tags=["important"],
         )
@@ -255,7 +255,7 @@ def test_get_schedules(
             name=f"other_schedule_{i}",
             category=ScheduleCategory.other,
             language=LanguageSchema(
-                code="en", name_en="English", name_native="English"
+                code="eng", name_en="English", name_native="English"
             ),
             tags=["test"],
         )

--- a/backend/tests/routes/test_schedules.py
+++ b/backend/tests/routes/test_schedules.py
@@ -18,20 +18,20 @@ from zimfarm_backend.utils.token import generate_access_token
     "query_string,expected_count",
     [
         pytest.param("", 10, id="all"),
-        pytest.param("&name=wiki&lang=en", 10, id="wiki_en"),
-        pytest.param("&name=wiki&lang=fr", 0, id="wiki_fr"),
+        pytest.param("&name=wiki&lang=eng", 10, id="wiki_eng"),
+        pytest.param("&name=wiki&lang=fra", 0, id="wiki_fra"),
         pytest.param("&name=schedule&category=wikipedia", 0, id="schedule_wikipedia"),
-        pytest.param("&name=schedule&lang=en&tag=important", 0, id="en_important"),
+        pytest.param("&name=schedule&lang=eng&tag=important", 0, id="eng_important"),
         pytest.param("&name=nonexistent", 0, id="nonexistent"),
         pytest.param(
-            "&name=schedule&lang=en&category=other&tag=test",
+            "&name=schedule&lang=eng&category=other&tag=test",
             0,
-            id="schedule_en_other_test",
+            id="schedule_eng_other_test",
         ),
         pytest.param(
-            "&name=wiki&lang=en&category=wikipedia&tag=important",
+            "&name=wiki&lang=eng&category=wikipedia&tag=important",
             10,
-            id="wiki_en_important",
+            id="wiki_eng_important",
         ),
     ],
 )
@@ -56,10 +56,10 @@ def test_get_schedules(
 
     for i in range(10):
         schedule = create_schedule(
-            name=f"wiki_en_{i}",
+            name=f"wiki_eng_{i}",
             category=ScheduleCategory.wikipedia,
             language=LanguageSchema(
-                code="en", name_en="English", name_native="English"
+                code="eng", name_en="English", name_native="English"
             ),
             tags=["important"],
         )
@@ -116,7 +116,7 @@ def test_create_schedule(
             "name": "test_schedule",
             "category": ScheduleCategory.wikipedia.value,
             "language": {
-                "code": "en",
+                "code": "eng",
                 "name_en": "English",
                 "name_native": "English",
             },

--- a/backend/tests/test_validators.py
+++ b/backend/tests/test_validators.py
@@ -1,8 +1,10 @@
 from contextlib import nullcontext as does_not_raise
 
 import pytest
+from _pytest.python_api import RaisesContext
 from pydantic import ValidationError
 
+from zimfarm_backend.common.schemas.fields import ZIMFileName
 from zimfarm_backend.common.schemas.models import BaseModel
 from zimfarm_backend.common.schemas.offliners.freecodecamp import (
     FCCLanguageValue,
@@ -11,6 +13,10 @@ from zimfarm_backend.common.schemas.offliners.freecodecamp import (
 
 class TestModel(BaseModel):
     value: FCCLanguageValue
+
+
+class TestZIMFileNameModel(BaseModel):
+    value: ZIMFileName
 
 
 def test_enum_validator_accepts_valid_value():
@@ -27,4 +33,59 @@ def test_enum_validator_skips_validation_when_context_set():
     with does_not_raise():
         TestModel.model_validate(
             {"value": "invalid"}, context={"skip_validation": True}
+        )
+
+
+@pytest.mark.parametrize(
+    "filename,expected",
+    [
+        ("wikipedia_en_2024-01.zim", does_not_raise()),
+        ("ted-talks_eng_2024-03.zim", does_not_raise()),
+        ("ted-talks_eng_{period}.zim", does_not_raise()),
+        ("wikipedia_eng_all_{period}.zim", does_not_raise()),
+        # Invalid filenames
+        (
+            "wikipedia_eng_2024-01",
+            pytest.raises(ValidationError),
+        ),  # Missing .zim extension
+        (
+            "WIKIPEDIA_EN_2024-01.zim",
+            pytest.raises(ValidationError),
+        ),  # Uppercase letters
+        (
+            "wikipedia_en_2024_01.zim",
+            pytest.raises(ValidationError),
+        ),  # Wrong date format (underscore instead of dash)
+        ("_en_2024-01.zim", pytest.raises(ValidationError)),  # Empty first part
+        (
+            "wikipedia__2024-01.zim",
+            pytest.raises(ValidationError),
+        ),  # Empty language part
+        ("wikipedia_en_.zim", pytest.raises(ValidationError)),  # Empty date part
+        (
+            "wikipedia_en_2024-01_.zim",
+            pytest.raises(ValidationError),
+        ),  # Trailing underscore
+        ("_en_2024-01.zim", pytest.raises(ValidationError)),  # Leading underscore
+        (
+            "wikipedia en_2024-01.zim",
+            pytest.raises(ValidationError),
+        ),  # Space in first part
+        (
+            "wikipedia_en 2024-01.zim",
+            pytest.raises(ValidationError),
+        ),  # Space in date part
+    ],
+)
+def test_zimfilename_pattern(filename: str, expected: RaisesContext[Exception]):
+    """Test ZIMFileName pattern validation with various inputs."""
+    with expected:
+        TestZIMFileNameModel.model_validate({"value": filename})
+
+
+def test_zimfilename_skips_validation_when_context_set():
+    """Test that ZIMFileName validation is skipped when context is set."""
+    with does_not_raise():
+        TestZIMFileNameModel.model_validate(
+            {"value": "invalid_filename"}, context={"skip_validation": True}
         )

--- a/backend/tests/test_validators.py
+++ b/backend/tests/test_validators.py
@@ -39,40 +39,44 @@ def test_enum_validator_skips_validation_when_context_set():
 @pytest.mark.parametrize(
     "filename,expected",
     [
-        ("wikipedia_en_2024-01.zim", does_not_raise()),
-        ("ted-talks_eng_2024-03.zim", does_not_raise()),
-        ("ted-talks_eng_{period}.zim", does_not_raise()),
+        ("wikipedia_en_all_2024-01.zim", does_not_raise()),
+        ("ted-talks_eng_all_2024-03.zim", does_not_raise()),
         ("wikipedia_eng_all_{period}.zim", does_not_raise()),
+        ("ted-talks_eng_football_{period}.zim", does_not_raise()),
+        ("wikipedia_en_all_nopic_2024-01.zim", does_not_raise()),  # selection + flavor
         # Invalid filenames
         (
-            "wikipedia_eng_2024-01",
+            "wikipedia_eng_all_2024-01",
             pytest.raises(ValidationError),
         ),  # Missing .zim extension
         (
-            "WIKIPEDIA_EN_2024-01.zim",
+            "WIKIPEDIA_EN_ALL_2024-01.zim",
             pytest.raises(ValidationError),
         ),  # Uppercase letters
         (
-            "wikipedia_en_2024_01.zim",
+            "wikipedia_eng_all_2024_01.zim",
             pytest.raises(ValidationError),
         ),  # Wrong date format (underscore instead of dash)
-        ("_en_2024-01.zim", pytest.raises(ValidationError)),  # Empty first part
+        ("_en_all_2024-01.zim", pytest.raises(ValidationError)),  # Empty first part
         (
-            "wikipedia__2024-01.zim",
+            "wikipedia__all_2024-01.zim",
             pytest.raises(ValidationError),
         ),  # Empty language part
-        ("wikipedia_en_.zim", pytest.raises(ValidationError)),  # Empty date part
+        ("wikipedia_en_all_.zim", pytest.raises(ValidationError)),  # Empty date part
         (
-            "wikipedia_en_2024-01_.zim",
+            "wikipedia_en_all_2024-01_.zim",
             pytest.raises(ValidationError),
-        ),  # Trailing underscore
-        ("_en_2024-01.zim", pytest.raises(ValidationError)),  # Leading underscore
+        ),  # Trailing underscore after period
         (
-            "wikipedia en_2024-01.zim",
+            "_wikipedia_en_all_2024-01.zim",
+            pytest.raises(ValidationError),
+        ),  # Leading underscore
+        (
+            "wikipedia en_all_2024-01.zim",
             pytest.raises(ValidationError),
         ),  # Space in first part
         (
-            "wikipedia_en 2024-01.zim",
+            "wikipedia_en_all 2024-01.zim",
             pytest.raises(ValidationError),
         ),  # Space in date part
     ],


### PR DESCRIPTION
## Rationale
This PR serves as foundation for enforcing zim metadata conventions and inputs for fields according to #783 

## Changes
- Change regex for `ZIMFilename` to conform to [Naming Convention](https://wiki.openzim.org/wiki/Content_team/ZIM_Naming_Convention)
- Change language code to be of 3 characters according to ISO 639-3 length
