### PR TITLE
update offliner details on artifacts globs change

### DIFF
--- a/frontend-ui/src/components/ScheduleEditor.vue
+++ b/frontend-ui/src/components/ScheduleEditor.vue
@@ -565,13 +565,9 @@ const hasChanges = computed(() => {
     return true
 
   // Check artifacts globs
-  if (
-    !stringArrayEqual(
-      editSchedule.value.config.artifacts_globs || [],
-      props.schedule.config.artifacts_globs || [],
-    )
-  )
-    return true
+  const artifacts_globs = processArtifactsGlobs(editSchedule.value.config.artifacts_globs_str)
+
+  if (!stringArrayEqual(artifacts_globs, props.schedule.config.artifacts_globs || [])) return true
 
   // Check flags - use editFlags instead of the potentially mutated offliner object
   let changes = diff(props.schedule.config.offliner, editFlags.value)
@@ -768,6 +764,15 @@ const handleReset = () => {
   }
 }
 
+const processArtifactsGlobs = (artifactsGlobsStr: string | undefined): string[] => {
+  return artifactsGlobsStr
+    ? artifactsGlobsStr
+        .split('\n')
+        .map((line) => line.trim())
+        .filter((line) => line !== '')
+    : []
+}
+
 const handleOfflinerChange = () => {
   // assume flags are different, so reset edit schedule flags
   editFlags.value = {}
@@ -851,13 +856,10 @@ const buildPayload = (): ScheduleUpdateSchema | null => {
   }
 
   // Artifacts
-  if (
-    !stringArrayEqual(
-      editSchedule.value.config.artifacts_globs || [],
-      props.schedule.config.artifacts_globs || [],
-    )
-  ) {
-    payload.artifacts_globs = editSchedule.value.config.artifacts_globs
+  const artifacts_globs = processArtifactsGlobs(editSchedule.value.config.artifacts_globs_str)
+
+  if (!stringArrayEqual(artifacts_globs, props.schedule.config.artifacts_globs || [])) {
+    payload.artifacts_globs = artifacts_globs
   }
 
   // Flags

--- a/frontend-ui/src/types/schedule.ts
+++ b/frontend-ui/src/types/schedule.ts
@@ -1,4 +1,10 @@
-import type { ConfigWithOnlyOffliner, DockerImage, MostRecentTask, Resources, ScheduleDuration } from '@/types/base'
+import type {
+  ConfigWithOnlyOffliner,
+  DockerImage,
+  MostRecentTask,
+  Resources,
+  ScheduleDuration,
+} from '@/types/base'
 import type { Language } from '@/types/language'
 
 export interface OfflinerFlags {
@@ -32,15 +38,14 @@ export interface Schedule {
 }
 
 export interface ScheduleLight {
-    name: string
-    category: string
-    most_recent_task: MostRecentTask | null
-    config: ConfigWithOnlyOffliner
-    language: Language
-    enabled: boolean
-    is_requested: boolean
+  name: string
+  category: string
+  most_recent_task: MostRecentTask | null
+  config: ConfigWithOnlyOffliner
+  language: Language
+  enabled: boolean
+  is_requested: boolean
 }
-
 
 export interface ScheduleUpdateSchema {
   name: string | null
@@ -59,45 +64,43 @@ export interface ScheduleUpdateSchema {
   artifacts_globs: string[] | null
 }
 
-
 export interface ScheduleUpdateSchema {
-    name: string | null
-    language: Language | null
-    category: string | null
-    periodicity: string | null
-    tags: string[] | null
-    enabled: boolean | null
-    offliner: string | null
-    warehouse_path: string | null
-    image: DockerImage | null
-    platform: string | null
-    resources: Resources | null
-    monitor: boolean | null
-    flags: Record<string, unknown> | null
-    artifacts_globs: string[] | null
+  name: string | null
+  language: Language | null
+  category: string | null
+  periodicity: string | null
+  tags: string[] | null
+  enabled: boolean | null
+  offliner: string | null
+  warehouse_path: string | null
+  image: DockerImage | null
+  platform: string | null
+  resources: Resources | null
+  monitor: boolean | null
+  flags: Record<string, unknown> | null
+  artifacts_globs: string[] | null
 }
 
 export interface EventNotification {
-    mailgun: string[] | null
-    webhook: string[] | null
-    slack: string[] | null
+  mailgun: string[] | null
+  webhook: string[] | null
+  slack: string[] | null
 }
 
 export interface ScheduleNotification {
-    requested: EventNotification | null
-    started: EventNotification | null
-    ended: EventNotification | null
+  requested: EventNotification | null
+  started: EventNotification | null
+  ended: EventNotification | null
 }
 
 export interface ExpandedScheduleDockerImage {
-    name: string
-    tag: string
+  name: string
+  tag: string
 }
 
-
-export interface ExpandedScheduleConfig  extends ScheduleConfig{
-    image: ExpandedScheduleDockerImage
-    mount_point: string
-    command: string[]
-    str_command: string
+export interface ExpandedScheduleConfig extends ScheduleConfig {
+  image: ExpandedScheduleDockerImage
+  mount_point: string
+  command: string[]
+  str_command: string
 }


### PR DESCRIPTION
## Rationale
The schedule editor is set to track changes on the `artifacts_globs_str` but it is an array on the backend. So, while checking for changes, we convert the input to an array and compare with the original from the API.

By using the `stringArrayEqual`, order does not matter in comparison. This resolves #994 
