### PR TITLE
validate schedule names in ScheduleNameField

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/fields.py
+++ b/backend/src/zimfarm_backend/common/schemas/fields.py
@@ -251,6 +251,10 @@ def validate_schedule_name(name: str, info: ValidationInfo) -> str:
         raise ValueError("`none` is a restricted keyword")
     if not name.strip() or name != name.strip():
         raise ValueError("Recipe name cannot contain leading and/or trailing space(s)")
+    if "/" in name:
+        raise ValueError("Recipe name cannot contain slash")
+    if any(char.isupper() for char in name):
+        raise ValueError("Recipe name should only contain lower case characters")
     return name
 
 

--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -106,7 +106,7 @@ class BaseRequestedTaskSchema(BaseModel):
     timestamp: list[tuple[str, datetime.datetime]]
     requested_by: str
     priority: int
-    schedule_name: str
+    schedule_name: str | None
     original_schedule_name: str
     worker_name: str | None
     updated_at: datetime.datetime
@@ -130,7 +130,6 @@ class RequestedTaskFullSchema(BaseRequestedTaskSchema):
     upload: dict[str, Any]
     notification: ScheduleNotificationSchema | None
     rank: int | None = None
-    schedule_name: str
     schedule_id: UUID | None = Field(exclude=True)
 
 

--- a/backend/src/zimfarm_backend/db/requested_task.py
+++ b/backend/src/zimfarm_backend/db/requested_task.py
@@ -274,7 +274,7 @@ def compute_task_eta(session: OrmSession, task: Task) -> dict[str, Any]:
 
 class RunningTask(BaseModel):
     config: ExpandedScheduleConfigSchema
-    schedule_name: str
+    schedule_name: str | None
     timestamp: list[tuple[str, datetime.datetime]]
     worker_name: str
     duration: ScheduleDurationSchema
@@ -298,7 +298,7 @@ def get_currently_running_tasks(
             config=ExpandedScheduleConfigSchema.model_validate(
                 task.config, context={"skip_validation": True}
             ),
-            schedule_name=task.schedule.name if task.schedule else "none",
+            schedule_name=task.schedule.name if task.schedule else None,
             timestamp=task.timestamp,
             worker_name=task.worker.name,
             **compute_task_eta(session, task),
@@ -314,7 +314,7 @@ class RequestedTaskWithDuration(BaseModel):
     timestamp: list[tuple[str, datetime.datetime]]
     requested_by: str
     priority: int
-    schedule_name: str
+    schedule_name: str | None
     original_schedule_name: str
     worker_name: str
     duration: ScheduleDurationSchema
@@ -353,7 +353,7 @@ def get_tasks_doable_by_worker(
             RequestedTaskWithDuration(
                 id=task.id,
                 status=task.status,
-                schedule_name=task.schedule.name if task.schedule else "none",
+                schedule_name=task.schedule.name if task.schedule else None,
                 original_schedule_name=task.original_schedule_name,
                 config=ExpandedScheduleConfigSchema.model_validate(
                     task.config, context={"skip_validation": True}
@@ -566,7 +566,7 @@ def _create_requested_task_full_schema(
         requested_by=requested_task.requested_by,
         priority=requested_task.priority,
         schedule_name=(
-            requested_task.schedule.name if requested_task.schedule else "none"
+            requested_task.schedule.name if requested_task.schedule else None
         ),
         original_schedule_name=requested_task.original_schedule_name,
         worker_name=requested_task.worker.name if requested_task.worker else None,

--- a/backend/tests/test_validators.py
+++ b/backend/tests/test_validators.py
@@ -11,31 +11,31 @@ from zimfarm_backend.common.schemas.offliners.freecodecamp import (
 )
 
 
-class TestModel(BaseModel):
+class FCCLanguageModel(BaseModel):
     value: FCCLanguageValue
 
 
-class TestZIMFileNameModel(BaseModel):
+class ZIMFileNameModel(BaseModel):
     value: ZIMFileName
 
 
-class TestZIMNameModel(BaseModel):
+class ZIMNameModel(BaseModel):
     value: ZIMName
 
 
 def test_enum_validator_accepts_valid_value():
     with does_not_raise():
-        TestModel.model_validate({"value": "eng"})
+        FCCLanguageModel.model_validate({"value": "eng"})
 
 
 def test_enum_validator_rejects_invalid_value():
     with pytest.raises(ValidationError):
-        TestModel.model_validate({"value": "jp"})
+        FCCLanguageModel.model_validate({"value": "jp"})
 
 
 def test_enum_validator_skips_validation_when_context_set():
     with does_not_raise():
-        TestModel.model_validate(
+        FCCLanguageModel.model_validate(
             {"value": "invalid"}, context={"skip_validation": True}
         )
 
@@ -88,13 +88,13 @@ def test_enum_validator_skips_validation_when_context_set():
 def test_zimfilename_pattern(filename: str, expected: RaisesContext[Exception]):
     """Test ZIMFileName pattern validation with various inputs."""
     with expected:
-        TestZIMFileNameModel.model_validate({"value": filename})
+        ZIMFileNameModel.model_validate({"value": filename})
 
 
 def test_zimfilename_skips_validation_when_context_set():
     """Test that ZIMFileName validation is skipped when context is set."""
     with does_not_raise():
-        TestZIMFileNameModel.model_validate(
+        ZIMFileNameModel.model_validate(
             {"value": "invalid_filename"}, context={"skip_validation": True}
         )
 
@@ -177,12 +177,12 @@ def test_zimfilename_skips_validation_when_context_set():
 def test_zimname_pattern(name: str, expected: RaisesContext[Exception]):
     """Test ZIMName pattern validation with various inputs."""
     with expected:
-        TestZIMNameModel.model_validate({"value": name})
+        ZIMNameModel.model_validate({"value": name})
 
 
 def test_zimname_skips_validation_when_context_set():
     """Test that ZIMName validation is skipped when context is set."""
     with does_not_raise():
-        TestZIMNameModel.model_validate(
+        ZIMNameModel.model_validate(
             {"value": "invalid_name"}, context={"skip_validation": True}
         )

--- a/frontend-ui/src/components/PipelineTable.vue
+++ b/frontend-ui/src/components/PipelineTable.vue
@@ -1,7 +1,10 @@
 <template>
   <div>
-    <v-card v-if="!errors.length" :class="{ 'loading': loading }" flat>
-      <v-card-title v-if="props.paginator.count > 0" class="d-flex align-center justify-space-between">
+    <v-card v-if="!errors.length" :class="{ loading: loading }" flat>
+      <v-card-title
+        v-if="props.paginator.count > 0"
+        class="d-flex align-center justify-space-between"
+      >
         <span class="text-subtitle-1 d-flex align-center">
           Showing max.
           <v-select
@@ -28,12 +31,11 @@
         :hide-default-footer="props.paginator.count === 0"
         :hide-default-header="props.paginator.count === 0"
       >
-
         <template #loading>
           <div class="d-flex flex-column align-center justify-center pa-8">
             <v-progress-circular indeterminate size="64" />
-              <div class="mt-4 text-body-1">{{ loadingText || 'Fetching tasks...' }}</div>
-            </div>
+            <div class="mt-4 text-body-1">{{ loadingText || 'Fetching tasks...' }}</div>
+          </div>
         </template>
 
         <template #no-data>
@@ -44,10 +46,13 @@
         </template>
 
         <template #[`item.schedule_name`]="{ item }">
-          <span v-if="item.schedule_name === null || item.schedule_name === 'none'">
+          <span v-if="item.schedule_name === null">
             {{ item.original_schedule_name }}
           </span>
-          <router-link v-else :to="{ name: 'schedule-detail', params: { scheduleName: item.schedule_name } }">
+          <router-link
+            v-else
+            :to="{ name: 'schedule-detail', params: { scheduleName: item.schedule_name } }"
+          >
             {{ item.schedule_name }}
           </router-link>
         </template>
@@ -104,9 +109,9 @@
 
         <template #[`item.resources`]="{ item }">
           <div class="d-flex flex-sm-column flex-lg-row py-1">
-            <ResourceBadge kind="cpu" :value="item.config.resources.cpu" variant="text"/>
-            <ResourceBadge kind="memory" :value="item.config.resources.memory" variant="text"/>
-            <ResourceBadge kind="disk" :value="item.config.resources.disk"  variant="text"/>
+            <ResourceBadge kind="cpu" :value="item.config.resources.cpu" variant="text" />
+            <ResourceBadge kind="memory" :value="item.config.resources.memory" variant="text" />
+            <ResourceBadge kind="disk" :value="item.config.resources.disk" variant="text" />
           </div>
         </template>
 
@@ -116,11 +121,20 @@
         </template>
 
         <template #[`item.remove`]="{ item }">
-          <RemoveRequestedTaskButton v-if="canUnRequestTasks" :id="item.id" @requested-task-removed="emit('loadData', selectedLimit, 0)" />
+          <RemoveRequestedTaskButton
+            v-if="canUnRequestTasks"
+            :id="item.id"
+            @requested-task-removed="emit('loadData', selectedLimit, 0)"
+          />
         </template>
 
         <template #[`item.duration`]="{ item }">
-          {{ formatDurationBetween(getTimestampStringForStatus(item.timestamp, 'started'), item.updated_at) }}
+          {{
+            formatDurationBetween(
+              getTimestampStringForStatus(item.timestamp, 'started'),
+              item.updated_at,
+            )
+          }}
         </template>
 
         <template #[`item.status`]="{ item }">
@@ -128,10 +142,10 @@
         </template>
 
         <template #[`item.last_run`]="{ item }">
-          <span v-if="lastRunsLoaded && schedulesLastRuns[item.schedule_name]">
+          <span v-if="lastRunsLoaded && item.schedule_name && schedulesLastRuns[item.schedule_name]">
             <code :class="statusClass(schedulesLastRuns[item.schedule_name].status)">
-              {{ schedulesLastRuns[item.schedule_name].status }}
-            </code>,
+              {{ schedulesLastRuns[item.schedule_name].status }} </code
+            >,
             <TaskLink
               :id="schedulesLastRuns[item.schedule_name].id"
               :updatedAt="schedulesLastRuns[item.schedule_name].updated_at"
@@ -142,7 +156,6 @@
         <template #[`item.requested_by`]="{ item }">
           {{ (item as any).requested_by }}
         </template>
-
       </v-data-table-server>
       <ErrorMessage v-for="error in errors" :key="error" :message="error" />
     </v-card>
@@ -150,16 +163,16 @@
 </template>
 
 <script setup lang="ts">
-import ErrorMessage from '@/components/ErrorMessage.vue';
-import RemoveRequestedTaskButton from '@/components/RemoveRequestedTaskButton.vue';
-import ResourceBadge from '@/components/ResourceBadge.vue';
-import TaskLink from '@/components/TaskLink.vue';
-import type { MostRecentTask, Paginator } from '@/types/base';
-import type { RequestedTaskLight } from '@/types/requestedTasks';
-import type { TaskLight } from '@/types/tasks';
-import { formatDt, formatDurationBetween, fromNow } from '@/utils/format';
-import { getTimestampStringForStatus } from '@/utils/timestamp';
-import { ref, watch } from 'vue';
+import ErrorMessage from '@/components/ErrorMessage.vue'
+import RemoveRequestedTaskButton from '@/components/RemoveRequestedTaskButton.vue'
+import ResourceBadge from '@/components/ResourceBadge.vue'
+import TaskLink from '@/components/TaskLink.vue'
+import type { MostRecentTask, Paginator } from '@/types/base'
+import type { RequestedTaskLight } from '@/types/requestedTasks'
+import type { TaskLight } from '@/types/tasks'
+import { formatDt, formatDurationBetween, fromNow } from '@/utils/format'
+import { getTimestampStringForStatus } from '@/utils/timestamp'
+import { ref, watch } from 'vue'
 
 const props = defineProps<{
   headers: { title: string; value: string }[] // the headers to display
@@ -171,25 +184,29 @@ const props = defineProps<{
   lastRunsLoaded: boolean // whether the last runs have been loaded
   schedulesLastRuns: Record<string, MostRecentTask> // the last runs for each schedule
   errors: string[] // the errors to display
-}>();
+}>()
 
 const emit = defineEmits<{
-  'limitChanged': [limit: number]
-  'loadData': [limit: number, skip: number]
-}>();
+  limitChanged: [limit: number]
+  loadData: [limit: number, skip: number]
+}>()
 
-const limits = [10, 20, 50, 100];
-const selectedLimit = ref(props.paginator.limit);
+const limits = [10, 20, 50, 100]
+const selectedLimit = ref(props.paginator.limit)
 
-function onUpdateOptions(options: { page: number, itemsPerPage: number }) {
+function onUpdateOptions(options: { page: number; itemsPerPage: number }) {
   //  number is the next number, we need to calculate the skip for the request
   const page = options.page > 1 ? options.page - 1 : 0
-  emit('loadData', options.itemsPerPage, page * options.itemsPerPage);
+  emit('loadData', options.itemsPerPage, page * options.itemsPerPage)
 }
 
-watch(() => props.paginator, (newPaginator) => {
-  selectedLimit.value = newPaginator.limit;
-}, { immediate: true })
+watch(
+  () => props.paginator,
+  (newPaginator) => {
+    selectedLimit.value = newPaginator.limit
+  },
+  { immediate: true },
+)
 
 function statusClass(status: string) {
   if (status === 'succeeded') return 'schedule-succeeded'

--- a/frontend-ui/src/types/base.ts
+++ b/frontend-ui/src/types/base.ts
@@ -90,7 +90,7 @@ export interface BaseTask {
   id: string
   status: string
   timestamp: [string, string][] // [status, datetime] tuples
-  schedule_name: string
+  schedule_name: string | null
   worker_name: string
   updated_at: string
   original_schedule_name: string

--- a/frontend-ui/src/types/requestedTasks.ts
+++ b/frontend-ui/src/types/requestedTasks.ts
@@ -17,5 +17,5 @@ export interface RequestedTaskFullSchema {
     upload: Record<string, unknown>
     notification: ScheduleNotification | null
     rank: number | null
-    schedule_name: string
+    schedule_name: string | null
 }

--- a/frontend-ui/src/views/TaskDetailView.vue
+++ b/frontend-ui/src/views/TaskDetailView.vue
@@ -32,7 +32,7 @@
           </code>
         </router-link>
       </v-col>
-    </v-row
+    </v-row>
 
     <!-- Content -->
     <div v-if="!error && task">
@@ -71,7 +71,10 @@
                   <tr>
                     <th class="text-left w-20">Recipe</th>
                     <td>
-                      <router-link :to="{ name: 'schedule-detail', params: { scheduleName: task.schedule_name } }">
+                      <span v-if="task.schedule_name === null || task.schedule_name === 'none'">
+                        {{ task.original_schedule_name }}
+                      </span>
+                      <router-link v-else :to="{ name: 'schedule-detail', params: { scheduleName: task.schedule_name } }">
                         {{ task.schedule_name }}
                       </router-link>
                     </td>

--- a/frontend-ui/src/views/WorkersView.vue
+++ b/frontend-ui/src/views/WorkersView.vue
@@ -95,7 +95,7 @@
             </th>
 
             <td v-if="row.kind === 'task' && row.task">
-              <span v-if="row.task.schedule_name === null || row.task.schedule_name === 'none'">
+              <span v-if="row.task.schedule_name === null">
                 {{ row.task.original_schedule_name }}
               </span>
               <router-link v-else :to="{ name: 'schedule-detail', params: { scheduleName: row.task.schedule_name } }">


### PR DESCRIPTION
## Changes
- prevent slash `(/)` in schedule names in validator function for custom type `ScheduleNameField`. 
- disallow uppercase characters
This type is reused across routes that get, create, clone, update, delete, etc that deal with schedules

This PR resolves #634 
