### PR TITLE
enforce language code restrictions on offliners

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "psycopg[binary,pool] == 3.2.9",
     "Werkzeug == 3.1.3",
     "cryptography == 45.0.3",
+    "pycountry == 24.6.1"
 ]
 dynamic = ["version"]
 

--- a/backend/src/zimfarm_backend/common/schemas/offliners/kolibri.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/kolibri.py
@@ -10,6 +10,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
+    OptionalZIMLangCode,
     OptionalZIMLongDescription,
     OptionalZIMOutputFolder,
     OptionalZIMTitle,
@@ -31,7 +32,7 @@ class KolibriFlagsSchema(DashModel):
         "the scraper. Defaults to the root of the channel.",
     )
 
-    lang: OptionalNotEmptyString = OptionalField(
+    lang: OptionalZIMLangCode = OptionalField(
         title="Language",
         description="ISO-639-3 (3 chars) language code of content. "
         "If unspecified, will attempt to detect from main page, or use 'eng'",

--- a/backend/src/zimfarm_backend/common/schemas/offliners/mwoffliner.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/mwoffliner.py
@@ -10,6 +10,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalNotEmptyString,
     OptionalSecretUrl,
     OptionalZIMDescription,
+    OptionalZIMLangCode,
     OptionalZIMLongDescription,
     OptionalZIMOutputFolder,
     OptionalZIMSecretStr,
@@ -118,7 +119,7 @@ class MWOfflinerFlagsSchema(DashModel):
         title="ZIM Tags",
         description="Semi-colon separated list of ZIM tags",
     )
-    customZimLanguage: OptionalNotEmptyString = OptionalField(
+    customZimLanguage: OptionalZIMLangCode = OptionalField(
         title="ZIM Language metadata",
         description="Custom ISO-639-3 language code for the ZIM",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/nautilus.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/nautilus.py
@@ -9,6 +9,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
+    OptionalZIMLangCode,
     OptionalZIMOutputFolder,
     OptionalZIMTitle,
     ZIMName,
@@ -60,7 +61,7 @@ class NautilusFlagsSchema(DashModel):
         title="ZIM filename",
         description="ZIM file name (based on --name if not provided)",
     )
-    language: OptionalNotEmptyString = OptionalField(
+    language: OptionalZIMLangCode = OptionalField(
         title="Language",
         description="ISO-639-3 (3 chars) language code of content",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/ted.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/ted.py
@@ -1,7 +1,12 @@
 from enum import StrEnum
 from typing import Annotated, Literal
 
-from pydantic import Field, WrapValidator
+from pydantic import (
+    Field,
+    ValidationInfo,
+    WrapValidator,
+    field_validator,
+)
 
 from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
@@ -15,6 +20,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalZIMTitle,
     ZIMName,
     enum_member,
+    validate_language_code,
 )
 
 
@@ -48,7 +54,7 @@ class TedFlagsSchema(DashModel):
     languages: OptionalNotEmptyString = OptionalField(
         title="Languages",
         description=(
-            "Comma-separated list of languages to filter videos. Do not "
+            "Comma-separated list of ISO-639-3 language codes to filter videos. Do not "
             "pass this parameter for all languages"
         ),
     )
@@ -170,3 +176,11 @@ class TedFlagsSchema(DashModel):
         title="Locale",
         description="The locale to use for the translations in ZIM",
     )
+
+    @field_validator("languages", mode="after")
+    @classmethod
+    def validate_languages(cls, value: str, info: ValidationInfo) -> str:
+        """Validate that comma-seperated languages are all ISO 693-3 compliant."""
+        for code in value.split(","):
+            validate_language_code(code, info)
+        return value

--- a/backend/src/zimfarm_backend/common/schemas/offliners/youtube.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/youtube.py
@@ -10,6 +10,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalSecretUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
+    OptionalZIMLangCode,
     OptionalZIMLongDescription,
     OptionalZIMOutputFolder,
     OptionalZIMProgressFile,
@@ -40,7 +41,7 @@ class YoutubeFlagsSchema(DashModel):
         alias="id",
     )
 
-    language: OptionalNotEmptyString = OptionalField(
+    language: OptionalZIMLangCode = OptionalField(
         title="Language",
         description="ISO-639-3 (3 chars) language code of content",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/zimit.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/zimit.py
@@ -10,6 +10,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalPercentage,
     OptionalZIMDescription,
     OptionalZIMFileName,
+    OptionalZIMLangCode,
     OptionalZIMLongDescription,
     OptionalZIMOutputFolder,
     OptionalZIMProgressFile,
@@ -497,7 +498,7 @@ class ZimitFlagsFullSchema(CamelModel):
         description="The depth of the crawl for all seeds. Default is -1 (infinite).",
     )
     # Dash aliases
-    zim_lang: OptionalNotEmptyString = OptionalField(
+    zim_lang: OptionalZIMLangCode = OptionalField(
         title="ZIM Language",
         description="Language metadata of ZIM (warc2zim --lang param). "
         "ISO-639-3 code. Retrieved from homepage if found, fallback to `eng`",


### PR DESCRIPTION
## Changes
- validate `ZIMLangCode` using pycountry
- update offliners with type
- reuse validator for TED languages which is a comma-seperated list of language codes

This PR complements #1224 in order to close #783 
