### PR TITLE
distinguish integrity errors when cloning schedules

### DIFF
--- a/backend/src/zimfarm_backend/db/language.py
+++ b/backend/src/zimfarm_backend/db/language.py
@@ -26,7 +26,7 @@ def get_language_from_code(language_code: str) -> LanguageSchema:
         )
 
     return LanguageSchema(
-        code=language.alpha_3,  # return alpha_3 code for consistency
+        code=language.alpha_3,
         name=language.name,
     )
 

--- a/backend/src/zimfarm_backend/routes/schedules/logic.py
+++ b/backend/src/zimfarm_backend/routes/schedules/logic.py
@@ -381,8 +381,8 @@ def update_schedule(
     else:
         language = None
 
-    schedule = create_schedule_full_schema(
-        db_update_schedule(
+    try:
+        schedule = db_update_schedule(
             session,
             schedule_name=schedule_name,
             new_schedule_config=new_schedule_config,
@@ -393,7 +393,10 @@ def update_schedule(
             enabled=request.enabled,
             periodicity=request.periodicity,
         )
-    )
+    except RecordAlreadyExistsError as exc:
+        raise BadRequestError(f"Schedule {request.name} already exists") from exc
+
+    schedule = create_schedule_full_schema(schedule)
     schedule.config = expanded_config(cast(ScheduleConfigSchema, schedule.config))
     return JSONResponse(
         content=schedule.model_dump(

--- a/backend/src/zimfarm_backend/routes/schedules/logic.py
+++ b/backend/src/zimfarm_backend/routes/schedules/logic.py
@@ -121,17 +121,21 @@ def create_schedule(
     except RecordDoesNotExistError as exc:
         raise BadRequestError(f"Language code {schedule.language} not found.") from exc
 
-    db_schedule = db_create_schedule(
-        session,
-        name=schedule.name,
-        category=ScheduleCategory(schedule.category),
-        language=language,
-        config=config,
-        tags=schedule.tags,
-        enabled=schedule.enabled,
-        notification=schedule.notification,
-        periodicity=schedule.periodicity,
-    )
+    try:
+        db_schedule = db_create_schedule(
+            session,
+            name=schedule.name,
+            category=ScheduleCategory(schedule.category),
+            language=language,
+            config=config,
+            tags=schedule.tags,
+            enabled=schedule.enabled,
+            notification=schedule.notification,
+            periodicity=schedule.periodicity,
+        )
+    except RecordAlreadyExistsError as exc:
+        raise BadRequestError(f"Schedule {schedule.name} already exists") from exc
+
     return JSONResponse(
         content=ScheduleCreateResponseSchema(
             id=db_schedule.id,

--- a/backend/tests/db/test_language.py
+++ b/backend/tests/db/test_language.py
@@ -186,6 +186,38 @@ def test_get_schedule_with_invalid_language_from_db(
 
 
 @pytest.mark.parametrize(
+    "code",
+    ["en", "fr", "invalid"],
+)
+def test_get_schedule_with_invalid_language_from_db(
+    dbsession: OrmSession,
+    create_schedule_config: Callable[..., ScheduleConfigSchema],
+    code: str,
+):
+    # Create test schedule with invalid language code
+    dbsession.add(
+        Schedule(
+            language_code=code,
+            name="test1",
+            category="test",
+            config=create_schedule_config().model_dump(mode="json"),
+            enabled=True,
+            tags=["test"],
+            periodicity="test",
+            notification={"test": "test"},
+        )
+    )
+    dbsession.flush()
+    # assert we can read schedules with invalid codes from db
+    schedule = get_schedule(dbsession, schedule_name="test1")
+    assert schedule.language_code == code
+    schedule_schema = create_schedule_full_schema(schedule)
+    # for unknown languages, the code and name should be the same
+    assert schedule_schema.language.code == code
+    assert schedule_schema.language.name == code
+
+
+@pytest.mark.parametrize(
     "code,name",
     [
         ("eng", "English"),

--- a/backend/tests/db/test_language.py
+++ b/backend/tests/db/test_language.py
@@ -186,38 +186,6 @@ def test_get_schedule_with_invalid_language_from_db(
 
 
 @pytest.mark.parametrize(
-    "code",
-    ["en", "fr", "invalid"],
-)
-def test_get_schedule_with_invalid_language_from_db(
-    dbsession: OrmSession,
-    create_schedule_config: Callable[..., ScheduleConfigSchema],
-    code: str,
-):
-    # Create test schedule with invalid language code
-    dbsession.add(
-        Schedule(
-            language_code=code,
-            name="test1",
-            category="test",
-            config=create_schedule_config().model_dump(mode="json"),
-            enabled=True,
-            tags=["test"],
-            periodicity="test",
-            notification={"test": "test"},
-        )
-    )
-    dbsession.flush()
-    # assert we can read schedules with invalid codes from db
-    schedule = get_schedule(dbsession, schedule_name="test1")
-    assert schedule.language_code == code
-    schedule_schema = create_schedule_full_schema(schedule)
-    # for unknown languages, the code and name should be the same
-    assert schedule_schema.language.code == code
-    assert schedule_schema.language.name == code
-
-
-@pytest.mark.parametrize(
     "code,name",
     [
         ("eng", "English"),


### PR DESCRIPTION
## Rationale
When cloning a schedule, `IntegrityError` is raised but doesn't offer insights on the specifity of the error. Psycopg currently [has 7 exceptions](https://www.psycopg.org/psycopg3/docs/api/errors.html#list-of-known-exceptions) under this category. This PR does an `isinstance` check on the type of error and returns a custom exception depending on the specific error. For now, only `UniqueViolation` errors are caught and propagated.

## Changes
- detect specific integrity error on clone, update and create
