### PR TITLE
Extract offliner validation constraints from API

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/offliners/zimit.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/zimit.py
@@ -189,7 +189,7 @@ class ZimitFlagsFullSchema(CamelModel):
     )
     lang: OptionalNotEmptyString = OptionalField(
         title="Browser Language",
-        description="If set, sets the language used by the browser, should be"
+        description="If set, sets the language used by the browser, should be "
         "ISO 639 language[-country] code, e.g. `en` or `en-GB`",
     )
     title: OptionalZIMTitle = OptionalField(

--- a/backend/src/zimfarm_backend/routes/offliners/logic.py
+++ b/backend/src/zimfarm_backend/routes/offliners/logic.py
@@ -47,11 +47,11 @@ async def get_offliner(offliner: Annotated[Offliner, Path()]) -> JSONResponse:
     if schema_cls is None:
         raise NotFoundError(f"Offliner {offliner} not found")
 
-    definition = schema_to_flags(schema_cls)
+    flags = schema_to_flags(schema_cls)
 
     return JSONResponse(
         content={
-            "flags": definition["flags"],
+            "flags": [flag.model_dump(mode="json") for flag in flags],
             "help": (  # dynamic + sourced from backend because it might be custom
                 f"https://github.com/openzim/{offliner}/wiki/Frequently-Asked-Questions"
             ),

--- a/backend/tests/test_offliner_serializer.py
+++ b/backend/tests/test_offliner_serializer.py
@@ -63,7 +63,7 @@ def test_get_field_type(field_type: Any, expected_type: str):
     ),
 )
 def test_get_enum_choices(field_type: Any, expected_choices: list[str]):
-    choices = [choice["value"] for choice in get_enum_choices(field_type)]
+    choices = [choice.value for choice in get_enum_choices(field_type)]
     assert len(choices) == len(expected_choices)
     for choice in choices:
         assert choice in expected_choices
@@ -90,35 +90,35 @@ def test_is_secret(field: Any, *, is_secret_field: bool):
     assert is_secret(field) == is_secret_field
 
 
-def test_schema_to_flags():
+def test_mw_offliner_schema_to_flags():
     flags = schema_to_flags(MWOfflinerFlagsSchema)
-    for flag in flags["flags"]:
-        key = flag["key"]
+    for flag in flags:
+        key = flag.key
 
         # Check if the flag is required
         if key in (
             "mwUrl",
             "adminEmail",
         ):
-            assert flag["required"]
+            assert flag.required
         else:
-            assert not flag["required"]
+            assert not flag.required
 
         # Check if the flag is secret
         if key in ("mwPassword", "optimisationCacheUrl"):
-            assert flag["secret"]
+            assert flag.secret
         else:
-            assert "secret" not in flag
+            assert not flag.secret
 
         if key in ("format",):
-            assert flag["type"] == "list-of-string-enum"
-            assert "choices" in flag
+            assert flag.type == "list-of-string-enum"
+            assert flag.choices is not None
         elif key in ("customFlavour", "verbose", "forceRender"):
-            assert flag["type"] == "string-enum"
-            assert "choices" in flag
+            assert flag.type == "string-enum"
+            assert flag.choices is not None
         elif key in ("adminEmail",):
-            assert flag["type"] == "email"
-            assert "choices" not in flag
+            assert flag.type == "email"
+            assert flag.choices is None
         elif key in (
             "getCategories",
             "keepEmptyParagraphs",
@@ -127,17 +127,33 @@ def test_schema_to_flags():
             "insecure",
             "withoutZimFullTextIndex",
         ):
-            assert flag["type"] == "boolean"
-            assert "choices" not in flag
+            assert flag.type == "boolean"
+            assert flag.choices is None
         elif key in ("requestTimeout",):
-            assert flag["type"] == "integer"
-            assert "choices" not in flag
+            assert flag.type == "integer"
+            assert flag.choices is None
         elif key in ("speed",):
-            assert flag["type"] == "float"
-            assert "choices" not in flag
+            assert flag.type == "float"
+            assert flag.choices is None
         elif key in ("mwUrl", "articleList", "articleListToIgnore", "customZimFavicon"):
-            assert flag["type"] == "url"
-            assert "choices" not in flag
+            assert flag.type == "url"
+            assert flag.choices is None
         else:
-            assert flag["type"] == "string"
-            assert "choices" not in flag
+            assert flag.type == "string"
+            assert flag.choices is None
+
+        # Validat that restrictions are correctly inferred
+        if key in ("customZIMTitle",):
+            assert flag.min_length == 1
+            assert flag.min_length == 30
+        elif key in ("customZIMDescription",):
+            assert flag.min_length == 1
+            assert flag.min_length == 80
+        elif key in ("customZIMLongDescription",):
+            assert flag.min_length == 1
+            assert flag.min_length == 4000
+        elif key in ("customZimLanguage",):
+            assert flag.min_length == 3
+            assert flag.max_length == 3
+        elif key in ("outputDirectory",):
+            assert flag.pattern is not None

--- a/frontend-ui/src/types/offliner.ts
+++ b/frontend-ui/src/types/offliner.ts
@@ -10,6 +10,11 @@ export interface OfflinerDefinition {
   key: string;
   required: boolean;
   type: string;
+  min: number | null;
+  max: number | null;
+  min_length: number | null;
+  max_length: number | null;
+  pattern: string | null;
 }
 
 export interface OfflinerDefinitionResponse {


### PR DESCRIPTION
## Rationale
By returning the same validation constraints (`min_length`, `max_length`, etc) used in the definition of an offliner from the backend, the UI/clients can reuse these validation rules to enforce constraints on their end e.g the ScheduleEditor. 

## Changes
- extract validation information from fields and return to clients
- use in schedule editor for client side validation of user inputs
- default to original Pydantic `Field` for passing validation rules
- use [WrapValidator](https://docs.pydantic.dev/latest/concepts/validators/#field-wrap-validator) to bypass validation instead of `AfterValidator` for cases where the validation information can be passed to `Field`

