### PR TITLE
remove zimcheck from receiver

### DIFF
--- a/receiver/Dockerfile
+++ b/receiver/Dockerfile
@@ -48,18 +48,11 @@ VOLUME /mnt/quarantine
 VOLUME /mnt/zim
 VOLUME /mnt/check_logs
 
-ENV ZIM_TOOLS_URL https://download.openzim.org/release/zim-tools/zim-tools_linux-x86_64-3.6.0.tar.gz
 ENV ZIM_SRC_DIR /jail/zim
 ENV ZIM_DST_DIR /mnt/zim
 ENV ZIM_QUAR_DIR /mnt/quarantine
-ENV VALIDATION_LOG_DIR /mnt/check_logs
-ENV ZIMCHECK_OPTION -A
 ENV ZIMCHECK_PARALLEL_JOBS 2
 
-RUN wget -nv -O zim-tools.tar.gz -q $ZIM_TOOLS_URL && \
-  tar -xzf zim-tools.tar.gz && \
-  cp zim-tools*/* /usr/local/bin/ && \
-  rm -rf zim-tools*
 COPY apps/check_zims.sh /usr/local/bin/
 COPY apps/check_zim.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/check_zim.sh /usr/local/bin/check_zims.sh

--- a/receiver/apps/check_zim.sh
+++ b/receiver/apps/check_zim.sh
@@ -2,21 +2,18 @@
 #
 # Author : Florent Kaisser
 #
-# Usage : check_zim.sh <zimFilePath> <zimSrcDir> <zimDstDir> <zimQuarantineDir> <logDir> <zimCheckOptions> [NO_QUARANTINE|NO_CHECK]
+# Usage : check_zim.sh <zimFilePath> <zimSrcDir> <zimDstDir> <zimQuarantineDir> [NO_QUARANTINE|NO_CHECK]
 #
-
-ZIMCHECK=/usr/local/bin/zimcheck
 
 ZIMFILE=$1
 ZIMSRCDIR=$2
-ZIMCHECK_OPTION=$6
-OPTION=$7
+OPTION=$5
 
 
 ZIMPATH=$(echo $ZIMFILE | sed "s:$ZIMSRCDIR::")
 
 DESTFILE=$3$ZIMPATH
-DESTDIR=$(dirname $DESTFILE)
+DESTDIR=$(dirname "$DESTFILE")
 
 if [ "$OPTION" = "NO_QUARANTINE" ]
 then
@@ -24,14 +21,9 @@ then
  QUARFILE=$DESTFILE
 else
  QUARFILE=$4$ZIMPATH
- QUARDIR=$(dirname $QUARFILE)
+ QUARDIR=$(dirname "$QUARFILE")
 fi
 
-LOGFILE=$(echo "$5$ZIMPATH" | cut -f 1 -d '.').log
-LOGDIR=$(dirname $5$ZIMPATH)
-
-NAME_FORMAT="^(.+?_)([a-z\-]{2,10}?_|)(.+_|)([\d]{4}|)\-([\d]{2})$"
-ZIM_NAME=$(basename "$ZIMPATH" .zim)
 
 function moveZim () {
    mkdir -p $1
@@ -47,24 +39,5 @@ if [ $(dirname $ZIMPATH) = "." ] ; then
   exit 0
 fi
 
-if [ "$OPTION" = "NO_CHECK" ]
-then
-  echo "move $ZIMFILE to $DESTFILE"
-  moveZim $DESTDIR $DESTFILE
-else
-  mkdir -p $LOGDIR
-  if $ZIMCHECK $ZIMCHECK_OPTION $ZIMFILE > $LOGFILE 2>&1
-  then
-   if (echo $ZIM_NAME | grep -q -P $NAME_FORMAT)
-   then
-    echo "$ZIMFILE is valid" >> $LOGFILE
-    moveZim $DESTDIR $DESTFILE
-   else
-    echo "$ZIMFILE is valid but name is in an invalid format" >> $LOGFILE
-    moveZim $QUARDIR $QUARFILE
-   fi
-  else
-   echo "$ZIMFILE is not valid" >> $LOGFILE
-   moveZim $QUARDIR $QUARFILE
-  fi
-fi
+echo "move $ZIMFILE to $DESTFILE"
+moveZim $DESTDIR $DESTFILE

--- a/receiver/apps/check_zims.sh
+++ b/receiver/apps/check_zims.sh
@@ -2,19 +2,17 @@
 #
 # Author : Emmanuel Engelhart
 #
-# Usage : check_zims <nbJobs> <zimSrcDir> <zimDstDir> <zimQuarantineDir> <logDir> <zimCheckOptions> [NO_QUARANTINE|NO_CHECK]
+# Usage : check_zims <nbJobs> <zimSrcDir> <zimDstDir> <zimQuarantineDir> [NO_QUARANTINE|NO_CHECK]
 #
 
 ZIMCHECK_PARALLEL_JOBS=$1
 ZIM_SRC_DIR=$2
 ZIM_DST_DIR=$3
 ZIM_QUAR_DIR=$4
-VALIDATION_LOG_DIR=$5
-ZIMCHECK_OPTION=$6
-VALIDATION_OPTION=$7
+ZIMCHECK_OPTION=$5
 
 PARALLEL="parallel -j${ZIMCHECK_PARALLEL_JOBS}"
 ZIMCHECK='/usr/local/bin/check_zim.sh'
 
 find $ZIM_SRC_DIR -iname '*.zim' |
-    $PARALLEL "$ZIMCHECK {} $ZIM_SRC_DIR $ZIM_DST_DIR $ZIM_QUAR_DIR $VALIDATION_LOG_DIR \"$ZIMCHECK_OPTION\" $VALIDATION_OPTION"
+    $PARALLEL "$ZIMCHECK {} $ZIM_SRC_DIR $ZIM_DST_DIR $ZIM_QUAR_DIR \"$ZIMCHECK_OPTION\""

--- a/receiver/entrypoint.sh
+++ b/receiver/entrypoint.sh
@@ -23,7 +23,7 @@ cat $JSON_PATH
 /etc/init.d/ssh start
 
 # Create cron entry for ZIM quarantine
-echo "* *  * * *  root  /usr/bin/flock -w 0 /dev/shm/cron.lock /usr/local/bin/check_zims.sh $ZIMCHECK_PARALLEL_JOBS $ZIM_SRC_DIR $ZIM_DST_DIR $ZIM_QUAR_DIR $VALIDATION_LOG_DIR \"$ZIMCHECK_OPTION\" $VALIDATION_OPTION >> /dev/shm/check_zims.log 2>&1" >> /etc/cron.d/check_zims
+echo "* *  * * *  root  /usr/bin/flock -w 0 /dev/shm/cron.lock /usr/local/bin/check_zims.sh $ZIMCHECK_PARALLEL_JOBS $ZIM_SRC_DIR $ZIM_DST_DIR $ZIM_QUAR_DIR \"$ZIMCHECK_OPTION\" >> /dev/shm/check_zims.log 2>&1" >> /etc/cron.d/check_zims
 chmod +x /etc/cron.d/check_zims
 
 exec "$@"


### PR DESCRIPTION
## Rationale
Remove `zimcheck` from receiver as it is done in worker. Receiver now moves files only to uploader.

## Changes
- remove zim-tools in Dockerfile since it's the provider of the `zimcheck` CLI
- remove `zimcheck` specific options as they are no longer needed

This fixes #655 