### PR TITLE
update ssh keys for receiver and uploader communication

### DIFF
--- a/backend/src/zimfarm_backend/db/ssh_key.py
+++ b/backend/src/zimfarm_backend/db/ssh_key.py
@@ -17,7 +17,7 @@ def get_ssh_key_by_fingerprint_or_none(
         select(Sshkey)
         .options(selectinload(Sshkey.user))
         .where(Sshkey.fingerprint == fingerprint)
-    ).one_or_none()
+    ).first()
 
 
 def create_ssh_key(
@@ -28,6 +28,7 @@ def create_ssh_key(
     key: str,
     pkcs8_key: str,
     name: str,
+    type_: str,
 ) -> Sshkey:
     """Create a new ssh key"""
     ssh_key = Sshkey(
@@ -35,7 +36,7 @@ def create_ssh_key(
         key=key,
         pkcs8_key=pkcs8_key,
         name=name,
-        type="RSA",
+        type=type_,
         added=getnow(),
     )
 

--- a/backend/src/zimfarm_backend/routes/users/logic.py
+++ b/backend/src/zimfarm_backend/routes/users/logic.py
@@ -1,6 +1,7 @@
 from http import HTTPStatus
 from typing import Annotated
 
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPublicKey
 from fastapi import APIRouter, Depends, Path, Query, Response
 from sqlalchemy.orm import Session
 from werkzeug.security import check_password_hash, generate_password_hash
@@ -217,6 +218,7 @@ def create_user_key(
         key=ssh_key.key,
         pkcs8_key=serialize_public_key(public_key).decode("ascii"),
         name=ssh_key.name,
+        type_="RSA" if isinstance(public_key, RSAPublicKey) else "ECDSA",
     )
     return SshKeyRead.model_validate(db_ssh_key)
 

--- a/backend/src/zimfarm_backend/routes/users/models.py
+++ b/backend/src/zimfarm_backend/routes/users/models.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Any
 
-from pydantic import EmailStr, Field, computed_field
+from pydantic import EmailStr, Field, computed_field, field_validator
 
 from zimfarm_backend.common.roles import RoleEnum, get_role_for
 from zimfarm_backend.common.schemas import BaseModel
@@ -79,8 +79,20 @@ class KeySchema(BaseModel):
     Schema for creating a ssh key
     """
 
-    name: NotEmptyString
     key: NotEmptyString
+
+    @field_validator("key", mode="after")
+    @classmethod
+    def validate_key(cls, value: str) -> str:
+        value = value.strip()
+        if len(value.split(" ")) != 3:  # noqa: PLR2004
+            raise ValueError("Key does not appear to be an SSH public file.")
+        return value
+
+    @computed_field
+    @property
+    def name(self) -> str:
+        return self.key.split(" ")[2]
 
 
 class PasswordUpdateSchema(BaseModel):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -96,8 +96,8 @@ def rsa_public_key(rsa_private_key: RSAPrivateKey) -> RSAPublicKey:
 def rsa_public_key_data(rsa_private_key: RSAPrivateKey) -> bytes:
     """Serialize public key using PEM format."""
     return rsa_private_key.public_key().public_bytes(
-        encoding=serialization.Encoding.PEM,
-        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+        encoding=serialization.Encoding.OpenSSH,
+        format=serialization.PublicFormat.OpenSSH,
     )
 
 
@@ -146,7 +146,7 @@ def create_user(
 
         key = Sshkey(
             name=data_gen.word(),
-            key=rsa_public_key_data.decode("ascii"),
+            key=rsa_public_key_data.decode("ascii") + " test@localhost",
             fingerprint=get_public_key_fingerprint(rsa_public_key),
             type="RSA",
             added=getnow(),

--- a/frontend-ui/src/components/UpdateUser.vue
+++ b/frontend-ui/src/components/UpdateUser.vue
@@ -208,21 +208,13 @@ const keyFileSelected = () => {
     const parts = result.trim().split(/\s/)
     if (parts.length !== 3) {
       notificationStore.showError(
-        `File ${file.name} doesn't appear to be an RSA public file (format).`
+        `File ${file.name} doesn't appear to be an SSH public file.`
       )
       // Clear the file input on error
       keyFile.value = null
       return
     }
 
-    if (parts[0].toLowerCase().indexOf('rsa') === -1) {
-      notificationStore.showError(
-        `File ${file.name} doesn't appear to be an RSA public file (no RSA prefix).`
-      )
-      // Clear the file input on error
-      keyFile.value = null
-      return
-    }
     keyForm.value.key = result.trim()
     keyForm.value.name = parts[2].trim()
   }

--- a/frontend-ui/src/stores/user.ts
+++ b/frontend-ui/src/stores/user.ts
@@ -124,10 +124,10 @@ export const useUserStore = defineStore('user', () => {
     }
   }
 
-  const addSshKey = async (username: string, payload: { name: string; key: string }) => {
+  const addSshKey = async (username: string, payload: { key: string }) => {
     const service = await authStore.getApiService('users')
     try {
-      await service.post<{ name: string; key: string }, SshKeyRead>(`/${username}/keys`, payload)
+      await service.post<{ key: string }, SshKeyRead>(`/${username}/keys`, payload)
       errors.value = []
       return true
     } catch (error) {

--- a/receiver/apps/get_zimfarm_key.py
+++ b/receiver/apps/get_zimfarm_key.py
@@ -53,10 +53,7 @@ def print_keys_for(username, fingerprint):
     print("\n".join(keys))
 
 
-def fetch_public_keys_for(username, raw_fingerprint):
-    # convert fingerprint to dispatcher's format
-    fingerprint = "".join(raw_fingerprint.split(":")[1:])
-
+def fetch_public_keys_for(username, fingerprint):
     req = requests.get(
         url=f"{environ['ZIMFARM_WEBAPI']}/users/-/keys/{fingerprint}",
         params={"with_permission": ["zim.upload"]},
@@ -70,16 +67,14 @@ def fetch_public_keys_for(username, raw_fingerprint):
         reason = f"HTTP {req.status_code}."
         if response and "message" in response:
             reason += f" {response['message']}"
-        logger.warning(
-            f"failed login attempt using {raw_fingerprint}/{fingerprint}: {reason}"
-        )
+        logger.warning(f"failed login attempt using {fingerprint}: {reason}")
         return
 
     logger.info(
         f"granted login for {response['username']} via {response['type']} key "
         f"{response['name']}"
     )
-    return [f"ssh-rsa {response['key']} {response['name']}"]
+    return [f"{response['key']}"]
 
 
 if __name__ == "__main__":

--- a/receiver/sshd_config
+++ b/receiver/sshd_config
@@ -42,7 +42,7 @@ PubkeyAuthentication yes
 
 #AuthorizedPrincipalsFile none
 
-FingerprintHash md5
+FingerprintHash sha256
 AuthorizedKeysCommand /usr/bin/get_zimfarm_keys %u %f
 AuthorizedKeysCommandUser nobody
 


### PR DESCRIPTION
## Changes
- change Fingerprint hash function from md5 to sha256 for receiver sshd config (same hash function used by the new API)
-  newer API stores the full ssh in the `key` column. refactor `get_zimfarm_key` in `receiver` to return it as the key for authentication
- sometimes, there might be workers with the same fingerprint (or key) as there is no `unique` constraint. so, we return the `first` entry that matches the fingerprint. `one_or_none` raises a MultipleRows exception
