### PR TITLE
expire ssh keys

### DIFF
--- a/backend/src/zimfarm_backend/common/constants.py
+++ b/backend/src/zimfarm_backend/common/constants.py
@@ -158,3 +158,7 @@ POSTGRES_URI = getenv("POSTGRES_URI", mandatory=True)
 WORKER_OFFLINE_DELAY_DURATION = parse_timespan(
     getenv("WORKER_OFFLINE_DELAY_DURATION", default="20m")
 )
+
+SSH_KEY_EXPIRY_DURATION = parse_timespan(
+    getenv("SSH_KEY_EXPIRY_DURATION", default="365d")
+)

--- a/backend/src/zimfarm_backend/routes/users/models.py
+++ b/backend/src/zimfarm_backend/routes/users/models.py
@@ -3,6 +3,8 @@ from typing import Any
 
 from pydantic import EmailStr, Field, computed_field, field_validator
 
+from zimfarm_backend.common import getnow
+from zimfarm_backend.common.constants import SSH_KEY_EXPIRY_DURATION
 from zimfarm_backend.common.roles import RoleEnum, get_role_for
 from zimfarm_backend.common.schemas import BaseModel
 from zimfarm_backend.common.schemas.fields import NotEmptyString
@@ -50,6 +52,14 @@ class SshKeyRead(BaseSshKeySchema):
     added: datetime.datetime
     fingerprint: str
     pkcs8_key: str
+
+    @computed_field
+    @property
+    def has_expired(self) -> bool:
+        """Check if the key has expired (not active)"""
+        return getnow() > self.added + datetime.timedelta(
+            seconds=SSH_KEY_EXPIRY_DURATION
+        )
 
 
 class BaseUserWithSshKeysSchema(BaseUserSchema, BaseSshKeySchema):

--- a/backend/tests/routes/test_user.py
+++ b/backend/tests/routes/test_user.py
@@ -263,6 +263,7 @@ def test_list_user_keys(client: TestClient, users: list[User]):
         "type",
         "added",
         "pkcs8_key",
+        "has_expired",
     }
 
 


### PR DESCRIPTION
## Rationale

As per NIST recommendations, SSH keys should be rotated once or twice per year. This PR adds features to flag a key as expired if the date which it was added is greater than `SSH_KEY_EXPIRY_DURATION`. This way, workers are forced to delete old keys and create new ones.

## Changes
- add `SSH_KEY_EXPIRY_DURATION` to control when keys are considered as expired
- exclude keys that have "expired" from `db_get_ssh_key_by_fingerprint` used by workers to authenticate with backend
- include has expired flag in users list response
