### PR TITLE
add zimfarm prefix to uploader and dnscache images

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Build and publish Docker Image
         uses: openzim/docker-publish-action@v10
         with:
-          image-name: openzim/dnscache
+          image-name: openzim/zimfarm-dnscache
           on-master: latest
           tag-pattern: /^dnscache-v([0-9.]+)$/
           restrict-to: openzim/zimfarm
@@ -91,7 +91,7 @@ jobs:
       - name: Build and publish Docker Image
         uses: openzim/docker-publish-action@v10
         with:
-          image-name: openzim/uploader
+          image-name: openzim/zimfarm-uploader
           on-master: latest
           tag-pattern: /^uploader-v([0-9.]+)$/
           restrict-to: openzim/zimfarm

--- a/worker/src/zimfarm_worker/common/constants.py
+++ b/worker/src/zimfarm_worker/common/constants.py
@@ -30,8 +30,12 @@ TASK_WORKER = "task-worker"
 TASK_WORKER_IMAGE = getenv(
     "TASK_WORKER_IMAGE", default="ghcr.io/openzim/zimfarm-task-worker:latest"
 )
-DNSCACHE_IMAGE = getenv("DNSCACHE_IMAGE", default="ghcr.io/openzim/dnscache:latest")
-UPLOADER_IMAGE = getenv("UPLOADER_IMAGE", default="ghcr.io/openzim/uploader:latest")
+DNSCACHE_IMAGE = getenv(
+    "DNSCACHE_IMAGE", default="ghcr.io/openzim/zimfarm-dnscache:latest"
+)
+UPLOADER_IMAGE = getenv(
+    "UPLOADER_IMAGE", default="ghcr.io/openzim/zimfarm-uploader:latest"
+)
 CHECKER_IMAGE = getenv("CHECKER_IMAGE", default="ghcr.io/openzim/zim-tools:3.6.0")
 MONITOR_IMAGE = getenv(
     "MONITOR_IMAGE", default="ghcr.io/openzim/zimfarm-monitor:latest"


### PR DESCRIPTION
## Rationale
By adding `zimfarm-` prefix to uploader and dnscache docker images, it becomes clear that these images belong to zimfarm. This fixes #1286
