### PR TITLE
fix duration display for schedule

### DIFF
--- a/frontend-ui/src/utils/offliner.ts
+++ b/frontend-ui/src/utils/offliner.ts
@@ -128,7 +128,7 @@ export function buildScheduleDuration(duration: ScheduleDuration | null): Single
   if (minWorker == maxWorker && minWorker.worker_name) {
     return single_duration(
       duration.workers[minWorker.worker_name].value,
-      minWorker.toString(),
+      minWorker.worker_name,
       duration.workers[minWorker.worker_name].on
     );
   }

--- a/frontend-ui/src/views/ScheduleDetailView.vue
+++ b/frontend-ui/src/views/ScheduleDetailView.vue
@@ -198,7 +198,7 @@
                     <td>
                       <span v-if="durationDict.single">
                         {{ formatDuration(durationDict.value) }}
-                        (<code>{{ durationDict.worker }}</code> on {{ formatDt(durationDict.on) }})
+                        (<code class="text-pink-accent-2">{{ durationDict.worker }}</code> on {{ formatDt(durationDict.on) }})
                       </span>
                       <span v-else>
                         between {{ formatDuration(durationDict.minValue || 0) }} (<code
@@ -857,7 +857,7 @@ const getStatusColor = (status: string): string => {
     case 'pending':
       return 'warning'
     default:
-      return 'grey'
+      return 'dark-grey'
   }
 }
 


### PR DESCRIPTION
## Changes
- fix bug with duration display showing `([object Object] on April 8, 2025 at 4:13 PM GMT+1) ` by call to `toString()` instead of worker name
- use `dark-grey` as default task status color
