### PR TITLE
treat zim metadata values as graphemes

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -31,7 +31,8 @@ dependencies = [
     "psycopg[binary,pool] == 3.2.9",
     "Werkzeug == 3.1.3",
     "cryptography == 45.0.3",
-    "pycountry == 24.6.1"
+    "pycountry == 24.6.1",
+    "regex == 2025.9.1"
 ]
 dynamic = ["version"]
 

--- a/frontend-ui/package.json
+++ b/frontend-ui/package.json
@@ -22,6 +22,7 @@
     "jwt-decode": "^4.0.0",
     "luxon": "^3.6.1",
     "pinia": "^3.0.3",
+    "split-by-grapheme": "^1.0.1",
     "vite-plugin-vuetify": "^2.1.1",
     "vue": "^3.5.17",
     "vue-cookies": "^1.8.6",

--- a/frontend-ui/src/components/ScheduleEditor.vue
+++ b/frontend-ui/src/components/ScheduleEditor.vue
@@ -450,6 +450,7 @@ import type { Schedule, ScheduleConfig, ScheduleUpdateSchema } from '@/types/sch
 import { fuzzyFilter, stringArrayEqual } from '@/utils/cmp'
 import { formattedBytesSize } from '@/utils/format'
 import diff from 'deep-diff'
+import { byGrapheme } from 'split-by-grapheme'
 import { computed, onUnmounted, ref, watch } from 'vue'
 
 interface FlagField {
@@ -782,7 +783,7 @@ const getFieldRules = (field: FlagField) => {
   if (field.min_length !== null) {
     rules.push((value: unknown) => {
       if (shouldValidate(value) && typeof value === 'string') {
-        if (value.length < field.min_length!) {
+        if (value.split(byGrapheme).length < field.min_length!) {
           return `Minimum length is ${field.min_length} characters`
         }
       }
@@ -794,7 +795,7 @@ const getFieldRules = (field: FlagField) => {
   if (field.max_length !== null) {
     rules.push((value: unknown) => {
       if (shouldValidate(value) && typeof value === 'string') {
-        if (value.length > field.max_length!) {
+        if (value.split(byGrapheme).length > field.max_length!) {
           return `Maximum length is ${field.max_length} characters`
         }
       }

--- a/frontend-ui/yarn.lock
+++ b/frontend-ui/yarn.lock
@@ -2934,6 +2934,11 @@ speakingurl@^14.0.1:
   resolved "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz"
   integrity sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==
 
+split-by-grapheme@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/split-by-grapheme/-/split-by-grapheme-1.0.1.tgz#4d2b006b986a5fbe2c23357929e1566af7557dc1"
+  integrity sha512-aH+OtxnX+AOyWJvw2hNaQyY9wkzkG6o8URD+rRwFKWkqUduxMA+icOBJv1/aoLuKbb15f0qRHXM+rs94Q50blA==
+
 stackback@0.0.2:
   version "0.0.2"
   resolved "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz"


### PR DESCRIPTION
## Rationale
Zim metadata values are to be counted as graphemes and not bare strings as some languages need multiple unicode characters to render their string
## Changes
- define custom string class that overrides `__len__` to count number of graphemes. this allows to still get the validation logic extraction working as pydantic expects the type to be comparable.
- count inputs by graphemes on frontend

This fixes #1298 