### PR TITLE
load jinja templates via BASE_DIR

### DIFF
--- a/backend/periodic.conf.dev
+++ b/backend/periodic.conf.dev
@@ -1,0 +1,40 @@
+# define your periodic tasks here
+# use the following template making sure that:
+#  - you dont capture stdout for the eventlistener
+#  - you send its stderr to /dev/stdout (so it appears in logs)
+#  - you select a period (TICK_5 TICK_60 TICK_3600) that is shorter than your period
+#  - you specify the seconds interval of your period as arg 1 of the command
+#  - you specify the actual script path as arg 2 of the command (any subsequant arg it sent to your script)
+#
+#  template bellow (/app/my-script.sh every 2mn)
+#    [eventlistener:my-task-name]
+#    command=supervisor-listener 120 /app/my-script.sh
+#    events=TICK_60
+#    stderr_logfile=/dev/stdout
+#    stderr_logfile_maxbytes=0
+
+# periodic tasks (cleanup)  -- every 10mn
+# [eventlistener:zimfarm-periodic]
+# command=supervisor-listener 550 /app/periodic-tasks.py
+# events=TICK_60
+# stderr_logfile=/dev/stdout
+# stderr_logfile_maxbytes=0
+
+# periodic scheduler (creation of requested-tasks) -- every hour
+# [eventlistener:zimfarm-scheduler]
+# command=supervisor-listener 3500 /app/periodic-scheduler.py
+# events=TICK_3600
+# stderr_logfile=/dev/stdout
+# stderr_logfile_maxbytes=0
+
+
+[program:uvicorn]
+command=uvicorn zimfarm_backend.main:app --host 0.0.0.0 --port 80 --proxy-headers --forwarded-allow-ips "*" --reload --reload-dir /usr/local/lib/python3.13/site-packages/zimfarm_backend
+autostart=true
+autorestart=true
+startsecs=0
+exitcodes=0
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/stderr
+stderr_logfile_maxbytes=0

--- a/backend/src/zimfarm_backend/common/notifications.py
+++ b/backend/src/zimfarm_backend/common/notifications.py
@@ -14,6 +14,7 @@ from jinja2 import Environment, FileSystemLoader, select_autoescape
 from pydantic import ValidationError
 
 from zimfarm_backend.common.constants import (
+    BASE_DIR,
     PUBLIC_URL,
     REQ_TIMEOUT_NOTIFICATIONS,
     SLACK_EMOJI,
@@ -35,7 +36,7 @@ from zimfarm_backend.db.tasks import get_task_by_id_or_none
 
 logger = logging.getLogger(__name__)
 jinja_env = Environment(
-    loader=FileSystemLoader("templates"),
+    loader=FileSystemLoader(BASE_DIR / "templates"),
     autoescape=select_autoescape(["html", "xml", "txt"]),
 )
 jinja_env.filters["short_id"] = lambda value: str(value)[:5]

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -27,19 +27,7 @@ services:
       - ../backend/periodic-tasks.py:/app/periodic-tasks.py
       - ../backend/maint-scripts:/app/maint-scripts
       - ../backend/src/zimfarm_backend:/usr/local/lib/python3.13/site-packages/zimfarm_backend
-    command:
-      - uvicorn
-      - zimfarm_backend.main:app
-      - --host
-      - "0.0.0.0"
-      - --port
-      - "80"
-      - --proxy-headers
-      - --forwarded-allow-ips
-      - "*"
-      - --reload
-      - --reload-dir
-      - /usr/local/lib/python3.13/site-packages/zimfarm_backend
+      - ../backend/periodic.conf.dev:/etc/supervisor/conf.d/periodic.conf:ro
     ports:
       - 127.0.0.1:8000:80
     environment:


### PR DESCRIPTION
## Changes
- use `BASE_DIR` to compute `templates` directory for jinja templates
- add dev periodic.conf file for development with reload


This fixes #1300 