### PR TITLE
fix bug in retrieval of worker resources

### DIFF
--- a/worker/src/zimfarm_worker/common/constants.py
+++ b/worker/src/zimfarm_worker/common/constants.py
@@ -1,3 +1,4 @@
+import logging
 import multiprocessing
 import os
 import re
@@ -73,8 +74,13 @@ ZIMFARM_DISK_SPACE = as_pos_int(
 )
 
 physical_cpu = multiprocessing.cpu_count()
-zimfarm_cpus = as_pos_int(int(getenv("ZIMFARM_CPUS", default=physical_cpu)))
-ZIMFARM_CPUS = min([zimfarm_cpus, physical_cpu])
+
+ZIMFARM_CPUS = as_pos_int(int(getenv("ZIMFARM_CPUS", default=physical_cpu)))
+if ZIMFARM_CPUS > physical_cpu:
+    logging.warning(
+        f"Declared CPU count {ZIMFARM_CPUS} appears to be greater than actual CPU count"
+        f"{physical_cpu}"
+    )
 
 zimfarm_task_cpus = getenv("ZIMFARM_TASK_CPUS", default="")
 ZIMFARM_TASK_CPUS = float(zimfarm_task_cpus) if zimfarm_task_cpus else None
@@ -91,10 +97,15 @@ ZIMFARM_TASK_CPUSET = zimfarm_task_cpuset
 
 
 physical_mem = psutil.virtual_memory().total
-zimfarm_memory = as_pos_int(
+ZIMFARM_MEMORY = as_pos_int(
     humanfriendly.parse_size(getenv("ZIMFARM_MEMORY", default=str(physical_mem)))
 )
-ZIMFARM_MEMORY = min([zimfarm_memory, physical_mem])
+
+if ZIMFARM_MEMORY > physical_mem:
+    logging.warning(
+        f"Declared memory {ZIMFARM_MEMORY} appears to be greater than actual memory "
+        f"{physical_mem}"
+    )
 
 USE_PUBLIC_DNS = parse_bool(getenv("USE_PUBLIC_DNS", default="False"))
 DISABLE_IPV6 = parse_bool(getenv("DISABLE_IPV6", default="False"))


### PR DESCRIPTION
## Rationale
I introduced a bug while trying to get rid of the old way of setting resources from env vars.
The old code did this:
```py
ZIMFARM_MEMORY = None
try:
    ZIMFARM_MEMORY = as_pos_int(humanfriendly.parse_size(os.getenv("ZIMFARM_MEMORY")))
except Exception:
    physical_mem = psutil.virtual_memory().total
    if ZIMFARM_MEMORY:
        ZIMFARM_MEMORY = min([ZIMFARM_MEMORY, physical_mem])
    else:
        ZIMFARM_MEMORY = physical_mem
```

This PR refactors it to this:
```py
physical_mem = psutil.virtual_memory().total
ZIMFARM_MEMORY = as_pos_int(
    humanfriendly.parse_size(getenv("ZIMFARM_MEMORY", default=str(physical_mem)))
)
```

In the old code, `ZIMFARM_MEMORY` starts out as None and tries to read an env variable. If an exception happens, the block `if ZIMFARM_MEMORY` would never be entered because it starts out as `None`. So, it would always default to `physical_mem`.

The new code does pretty much the same thing but doesn't catch the exception which I think is a good thing. If a user sets a value that isn't an integer, then, the program shouldn't start.

The diff in the PR shows the flaw when I was to simplifying the logic.