### PR TITLE
use paths filter for pull requests

### DIFF
--- a/.github/workflows/backend-QA.yml
+++ b/.github/workflows/backend-QA.yml
@@ -2,6 +2,8 @@ name: Backend QA
 
 on:
   pull_request:
+    paths:
+      - "backend/**"
   push:
     paths:
       - "backend/**"

--- a/.github/workflows/backend-Tests.yml
+++ b/.github/workflows/backend-Tests.yml
@@ -2,6 +2,8 @@ name: Backend Tests
 
 on:
   pull_request:
+    paths:
+      - "backend/**"
   push:
     paths:
       - "backend/**"

--- a/.github/workflows/dnscache-Tests.yml
+++ b/.github/workflows/dnscache-Tests.yml
@@ -2,6 +2,8 @@ name: Dnscache Tests
 
 on:
   pull_request:
+    paths:
+      - "dnscache/**"
   push:
     paths:
       - "dnscache/**"

--- a/.github/workflows/frontend-QA.yml
+++ b/.github/workflows/frontend-QA.yml
@@ -2,6 +2,8 @@ name: Frontend QA
 
 on:
   pull_request:
+    paths:
+      - "frontend-ui/**"
   push:
     paths:
       - "frontend-ui/**"

--- a/.github/workflows/frontend-Tests.yml
+++ b/.github/workflows/frontend-Tests.yml
@@ -2,6 +2,8 @@ name: Frontend Tests
 
 on:
   pull_request:
+    paths:
+      - "frontend-ui/**"
   push:
     paths:
       - "frontend-ui/**"

--- a/.github/workflows/receiver-Tests.yml
+++ b/.github/workflows/receiver-Tests.yml
@@ -2,6 +2,8 @@ name: Receiver Tests
 
 on:
   pull_request:
+    paths:
+      - "receiver/**"
   push:
     paths:
       - "receiver/**"

--- a/.github/workflows/uploader-Tests.yml
+++ b/.github/workflows/uploader-Tests.yml
@@ -2,6 +2,8 @@ name: Uploader Tests
 
 on:
   pull_request:
+    paths:
+      - "uploader/**"
   push:
     paths:
       - "uploader/**"

--- a/.github/workflows/watcher-Tests.yml
+++ b/.github/workflows/watcher-Tests.yml
@@ -2,6 +2,8 @@ name: Watcher Tests
 
 on:
   pull_request:
+    paths:
+      - "watcher/**"
   push:
     paths:
       - "watcher/**"

--- a/.github/workflows/worker-QA.yml
+++ b/.github/workflows/worker-QA.yml
@@ -2,6 +2,8 @@ name: Worker QA
 
 on:
   pull_request:
+    paths:
+      - "worker/**"
   push:
     paths:
       - "worker/**"

--- a/.github/workflows/worker-Tests.yml
+++ b/.github/workflows/worker-Tests.yml
@@ -2,6 +2,8 @@ name: Worker Tests
 
 on:
   pull_request:
+    paths:
+      - "worker/**"
   push:
     paths:
       - "worker/**"


### PR DESCRIPTION
## Rationale

Previously, if a pull request is submitted, all the CI workflows are triggered even though the change has nothing to do with certain directories. By specifiying `paths` filters, we potentially skip waiting for CI jobs that have nothing to do with the PR to complete.

## Changes
- use `paths` filter for pull requests in workflows