### PR TITLE
define type for relaxing validation of gutenberg one-language-one-zim

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/fields.py
+++ b/backend/src/zimfarm_backend/common/schemas/fields.py
@@ -230,6 +230,9 @@ ZIMOutputFolder = Annotated[
     str, Field(pattern=r"^/output$"), WrapValidator(skip_validation)
 ]
 
+SkipableBool = Annotated[bool, WrapValidator(skip_validation)]
+OptionalSkipableBool = SkipableBool | None
+
 OptionalZIMOutputFolder = ZIMOutputFolder | None
 
 ZIMProgressFile = Annotated[

--- a/backend/src/zimfarm_backend/common/schemas/offliners/gutenberg.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/gutenberg.py
@@ -7,6 +7,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalField,
     OptionalNotEmptyString,
     OptionalSecretUrl,
+    OptionalSkipableBool,
     OptionalZIMDescription,
     OptionalZIMProgressFile,
     OptionalZIMTitle,
@@ -65,7 +66,7 @@ class GutenbergFlagsSchema(DashModel):
     # Given we can't set the output dir for regular mode, we're using this
     # flag to switch between the two and the path is set to the mount point
     # in command_for() (offliners.py)
-    one_language_one_zim: bool | None = OptionalField(
+    one_language_one_zim: OptionalSkipableBool = OptionalField(
         title="Multiple ZIMs",
         description="Create one ZIM per language",
     )

--- a/backend/tests/test_validators.py
+++ b/backend/tests/test_validators.py
@@ -9,6 +9,7 @@ from zimfarm_backend.common.constants import parse_bool
 from zimfarm_backend.common.schemas.fields import (
     CommaSeparatedZIMLangCode,
     GraphemeStr,
+    SkipableBool,
     ZIMFileName,
     ZIMLangCode,
     ZIMName,
@@ -43,6 +44,10 @@ class ZIMTitleModel(BaseModel):
 
 class CommaSeparatedZIMLanguageCodeModel(BaseModel):
     value: CommaSeparatedZIMLangCode
+
+
+class SkipableBoolModel(BaseModel):
+    value: SkipableBool
 
 
 def test_enum_validator_accepts_valid_value():
@@ -538,4 +543,74 @@ def test_comma_separated_zim_language_code_validator_skips_validation_when_conte
     with expected:
         CommaSeparatedZIMLanguageCodeModel.model_validate(
             {"value": languages}, context={"skip_validation": True}
+        )
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        pytest.param(True, does_not_raise(), id="true"),
+        pytest.param(False, does_not_raise(), id="false"),
+        pytest.param(
+            "a random word",
+            pytest.raises(ValidationError),
+            id="string-true",
+        ),
+        pytest.param(
+            "/output",
+            pytest.raises(ValidationError),
+            id="string-false",
+        ),
+        pytest.param(
+            "",
+            pytest.raises(ValidationError),
+            id="empty-string",
+        ),
+    ],
+)
+def test_relaxed_boolean_model(
+    value: str | int | bool, expected: RaisesContext[Exception]
+):
+    with expected:
+        SkipableBoolModel.model_validate({"value": value})
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        pytest.param(True, does_not_raise(), id="true"),
+        pytest.param(False, does_not_raise(), id="false"),
+        pytest.param(
+            "true",
+            does_not_raise(),
+            id="string-true",
+        ),
+        pytest.param(
+            "false",
+            does_not_raise(),
+            id="string-false",
+        ),
+        pytest.param(
+            0,
+            does_not_raise(),
+            id="integer-zero",
+        ),
+        pytest.param(
+            1,
+            does_not_raise(),
+            id="integer-1",
+        ),
+        pytest.param(
+            "",
+            does_not_raise(),
+            id="empty-string",
+        ),
+    ],
+)
+def test_relaxed_boolean_skip_validation(
+    value: str | int | bool, expected: RaisesContext[Exception]
+):
+    with expected:
+        SkipableBoolModel.model_validate(
+            {"value": value}, context={"skip_validation": True}
         )


### PR DESCRIPTION
## Rationale
While building the gutenberg flags, the `one_language_one_zim` is converted to a string which causes it to fail validation because our `skip_validation` does not apply to core types. By defining a custom type which wraps around the `bool` with the added benefit of skipping validation, we bypass this error while reading.

## Changes
- define custom type to skip validation of booleans

This fixes one of the cases mentioned in #1321
