### PR TITLE
rebuild task config while getting from db

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/offliners/sotoki.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/sotoki.py
@@ -135,7 +135,7 @@ class SotokiFlagsSchema(DashModel):
         description="S3 Storage URL including credentials and bucket",
     )
 
-    mirror: AnyUrl | None = OptionalField(
+    mirror: OptionalSecretUrl = OptionalField(
         title="Mirror",
         description="URL from which to download compressed XML dumps",
     )

--- a/backend/src/zimfarm_backend/utils/offliners.py
+++ b/backend/src/zimfarm_backend/utils/offliners.py
@@ -2,7 +2,7 @@ import pathlib
 import shlex
 from typing import Any, NamedTuple
 
-from pydantic import AnyUrl
+from pydantic import SecretStr
 
 from zimfarm_backend.common import constants
 from zimfarm_backend.common.enums import Offliner
@@ -114,7 +114,7 @@ def command_for(
     cmd = offliner_def.cmd
 
     if isinstance(config.offliner, SotokiFlagsSchema):
-        config.offliner.mirror = config.offliner.mirror or AnyUrl(
+        config.offliner.mirror = config.offliner.mirror or SecretStr(
             "https://s3.us-west-1.wasabisys.com/org-kiwix-stackexchange"
         )
         config.offliner.redis_url = "unix:///var/run/redis.sock"


### PR DESCRIPTION
## Rationale
While retrieving tasks from dB, the config should be rebuilt with secrets set based on permissions. This is because when they are saved, the `str_command` and `command` are strings and list of strings respectively and `show_secrets` won't apply to them. However, by rebuilding, they are hidden/shown to the user as the `expanded_config` uses it to build the commands.
## Changes
- rebuild secrets while fetching tasks
