### PR TITLE
define global app exception handlers

### DIFF
--- a/backend/src/zimfarm_backend/db/exceptions.py
+++ b/backend/src/zimfarm_backend/db/exceptions.py
@@ -3,6 +3,7 @@ class RecordDoesNotExistError(Exception):
 
     def __init__(self, message: str, *args: object) -> None:
         super().__init__(message, *args)
+        self.detail = message
 
 
 class RecordAlreadyExistsError(Exception):
@@ -10,3 +11,4 @@ class RecordAlreadyExistsError(Exception):
 
     def __init__(self, message: str, *args: object) -> None:
         super().__init__(message, *args)
+        self.detail = message

--- a/backend/src/zimfarm_backend/routes/schedules/logic.py
+++ b/backend/src/zimfarm_backend/routes/schedules/logic.py
@@ -117,10 +117,7 @@ def create_schedule(
             ]
         )
 
-    try:
-        language = get_language_from_code(schedule.language)
-    except RecordDoesNotExistError as exc:
-        raise BadRequestError(f"Language code {schedule.language} not found.") from exc
+    language = get_language_from_code(schedule.language)
 
     try:
         db_schedule = db_create_schedule(
@@ -192,10 +189,7 @@ def get_schedule(
     *,
     hide_secrets: Annotated[bool | None, Query()] = True,
 ) -> JSONResponse:
-    try:
-        db_schedule = db_get_schedule(session, schedule_name=schedule_name)
-    except RecordDoesNotExistError as e:
-        raise NotFoundError(f"Schedule {schedule_name} not found") from e
+    db_schedule = db_get_schedule(session, schedule_name=schedule_name)
 
     schedule = create_schedule_full_schema(db_schedule)
     if not (
@@ -241,12 +235,9 @@ def update_schedule(
     ):
         raise UnauthorizedError("You are not allowed to update a schedule")
 
-    try:
-        schedule = create_schedule_full_schema(
-            db_get_schedule(session, schedule_name=schedule_name)
-        )
-    except RecordDoesNotExistError as e:
-        raise NotFoundError(f"Schedule {schedule_name} not found") from e
+    schedule = create_schedule_full_schema(
+        db_get_schedule(session, schedule_name=schedule_name)
+    )
 
     schedule_config = schedule.config
     # Ensure we test flags according to new offliner name if present
@@ -424,10 +415,7 @@ def delete_schedule(
     ):
         raise UnauthorizedError("You are not allowed to delete a schedule")
 
-    try:
-        db_delete_schedule(session, schedule_name=schedule_name)
-    except RecordDoesNotExistError as e:
-        raise NotFoundError(f"Schedule {schedule_name} not found") from e
+    db_delete_schedule(session, schedule_name=schedule_name)
     return Response(status_code=HTTPStatus.NO_CONTENT)
 
 
@@ -469,10 +457,7 @@ def clone_schedule(
     if not check_user_permission(current_user, namespace="schedules", name="create"):
         raise UnauthorizedError("You are not allowed to clone a schedule")
 
-    try:
-        schedule = db_get_schedule(session, schedule_name=schedule_name)
-    except RecordDoesNotExistError as e:
-        raise NotFoundError(f"Schedule {schedule_name} not found") from e
+    schedule = db_get_schedule(session, schedule_name=schedule_name)
 
     # Skip validation while cloning a schedule
     try:
@@ -530,10 +515,7 @@ def validate_schedule(
     if not check_user_permission(current_user, namespace="schedules", name="update"):
         raise UnauthorizedError("You are not allowed to validate a schedule")
 
-    try:
-        schedule = db_get_schedule(session, schedule_name=schedule_name)
-    except RecordDoesNotExistError as e:
-        raise NotFoundError(f"Schedule {schedule_name} not found") from e
+    schedule = db_get_schedule(session, schedule_name=schedule_name)
 
     try:
         create_schedule_full_schema(schedule, skip_validation=False)

--- a/backend/src/zimfarm_backend/routes/tasks/logic.py
+++ b/backend/src/zimfarm_backend/routes/tasks/logic.py
@@ -21,7 +21,6 @@ from zimfarm_backend.common.schemas.orms import TaskLightSchema
 from zimfarm_backend.common.utils import task_event_handler
 from zimfarm_backend.db.exceptions import (
     RecordAlreadyExistsError,
-    RecordDoesNotExistError,
 )
 from zimfarm_backend.db.models import User
 from zimfarm_backend.db.requested_task import (
@@ -85,10 +84,7 @@ async def get_task(
     hide_secrets: Annotated[bool, Query()] = True,
 ) -> JSONResponse:
     """Get a task by ID"""
-    try:
-        task = db_get_task(db_session, task_id)
-    except RecordDoesNotExistError as exc:
-        raise NotFoundError(f"Task {task_id} not found") from exc
+    task = db_get_task(db_session, task_id)
     if not (
         current_user
         and check_user_permission(current_user, namespace="tasks", name="update")
@@ -125,17 +121,9 @@ async def create_task(
     if not check_user_permission(current_user, namespace="tasks", name="create"):
         raise ForbiddenError("You are not allowed to create tasks")
 
-    try:
-        requested_task = db_get_requested_task(db_session, requested_task_id)
-    except RecordDoesNotExistError as exc:
-        raise NotFoundError(f"Requested task {requested_task_id} not found") from exc
+    requested_task = db_get_requested_task(db_session, requested_task_id)
 
-    try:
-        worker = db_get_worker(db_session, worker_name=task_create_schema.worker_name)
-    except RecordDoesNotExistError as exc:
-        raise NotFoundError(
-            f"Worker {task_create_schema.worker_name} not found"
-        ) from exc
+    worker = db_get_worker(db_session, worker_name=task_create_schema.worker_name)
 
     try:
         task = db_create_task(
@@ -173,10 +161,7 @@ async def update_task(
     if not check_user_permission(current_user, namespace="tasks", name="update"):
         raise ForbiddenError("You are not allowed to update this task")
 
-    try:
-        task = db_get_task(db_session, task_id)
-    except RecordDoesNotExistError as exc:
-        raise NotFoundError(f"Task {task_id} not found") from exc
+    task = db_get_task(db_session, task_id)
 
     try:
         task_event_handler(
@@ -199,10 +184,7 @@ async def cancel_task(
     if not check_user_permission(current_user, namespace="tasks", name="cancel"):
         raise ForbiddenError("You are not allowed to cancel this task")
 
-    try:
-        task = db_get_task(db_session, task_id)
-    except RecordDoesNotExistError as exc:
-        raise NotFoundError(f"Task {task_id} not found") from exc
+    task = db_get_task(db_session, task_id)
 
     if task.status not in TaskStatus.incomplete():
         raise NotFoundError(f"Task {task_id} not found")


### PR DESCRIPTION
## Rationale

Across the application routes, there are calls to `try...except` and 90% of the time, they re-raise the same error message that the db raises. To simplify this and cut down redundancy, I've defined handlers to catch these exceptions and convert them to the same format clients expect

## Changes
- define global exception handlers to intercept application errors
