### PR TITLE
use skip validation context on secret urls

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/offliners/freecodecamp.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/freecodecamp.py
@@ -1,13 +1,14 @@
 from enum import StrEnum
 from typing import Annotated, Literal
 
-from pydantic import AnyUrl, Field, WrapValidator
+from pydantic import Field, WrapValidator
 
 from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
     NotEmptyString,
     OptionalField,
     OptionalNotEmptyString,
+    OptionalSkipableUrl,
     OptionalZIMFileName,
     OptionalZIMLongDescription,
     OptionalZIMOutputFolder,
@@ -94,7 +95,7 @@ class FreeCodeCampFlagsSchema(DashModel):
         "Include {period} to insert date period dynamically",
     )
 
-    illustration: AnyUrl | None = OptionalField(
+    illustration: OptionalSkipableUrl = OptionalField(
         title="Illustration",
         description="URL for ZIM illustration. Freecodecamp default logo if missing",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/ifixit.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/ifixit.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import AnyUrl, Field
+from pydantic import Field
 
 from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
@@ -9,6 +9,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalNotEmptyString,
     OptionalPercentage,
     OptionalSecretUrl,
+    OptionalSkipableUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMName,
@@ -43,7 +44,7 @@ class IFixitFlagsSchema(DashModel):
         "iFixIt homepage description (meta) otherwise",
     )
 
-    icon: AnyUrl | None = OptionalField(
+    icon: OptionalSkipableUrl = OptionalField(
         title="Icon",
         description="Custom Icon for your ZIM (URL). iFixit square logo otherwise",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/kolibri.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/kolibri.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import AnyUrl, Field
+from pydantic import Field
 
 from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
@@ -8,6 +8,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalField,
     OptionalNotEmptyString,
     OptionalSecretUrl,
+    OptionalSkipableUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMLangCode,
@@ -61,20 +62,20 @@ class KolibriFlagsSchema(DashModel):
         "too long to fit entirely in ZIM description",
     )
 
-    favicon: AnyUrl | None = OptionalField(
+    favicon: OptionalSkipableUrl = OptionalField(
         title="Favicon",
         description="URL for Favicon. Kolibri channel thumbnail otherwise "
         "or default Kolobri logo if missing",
     )
 
-    css: AnyUrl | None = OptionalField(
+    css: OptionalSkipableUrl = OptionalField(
         title="Custom CSS",
         description="URL to a single CSS file to be included in all pages "
         "(but not on kolibri-html-content ones). "
         "Inlude external resources using data URL.",
     )
 
-    about: AnyUrl | None = OptionalField(
+    about: OptionalSkipableUrl = OptionalField(
         title="Custom About",
         description="URL to a single HTML file to use as an about page. "
         "Place everythong inside `body .container` "

--- a/backend/src/zimfarm_backend/common/schemas/offliners/mindtouch.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/mindtouch.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import AnyUrl, Field
+from pydantic import Field
 
 from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
@@ -8,6 +8,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalField,
     OptionalNotEmptyString,
     OptionalSecretUrl,
+    OptionalSkipableUrl,
     OptionalZIMLongDescription,
     OptionalZIMOutputFolder,
     OptionalZIMProgressFile,
@@ -100,7 +101,7 @@ class MindtouchFlagsSchema(DashModel):
         "its subpages will be included in the ZIM",
     )
 
-    illustration_url: AnyUrl | None = OptionalField(
+    illustration_url: OptionalSkipableUrl = OptionalField(
         title="Illustration URL",
         description="URL to illustration to use for ZIM illustration and favicon",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/mwoffliner.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/mwoffliner.py
@@ -2,7 +2,7 @@
 from enum import StrEnum
 from typing import Annotated, Literal
 
-from pydantic import AnyUrl, EmailStr, Field, WrapValidator
+from pydantic import EmailStr, Field, WrapValidator
 
 from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
@@ -10,11 +10,13 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalField,
     OptionalNotEmptyString,
     OptionalSecretUrl,
+    OptionalSkipableUrl,
     OptionalZIMDescription,
     OptionalZIMLongDescription,
     OptionalZIMOutputFolder,
     OptionalZIMSecretStr,
     OptionalZIMTitle,
+    SkipableUrl,
     enum_member,
 )
 
@@ -75,7 +77,7 @@ MWOfflinerForceRenderValue = Annotated[
 class MWOfflinerFlagsSchema(DashModel):
     offliner_id: Literal["mwoffliner"] = Field(alias="offliner_id")
 
-    mwUrl: AnyUrl = Field(
+    mwUrl: SkipableUrl = Field(
         title="Wiki URL",
         description="The URL of the mediawiki to scrape",
     )
@@ -115,7 +117,7 @@ class MWOfflinerFlagsSchema(DashModel):
         title="ZIM Long Description",
         description=" Max length is 4000 chars",
     )
-    customZimFavicon: AnyUrl | None = OptionalField(
+    customZimFavicon: OptionalSkipableUrl = OptionalField(
         title="ZIM favicon",
         description="URL to a png to use as favicon. Will be resized to 48x48px.",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/nautilus.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/nautilus.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import AnyUrl, Field
+from pydantic import Field
 
 from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
@@ -8,6 +8,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalField,
     OptionalNotEmptyString,
     OptionalSecretUrl,
+    OptionalSkipableUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMOutputFolder,
@@ -19,7 +20,7 @@ from zimfarm_backend.common.schemas.fields import (
 class NautilusFlagsSchema(DashModel):
     offliner_id: Literal["nautilus"] = Field(alias="offliner_id")
 
-    archive: AnyUrl | None = OptionalField(
+    archive: OptionalSkipableUrl = OptionalField(
         title="Archive",
         description="URL to a ZIP archive containing all the documents",
     )
@@ -96,16 +97,16 @@ class NautilusFlagsSchema(DashModel):
         description="List of comma-separated Tags for the ZIM file.",
     )
 
-    main_logo: AnyUrl | None = OptionalField(
+    main_logo: OptionalSkipableUrl = OptionalField(
         title="Header Logo",
         description=("Custom logo. Will be resized to 300x65px. Nautilus otherwise."),
     )
-    secondary_logo: AnyUrl | None = OptionalField(
+    secondary_logo: OptionalSkipableUrl = OptionalField(
         title="Footer logo",
         description=("Custom footer logo. Will be resized to 300x65px. None otherwise"),
     )
 
-    favicon: AnyUrl | None = OptionalField(
+    favicon: OptionalSkipableUrl = OptionalField(
         title="Favicon",
         description=("Custom favicon. Will be resized to 48x48px. Nautilus otherwise."),
     )
@@ -123,7 +124,7 @@ class NautilusFlagsSchema(DashModel):
             " primary color solarized (or #95A5A6 if no logo)."
         ),
     )
-    about: AnyUrl | None = OptionalField(
+    about: OptionalSkipableUrl = OptionalField(
         title="About page",
         description="Custom about HTML page.",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/openedx.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/openedx.py
@@ -1,17 +1,19 @@
 from enum import StrEnum
 from typing import Annotated, Literal
 
-from pydantic import AnyUrl, EmailStr, Field, WrapValidator
+from pydantic import EmailStr, Field, WrapValidator
 
 from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
     OptionalField,
     OptionalNotEmptyString,
     OptionalSecretUrl,
+    OptionalSkipableUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMOutputFolder,
     OptionalZIMTitle,
+    SkipableUrl,
     ZIMName,
     ZIMSecretStr,
     enum_member,
@@ -29,7 +31,7 @@ VideoFormatValue = Annotated[VideoFormat, WrapValidator(enum_member(VideoFormat)
 class OpenedxFlagsSchema(DashModel):
     offliner_id: Literal["openedx"] = Field(alias="offliner_id")
 
-    course_url: AnyUrl = Field(
+    course_url: SkipableUrl = Field(
         title="Course URL",
         description="URL of the course you wnat to scrape",
     )
@@ -63,7 +65,7 @@ class OpenedxFlagsSchema(DashModel):
         ),
     )
 
-    favicon_url: AnyUrl | None = OptionalField(
+    favicon_url: OptionalSkipableUrl = OptionalField(
         title="Favicon URL",
         description=(
             "URL pointing to a favicon image. Recommended size >= (48px x 48px)"

--- a/backend/src/zimfarm_backend/common/schemas/offliners/sotoki.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/sotoki.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import AnyUrl, Field
+from pydantic import Field
 
 from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
@@ -8,6 +8,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalField,
     OptionalNotEmptyString,
     OptionalSecretUrl,
+    OptionalSkipableUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMName,
@@ -40,7 +41,7 @@ class SotokiFlagsSchema(DashModel):
         description="Custom description for your ZIM. Site tagline otherwise",
     )
 
-    favicon: AnyUrl | None = OptionalField(
+    favicon: OptionalSkipableUrl = OptionalField(
         title="Favicon",
         description="URL for Favicon. Site square logo otherwise",
     )
@@ -100,7 +101,7 @@ class SotokiFlagsSchema(DashModel):
         description="Replace usernames in posts with generated ones",
     )
 
-    censor_words_list: AnyUrl | None = OptionalField(
+    censor_words_list: OptionalSkipableUrl = OptionalField(
         title="Words black list",
         description="URL to a text file "
         "containing one word per line. Each of them to be removed from all content."

--- a/backend/src/zimfarm_backend/common/schemas/offliners/wikihow.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/wikihow.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import AnyUrl, Field
+from pydantic import Field
 
 from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
@@ -8,6 +8,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalField,
     OptionalNotEmptyString,
     OptionalSecretUrl,
+    OptionalSkipableUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMName,
@@ -42,7 +43,7 @@ class WikihowFlagsSchema(DashModel):
         "Wikihow homepage description (meta) otherwise",
     )
 
-    icon: AnyUrl | None = OptionalField(
+    icon: OptionalSkipableUrl = OptionalField(
         title="Icon",
         description="Custom Icon for your ZIM (URL). wikiHow square logo otherwise",
     )
@@ -75,14 +76,14 @@ class WikihowFlagsSchema(DashModel):
         "Most are copyrighted",
     )
 
-    exclude: AnyUrl | None = OptionalField(
+    exclude: OptionalSkipableUrl = OptionalField(
         title="Exclude",
         description="URL to a text file listing Article ID or "
         "`Category:` prefixed Category IDs to exclude from the scrape. "
         "Lines starting with # are ignored",
     )
 
-    only: AnyUrl | None = OptionalField(
+    only: OptionalSkipableUrl = OptionalField(
         title="Only",
         description="URL to a text file listing Article IDs. "
         "This filters out every other article. "

--- a/backend/src/zimfarm_backend/common/schemas/offliners/youtube.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/youtube.py
@@ -1,6 +1,6 @@
 from typing import Literal
 
-from pydantic import AnyUrl, Field
+from pydantic import Field
 
 from zimfarm_backend.common.schemas import DashModel
 from zimfarm_backend.common.schemas.fields import (
@@ -9,6 +9,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalField,
     OptionalNotEmptyString,
     OptionalSecretUrl,
+    OptionalSkipableUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMLongDescription,
@@ -123,12 +124,12 @@ class YoutubeFlagsSchema(DashModel):
         description="Number of videos per page (40 otherwise)",
     )
 
-    profile: AnyUrl | None = OptionalField(
+    profile: OptionalSkipableUrl = OptionalField(
         title="Profile Image",
         description="Custom profile image. Squared. Will be resized to 100x100px",
     )
 
-    banner: AnyUrl | None = OptionalField(
+    banner: OptionalSkipableUrl = OptionalField(
         title="Banner Image",
         description="Custom banner image. Will be resized to 1060x175px",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/zimit.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/zimit.py
@@ -1,7 +1,7 @@
 from enum import StrEnum
 from typing import Annotated, Literal
 
-from pydantic import AnyUrl, Field, WrapValidator
+from pydantic import Field, WrapValidator
 
 from zimfarm_backend.common.schemas import CamelModel
 from zimfarm_backend.common.schemas.fields import (
@@ -9,6 +9,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalField,
     OptionalNotEmptyString,
     OptionalPercentage,
+    OptionalSkipableUrl,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMLangCode,
@@ -197,7 +198,7 @@ class ZimitFlagsFullSchema(CamelModel):
         title="Description",
         description="Description for ZIM",
     )
-    favicon: AnyUrl | None = OptionalField(
+    favicon: OptionalSkipableUrl = OptionalField(
         title="Illustration",
         description="URL for Illustration. "
         "If unspecified, will attempt to use favicon from main page.",
@@ -507,7 +508,7 @@ class ZimitFlagsFullSchema(CamelModel):
         alias="long-description",
     )
 
-    custom_css: AnyUrl | None = OptionalField(
+    custom_css: OptionalSkipableUrl = OptionalField(
         title="Custom CSS",
         description="URL to a CSS file to inject into pages",
         alias="custom-css",
@@ -566,7 +567,7 @@ class ZimitFlagsFullSchema(CamelModel):
         alias="zimit-progress-file",
     )
 
-    replay_viewer_source: AnyUrl | None = OptionalField(
+    replay_viewer_source: OptionalSkipableUrl = OptionalField(
         title="Replay Viewer Source",
         description="URL from which to load the ReplayWeb.page replay viewer from",
         alias="replay-viewer-source",

--- a/backend/tests/test_validators.py
+++ b/backend/tests/test_validators.py
@@ -9,7 +9,9 @@ from zimfarm_backend.common.constants import parse_bool
 from zimfarm_backend.common.schemas.fields import (
     CommaSeparatedZIMLangCode,
     GraphemeStr,
+    SecretUrl,
     SkipableBool,
+    SkipableUrl,
     ZIMFileName,
     ZIMLangCode,
     ZIMName,
@@ -48,6 +50,14 @@ class CommaSeparatedZIMLanguageCodeModel(BaseModel):
 
 class SkipableBoolModel(BaseModel):
     value: SkipableBool
+
+
+class SecretUrlModel(BaseModel):
+    value: SecretUrl
+
+
+class SkipableUrlModel(BaseModel):
+    value: SkipableUrl
 
 
 def test_enum_validator_accepts_valid_value():
@@ -612,5 +622,121 @@ def test_relaxed_boolean_skip_validation(
 ):
     with expected:
         SkipableBoolModel.model_validate(
+            {"value": value}, context={"skip_validation": True}
+        )
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        pytest.param("https://example.com", does_not_raise(), id="true"),
+        pytest.param("a.b.cd", pytest.raises(ValidationError), id="invalid-url"),
+        pytest.param(
+            "https://example.com/path?query=value",
+            does_not_raise(),
+            id="valid-url-with-query",
+        ),
+        pytest.param(
+            "./example.com",
+            pytest.raises(ValidationError),
+            id="invalid-url-with-relative-path",
+        ),
+        pytest.param(
+            "//example.com",
+            pytest.raises(ValidationError),
+            id="invalid-url-with-protocol-relative-path",
+        ),
+    ],
+)
+def test_secret_url_model(value: str, expected: RaisesContext[Exception]):
+    with expected:
+        SecretUrlModel.model_validate({"value": value})
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        pytest.param("https://example.com", does_not_raise(), id="true"),
+        pytest.param("a.b.cd", does_not_raise(), id="invalid-url"),
+        pytest.param(
+            "https://example.com/path?query=value",
+            does_not_raise(),
+            id="valid-url-with-query",
+        ),
+        pytest.param(
+            "./example.com",
+            does_not_raise(),
+            id="invalid-url-with-relative-path",
+        ),
+        pytest.param(
+            "//example.com",
+            does_not_raise(),
+            id="invalid-url-with-protocol-relative-path",
+        ),
+    ],
+)
+def test_secret_url_model_skip_validation(
+    value: str, expected: RaisesContext[Exception]
+):
+    with expected:
+        SecretUrlModel.model_validate(
+            {"value": value}, context={"skip_validation": True}
+        )
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        pytest.param("https://example.com", does_not_raise(), id="true"),
+        pytest.param("a.b.cd", pytest.raises(ValidationError), id="invalid-url"),
+        pytest.param(
+            "https://example.com/path?query=value",
+            does_not_raise(),
+            id="valid-url-with-query",
+        ),
+        pytest.param(
+            "./example.com",
+            pytest.raises(ValidationError),
+            id="invalid-url-with-relative-path",
+        ),
+        pytest.param(
+            "//example.com",
+            pytest.raises(ValidationError),
+            id="invalid-url-with-protocol-relative-path",
+        ),
+    ],
+)
+def test_skipable_url_model(value: str, expected: RaisesContext[Exception]):
+    with expected:
+        SecretUrlModel.model_validate({"value": value})
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        pytest.param("https://example.com", does_not_raise(), id="true"),
+        pytest.param("a.b.cd", does_not_raise(), id="invalid-url"),
+        pytest.param(
+            "https://example.com/path?query=value",
+            does_not_raise(),
+            id="valid-url-with-query",
+        ),
+        pytest.param(
+            "./example.com",
+            does_not_raise(),
+            id="invalid-url-with-relative-path",
+        ),
+        pytest.param(
+            "//example.com",
+            does_not_raise(),
+            id="invalid-url-with-protocol-relative-path",
+        ),
+    ],
+)
+def test_skipable_url_model_skip_validation(
+    value: str, expected: RaisesContext[Exception]
+):
+    with expected:
+        SecretUrlModel.model_validate(
             {"value": value}, context={"skip_validation": True}
         )


### PR DESCRIPTION
## Changes
- define custom type `SkipableUrl` which skips `AnyUrl` validation based on context
- skip validation on `SecretUrl` based on context
- change model fields that used `AnyUrl | None` to use `OptionalSkipableUrl`

While `Skipableurl` and `SecretUrl` seem alike, the `SecretUrl` has the added benefit that it's underlying type is a sring that can be hidden.

This fixes #1331