### PR TITLE
reload schedule on clone

### DIFF
--- a/frontend-ui/src/views/ScheduleDetailView.vue
+++ b/frontend-ui/src/views/ScheduleDetailView.vue
@@ -929,6 +929,17 @@ watch(
     }
   },
 )
+
+// Watch for schedule name changes (when navigating to a different schedule)
+watch(
+  () => props.scheduleName,
+  async () => {
+    // Reset the current tab to details when switching schedules
+    // Clear current data and reload the new schedule
+    schedule.value = null
+    currentTab.value = 'details'
+  },
+)
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Rationale
After cloning a schedule (or changing it's name), reset the schedule reference to be null. This triggers a reload of the schedule and it's new properties.

## Changes
- add watcher for when a schedule name changes

This fixes #1329
