### PR TITLE
read task status from timestamp

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -145,6 +145,7 @@ class MostRecentTaskSchema(BaseModel):
     id: UUID
     status: str
     updated_at: MadeAwareDateTime
+    timestamp: list[tuple[str, datetime.datetime]]
 
 
 class ConfigOfflinerOnlySchema(BaseModel):
@@ -282,6 +283,7 @@ class RunningTask(BaseModel):
     updated_at: datetime.datetime
     config: ExpandedScheduleConfigSchema
     schedule_name: str | None
+    status: str
     timestamp: list[tuple[str, datetime.datetime]]
     worker_name: str
     duration: ScheduleDurationSchema

--- a/backend/src/zimfarm_backend/db/schedule.py
+++ b/backend/src/zimfarm_backend/db/schedule.py
@@ -235,6 +235,7 @@ def get_schedules(
             Task.id.label("task_id"),
             Task.status.label("task_status"),
             Task.updated_at.label("task_updated_at"),
+            Task.timestamp,
             func.coalesce(subquery.c.nb_requested_tasks, 0).label("nb_requested_tasks"),
             Schedule.context,
         )
@@ -267,6 +268,7 @@ def get_schedules(
         task_id,
         task_status,
         task_updated_at,
+        task_timestamp,
         nb_requested_tasks,
         context,
     ) in session.execute(stmt).all():
@@ -295,6 +297,7 @@ def get_schedules(
                         id=task_id,
                         status=task_status,
                         updated_at=task_updated_at,
+                        timestamp=task_timestamp,
                     )
                     if all([task_id, task_status, task_updated_at])
                     else None
@@ -391,6 +394,7 @@ def create_schedule_full_schema(
                 id=schedule.most_recent_task.id,
                 status=schedule.most_recent_task.status,
                 updated_at=schedule.most_recent_task.updated_at,
+                timestamp=schedule.most_recent_task.timestamp,
             )
             if schedule.most_recent_task
             else None

--- a/backend/src/zimfarm_backend/db/tasks.py
+++ b/backend/src/zimfarm_backend/db/tasks.py
@@ -258,6 +258,7 @@ def get_currently_running_tasks(
             timestamp=task.timestamp,
             updated_at=task.updated_at,
             worker_name=task.worker.name,
+            status=task.status,
             **compute_task_eta(session, task),
         )
         for task in session.scalars(stmt).all()

--- a/backend/tests/db/test_requested_task.py
+++ b/backend/tests/db/test_requested_task.py
@@ -541,6 +541,7 @@ def test_does_platform_allow_worker_to_run(
         config=expanded_config(schedule_config),
         schedule_name="test_schedule",
         timestamp=[("started", getnow()), ("reserved", getnow())],
+        status="started",
         worker_name=worker.name,
         duration=ScheduleDurationSchema(
             value=3600,

--- a/frontend-ui/src/components/PipelineTable.vue
+++ b/frontend-ui/src/components/PipelineTable.vue
@@ -135,6 +135,8 @@
             <TaskLink
               :id="schedulesLastRuns[item.schedule_name].id"
               :updatedAt="schedulesLastRuns[item.schedule_name].updated_at"
+              :status="schedulesLastRuns[item.schedule_name].status"
+              :timestamp="schedulesLastRuns[item.schedule_name].timestamp"
             />
           </span>
         </template>

--- a/frontend-ui/src/components/SchedulesTable.vue
+++ b/frontend-ui/src/components/SchedulesTable.vue
@@ -71,7 +71,9 @@
             <br />
             <TaskLink
               :id="item.most_recent_task.id"
-              :updated-at="item.most_recent_task.updated_at"
+              :updatedAt="item.most_recent_task.updated_at"
+              :status="item.most_recent_task.status"
+              :timestamp="item.most_recent_task.timestamp"
             />
           </div>
           <span v-else>-</span>

--- a/frontend-ui/src/components/TaskLink.vue
+++ b/frontend-ui/src/components/TaskLink.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-tooltip v-if="tooltip" :text="formatDt(updatedAt)">
+  <v-tooltip v-if="tooltip" :text="formatDt(computedTimestamp)">
     <template v-slot:activator="{ props }">
       <router-link v-bind="props" :to="to" class="text-decoration-none">
         {{ displayText }}
@@ -13,12 +13,15 @@
 
 <script setup lang="ts">
 import { formatDt, fromNow } from '@/utils/format'
+import { getTimestampStringForStatus } from '@/utils/timestamp'
 import { computed } from 'vue'
 
 // Props
 interface Props {
   id: string
   updatedAt: string
+  status: string
+  timestamp: [string, string][]
   tooltip?: boolean
   text?: string | null
 }
@@ -33,7 +36,11 @@ const to = computed(() => {
   return { name: 'task-detail', params: { id: props.id } }
 })
 
+const computedTimestamp = computed(() => {
+  return getTimestampStringForStatus(props.timestamp, props.status, props.updatedAt)
+})
+
 const displayText = computed(() => {
-  return props.text === null ? fromNow(props.updatedAt) : props.text
+  return props.text === null ? fromNow(computedTimestamp.value) : props.text
 })
 </script>

--- a/frontend-ui/src/components/WorkersTable.vue
+++ b/frontend-ui/src/components/WorkersTable.vue
@@ -147,7 +147,12 @@
                     </router-link>
                   </template>
                   <template #[`item.task`]="{ item: task }">
-                    <TaskLink :id="task.id" :updated-at="task.updated_at" />
+                    <TaskLink
+                      :id="task.id"
+                      :updatedAt="task.updated_at"
+                      :status="task.status"
+                      :timestamp="task.timestamp"
+                    />
                   </template>
                   <template #[`item.resources`]="{ item: task }">
                     <div class="d-flex flex-wrap flex-column flex-md-row py-1">

--- a/frontend-ui/src/types/base.ts
+++ b/frontend-ui/src/types/base.ts
@@ -66,6 +66,7 @@ export interface MostRecentTask {
   id: string
   status: string
   updated_at: string
+  timestamp: [string, string][] // [status, datetime] tuples
 }
 export enum TaskStatus {
   requested = 'requested',

--- a/frontend-ui/src/types/workers.ts
+++ b/frontend-ui/src/types/workers.ts
@@ -19,6 +19,7 @@ export interface RunningTask {
   config: ExpandedScheduleConfig
   schedule_name: string | null
   updated_at: string
+  status: string
   timestamp: [string, string][]
   worker_name: string
   duration: ScheduleDuration

--- a/frontend-ui/src/views/ScheduleDetailView.vue
+++ b/frontend-ui/src/views/ScheduleDetailView.vue
@@ -190,7 +190,12 @@
                       >
                         {{ lastRun.status }}
                       </v-chip>
-                      <TaskLink :id="lastRun.id" :updated-at="lastRun.updated_at" />
+                      <TaskLink
+                        :id="lastRun.id"
+                        :updatedAt="lastRun.updated_at"
+                        :status="lastRun.status"
+                        :timestamp="lastRun.timestamp"
+                      />
                     </td>
                     <td v-else>
                       <v-chip size="small" variant="outlined" color="grey"> none 🙁 </v-chip>
@@ -264,7 +269,12 @@
                               </v-chip>
                             </td>
                             <td>
-                              <TaskLink :id="run.id" :updated-at="run.updated_at" />
+                              <TaskLink
+                                :id="run.id"
+                                :updatedAt="run.updated_at"
+                                :status="run.status"
+                                :timestamp="run.timestamp"
+                              />
                             </td>
                           </tr>
                         </tbody>

--- a/frontend-ui/src/views/WorkerDetailView.vue
+++ b/frontend-ui/src/views/WorkerDetailView.vue
@@ -237,7 +237,9 @@
                         <TaskLink
                           v-if="t.id && t.updated_at"
                           :id="t.id"
-                          :updated-at="t.updated_at"
+                          :updatedAt="t.updated_at"
+                          :status="t.status"
+                          :timestamp="t.timestamp"
                         />
                         <span v-else class="text-caption">-</span>
                       </td>


### PR DESCRIPTION
## Rationale
In #1277, the task `updated_at` was updated for `scraper_running` events in order to be able to cancel incomplete tasks that have not been updated. As a consequence, the `updated_at` does not reflect the actual timestamp which one of the desired timestamp for a status was set. By using the helper function `getTimestampStringForStatus`, we can retrieve the exact time the status was updated (defaulting to the `updated_at`).  This fixes the inconsistencies in the UI as decribed in #1301 

## Changes
- add status plus timestamp from backend responses
- use helper function to retrieve the timestamp for a particular status in frontend instead of the default `updated_at`

This fixes #1301 
