### PR TITLE
default to reserved timestamp for task duration

### DIFF
--- a/frontend-ui/src/utils/timestamp.ts
+++ b/frontend-ui/src/utils/timestamp.ts
@@ -3,30 +3,15 @@
  */
 export const DEFAULT_TIMESTAMP = new Date('1970-01-01T00:00:00.000Z')
 
-export function getTimestampForStatus(
-  timestampList: [string, string][],
-  status: string,
-  defaultTimestamp: Date = DEFAULT_TIMESTAMP,
-): Date {
-  // Filter timestamps for the given status
-  const matchingTimestamps = timestampList
-    .filter(([statusStr]) => statusStr === status)
-    .map(([, timestamp]) => new Date(timestamp))
-
-  if (matchingTimestamps.length === 0) {
-    return defaultTimestamp
-  }
-
-  // Return the most recent timestamp for this status
-  return new Date(Math.max(...matchingTimestamps.map((d) => d.getTime())))
-}
-
 export function getTimestampStringForStatus(
-  timestampList: [string, string][],
+  timestampList: [string, string][] | undefined,
   status: string,
   defaultTimestamp: string = DEFAULT_TIMESTAMP.toISOString(),
 ): string {
   // Filter timestamps for the given status
+  if (!timestampList) {
+    return defaultTimestamp
+  }
   const matchingTimestamps = timestampList
     .filter(([statusStr]) => statusStr === status)
     .map(([, timestamp]) => timestamp)

--- a/frontend-ui/src/views/TaskDetailView.vue
+++ b/frontend-ui/src/views/TaskDetailView.vue
@@ -496,8 +496,8 @@ const taskDebug = computed(() => {
 
 const taskDuration = computed(() => {
   if (!task.value?.events) return ''
-  const first = getTimestampStringForStatus(task.value?.timestamp ?? [], 'started')
-  if (!first) return 'not actually started'
+  const first = getTimestampStringForStatus(task.value?.timestamp, 'started', '')
+  if (!first) return 'Not actually started ⌛'
   if (isRunning.value) {
     return formatDurationBetween(first, new Date().toISOString())
   }
@@ -505,16 +505,22 @@ const taskDuration = computed(() => {
   return formatDurationBetween(first, last)
 })
 
-const startedOn = computed(
-  () =>
-    getTimestampStringForStatus(task.value?.timestamp ?? [], 'started') ||
-    getTimestampStringForStatus(task.value?.timestamp ?? [], 'reserved'),
+const startedOn = computed(() =>
+  getTimestampStringForStatus(
+    task.value?.timestamp,
+    'started',
+    getTimestampStringForStatus(task.value?.timestamp, 'reserved'),
+  ),
 )
 
 const pipeDuration = computed(() =>
   formatDurationBetween(
-    getTimestampStringForStatus(task.value?.timestamp ?? [], 'requested'),
-    getTimestampStringForStatus(task.value?.timestamp ?? [], 'started'),
+    getTimestampStringForStatus(task.value?.timestamp, 'requested'),
+    getTimestampStringForStatus(
+      task.value?.timestamp,
+      'started',
+      getTimestampStringForStatus(task.value?.timestamp, 'reserved'),
+    ),
   ),
 )
 
@@ -557,9 +563,9 @@ const monitoringUrl = computed(() => {
   }/#menu_cgroup_zimscraper_${task.value?.original_schedule_name}_${
     shortId.value
   }_submenu_cpu;after=${new Date(
-    getTimestampStringForStatus(task.value?.timestamp ?? [], 'scraper_started') || 0,
+    getTimestampStringForStatus(task.value?.timestamp, 'scraper_started', '') || 0,
   ).getTime()};before=${new Date(
-    getTimestampStringForStatus(task.value?.timestamp ?? [], 'scraper_completed') || 0,
+    getTimestampStringForStatus(task.value?.timestamp, 'scraper_completed', '') || 0,
   ).getTime()};theme=slate;utc=Africa/Bamako`
 })
 
@@ -575,7 +581,7 @@ const canCreateTasks = computed(() => authStore.hasPermission('tasks', 'create')
 // Methods
 const createdAfter = (file: TaskFile, taskData: Task) => {
   return formatDurationBetween(
-    getTimestampStringForStatus(taskData.timestamp ?? [], 'scraper_started'),
+    getTimestampStringForStatus(taskData.timestamp, 'scraper_started'),
     file.created_timestamp,
   )
 }


### PR DESCRIPTION
## Rationale
When a task is created, it always has `reserved` set by the `task_event_handler`. However, sometimes, a task has not been started by the worker and the `started` timestamp will default to `1970, January 1` on the frontend when used to compute the duration. This leads to buggy/incorrect duration values when task has never really run

## Changes
- default to `reserved` when computing the `startedOn`. old code did  `started_on() { return this.task.timestamp.started || this.task.timestamp.reserved; }`
- for task duration, return `Not actually Started` with falsy value as default
- remove unused `getTimestampForStatus`
- pipe duration now computes reliably between `requested` and `started` (or `reserved`) which should always be set.

This fixes #1332
