### PR TITLE
make history display responsive

### DIFF
--- a/frontend-ui/src/components/DiffViewer.vue
+++ b/frontend-ui/src/components/DiffViewer.vue
@@ -5,23 +5,30 @@
         <v-card-text class="pa-0">
           <div class="diff-content">
             <div v-for="(diff, index) in flattenedDiffs" :key="index" class="diff-line">
-              <div
-                :class="getDiffLineClass(diff.type)"
-                class="d-flex align-center pa-2 font-monospace text-body-2"
-              >
-                <div class="diff-symbol mr-3">{{ getDiffSymbol(diff.type) }}</div>
-                <div class="diff-path mr-4 text-caption">{{ diff.path }}</div>
-                <div class="diff-value flex-grow-1">
-                  <template v-if="diff.type === 'modified' && diff.oldValue">
-                    <span class="text-error">{{ diff.oldValue }}</span>
-                    <span class="mx-2 text-medium-emphasis">→</span>
-                    <span class="text-success">{{ diff.value }}</span>
-                  </template>
-                  <template v-else>
-                    {{ diff.value }}
-                  </template>
-                </div>
-              </div>
+              <v-card :class="getDiffLineClass(diff.type)" flat class="mb-1">
+                <v-card-text class="pa-1 font-monospace">
+                  <div class="d-flex flex-column flex-sm-row mb-1 align-items-sm-center">
+                    <div style="min-width: 150px">
+                      <span class="diff-symbol text-center mr-1 font-weight-bold">{{
+                        getDiffSymbol(diff.type)
+                      }}</span>
+                      <span class="text-caption text-high-emphasis mr-4 text-break">{{
+                        diff.path
+                      }}</span>
+                    </div>
+                    <div class="text-body-2 text-break flex-grow-1">
+                      <template v-if="diff.type === 'modified' && diff.oldValue">
+                        <span class="text-error">{{ diff.oldValue }}</span>
+                        <span class="mx-2 text-medium-emphasis">→</span>
+                        <span class="text-success">{{ diff.value }}</span>
+                      </template>
+                      <template v-else>
+                        {{ diff.value }}
+                      </template>
+                    </div>
+                  </div>
+                </v-card-text>
+              </v-card>
             </div>
           </div>
         </v-card-text>
@@ -178,12 +185,11 @@ const getDiffLineClass = (type: string): string => {
   overflow-y: auto;
 }
 
-.diff-line {
-  border-bottom: 1px solid rgba(var(--v-border-color), var(--v-border-opacity));
-}
-
-.diff-line:last-child {
-  border-bottom: none;
+.diff-symbol {
+  width: 20px;
+  min-width: 20px;
+  font-weight: bold;
+  flex-shrink: 0;
 }
 
 .diff-line-added {
@@ -201,12 +207,6 @@ const getDiffLineClass = (type: string): string => {
   border-left: 3px solid #fbbc05;
 }
 
-.diff-symbol {
-  width: 20px;
-  font-weight: bold;
-  text-align: center;
-}
-
 .diff-line-added .diff-symbol {
   color: #2ea043;
 }
@@ -217,15 +217,5 @@ const getDiffLineClass = (type: string): string => {
 
 .diff-line-modified .diff-symbol {
   color: #fbbc05;
-}
-
-.diff-path {
-  min-width: 200px;
-  color: rgba(var(--v-theme-on-surface), 0.6);
-  font-size: 0.75rem;
-}
-
-.diff-value {
-  word-break: break-all;
 }
 </style>

--- a/frontend-ui/src/components/ScheduleHistory.vue
+++ b/frontend-ui/src/components/ScheduleHistory.vue
@@ -1,115 +1,93 @@
 <template>
-  <v-container fluid class="pa-0">
+  <v-container fluid>
     <template v-if="history.length > 0">
-      <v-row>
-        <!-- Left column with commit info -->
-        <v-col cols="4">
-          <v-list>
-            <template v-for="(item, index) in history" :key="item.id">
-              <v-list-item
-                @click="selectHistoryItem(item, index)"
-                :class="{ 'v-list-item--active': selectedItemIndex === index }"
-              >
-                <v-list-item-content>
-                  <v-list-item-title class="text-subtitle-1">
-                    <template v-if="item.comment">
-                      <v-tooltip
-                        v-if="item.comment.length > 50"
-                        :text="item.comment"
-                        location="top"
-                        activator="parent"
-                        max-width="400"
-                      >
-                        <template v-slot:activator="{ props: tooltipProps }">
-                          <span v-bind="tooltipProps" style="cursor: pointer">
-                            {{ item.comment.substring(0, 50) }}...
-                          </span>
-                        </template>
-                      </v-tooltip>
-                      <span v-else>{{ item.comment }}</span>
-                    </template>
-                    <span v-else class="font-italic text-medium-emphasis">No commit message</span>
-                  </v-list-item-title>
-                  <div class="d-flex align-center gap-4 justify-space-between">
+      <template v-if="!showDiffViewer">
+        <v-alert type="info" variant="tonal" :icon="false">
+          <template v-slot:prepend>
+            <v-icon>mdi-information-outline</v-icon>
+          </template>
+          Select any two entries to compare their differences
+        </v-alert>
+
+        <v-list>
+          <template v-for="(item, index) in history" :key="item.id">
+            <v-list-item
+              @click="toggleHistoryItemSelection(item, index)"
+              :class="{
+                'v-list-item--active': selectedItems.has(index),
+                'bg-primary-lighten-5': selectedItems.has(index),
+              }"
+              class="cursor-pointer"
+            >
+              <template v-slot:prepend>
+                <v-checkbox-btn
+                  :model-value="selectedItems.has(index)"
+                  @click.stop="toggleHistoryItemSelection(item, index)"
+                  :disabled="selectedItems.size >= 2 && !selectedItems.has(index)"
+                />
+              </template>
+
+              <v-list-item-content>
+                <v-list-item-title class="text-subtitle-2">
+                  <template v-if="item.comment">
+                    <span class="text-wrap">{{ item.comment }}</span>
+                  </template>
+                  <span v-else class="font-italic text-medium-emphasis">No comment</span>
+                </v-list-item-title>
+
+                <v-list-item-subtitle>
+                  <div class="d-flex flex-column-reverse flex-sm-row justify-space-between mt-2">
                     <div class="text-caption">
                       <v-icon size="small" class="me-1">mdi-identifier</v-icon>
                       {{ item.id.substring(0, 8) }}
                     </div>
-                    <div class="text-body-2 font-weight-medium">
+                    <div class="text-caption">
                       <v-icon size="small" class="me-1">mdi-account</v-icon>
                       {{ item.author }}
                     </div>
-                  </div>
-                  <div class="text-caption mt-1">
-                    <v-icon size="small" class="me-1">mdi-clock-outline</v-icon>
-                    {{ new Date(item.created_at).toLocaleString() }}
-                  </div>
-                </v-list-item-content>
-              </v-list-item>
-              <v-divider v-if="index < history.length - 1" />
-            </template>
-          </v-list>
-          <v-card-actions v-if="hasMore" class="justify-center">
-            <v-btn variant="text" :loading="loading" @click="loadMore"> Load More </v-btn>
-          </v-card-actions>
-        </v-col>
-
-        <!-- Right column with diff/raw data viewer -->
-        <v-col cols="8">
-          <v-card v-if="selectedConfig" flat>
-            <v-card-text>
-              <!-- Toggle between diff and raw config view -->
-              <v-tabs v-model="viewMode" class="mb-4">
-                <v-tab value="diff" :disabled="!canShowDiff">
-                  <v-icon class="mr-2">mdi-compare-horizontal</v-icon>
-                  Diff
-                </v-tab>
-                <v-tab value="config">
-                  <v-icon class="mr-2">mdi-code-braces</v-icon>
-                  JSON View
-                </v-tab>
-              </v-tabs>
-
-              <v-window v-model="viewMode">
-                <v-window-item value="diff">
-                  <div v-if="canShowDiff">
-                    <div class="mb-3">
-                      <v-chip size="small" color="info" variant="tonal" class="mr-2">
-                        Comparing {{ selectedItem?.id.substring(0, 8) }} with
-                        {{ previousItem?.id.substring(0, 8) }}
-                      </v-chip>
-                    </div>
-                    <DiffViewer :differences="scheduleDifferences" />
-                  </div>
-                  <div v-else class="text-center py-8">
-                    <v-icon size="large" color="grey" class="mb-2">mdi-information-outline</v-icon>
-                    <div class="text-body-1 text-medium-emphasis">
-                      Select a history item (except the oldest) to compare with the previous version
+                    <div class="text-subtitle-2">
+                      <v-icon size="small" class="me-1">mdi-clock-outline</v-icon>
+                      {{ formatDt(item.created_at, 'ff') }}
                     </div>
                   </div>
-                </v-window-item>
+                </v-list-item-subtitle>
+              </v-list-item-content>
+            </v-list-item>
+            <v-divider />
+          </template>
+        </v-list>
 
-                <v-window-item value="config">
-                  <v-textarea
-                    v-model="selectedConfigStr"
-                    readonly
-                    auto-grow
-                    variant="outlined"
-                    class="font-monospace"
-                    :rows="20"
-                  />
-                </v-window-item>
-              </v-window>
-            </v-card-text>
-          </v-card>
-          <v-card v-else flat class="d-flex align-center justify-center" height="100%">
-            <v-card-text class="text-center text-medium-emphasis">
-              Select a history item to view its configuration
-            </v-card-text>
-          </v-card>
-        </v-col>
-      </v-row>
+        <!-- Load More button -->
+        <v-card-actions v-if="hasMore" class="justify-center">
+          <v-btn variant="text" :loading="loading" @click="loadMore"> Load More </v-btn>
+        </v-card-actions>
+      </template>
+
+      <!-- Diff Viewer -->
+      <template v-else>
+        <v-card>
+          <v-card-title class="d-flex align-center text-wrap text-body-1">
+            <v-btn icon="mdi-arrow-left" variant="text" @click="backToHistoryList" class="me-2" />
+            Comparing History Items
+          </v-card-title>
+
+          <v-card-text>
+            <div class="mb-4">
+              <v-chip size="small" color="info" variant="tonal" class="me-2">
+                {{ selectedItemsArray[0]?.id.substring(0, 8) }}
+              </v-chip>
+              <v-icon class="mx-2">mdi-arrow-right</v-icon>
+              <v-chip size="small" color="info" variant="tonal">
+                {{ selectedItemsArray[1]?.id.substring(0, 8) }}
+              </v-chip>
+            </div>
+
+            <DiffViewer :differences="scheduleDifferences" />
+          </v-card-text>
+        </v-card>
+      </template>
     </template>
+
     <template v-else>
       <v-row>
         <v-col cols="12" class="d-flex flex-column align-center justify-center">
@@ -124,10 +102,11 @@
 <script setup lang="ts">
 import DiffViewer from '@/components/DiffViewer.vue'
 import type { Paginator } from '@/types/base'
-import type { BaseScheduleHistorySchema, ScheduleHistorySchema } from '@/types/schedule'
+import type { ScheduleHistorySchema } from '@/types/schedule'
+import { formatDt } from '@/utils/format'
 import type * as DeepDiff from 'deep-diff'
 import { diff } from 'deep-diff'
-import { computed, ref, watch } from 'vue'
+import { computed, ref } from 'vue'
 
 const props = defineProps<{
   history: ScheduleHistorySchema[]
@@ -140,42 +119,34 @@ const emit = defineEmits<{
   load: [{ limit: number; skip: number }]
 }>()
 
-const selectedConfig = ref<BaseScheduleHistorySchema | null>(null)
-const selectedItemIndex = ref<number | null>(null)
-const selectedItem = ref<ScheduleHistorySchema | null>(null)
-const viewMode = ref<'diff' | 'config'>('diff')
+// New state for multi-selection
+const selectedItems = ref<Set<number>>(new Set())
+const showDiffViewer = ref(false)
 
-const selectedConfigStr = computed(() => {
-  if (!selectedConfig.value) return ''
-  return JSON.stringify(selectedConfig.value, null, 2)
-})
-
-const previousItem = computed(() => {
-  if (selectedItemIndex.value === null || selectedItemIndex.value >= props.history.length - 1) {
-    return null
-  }
-  return props.history[selectedItemIndex.value + 1]
-})
-
-const canShowDiff = computed(() => {
-  return selectedItem.value !== null && previousItem.value !== null
+const selectedItemsArray = computed(() => {
+  return Array.from(selectedItems.value)
+    .map((index) => props.history[index])
+    .filter(Boolean)
+    .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
 })
 
 const scheduleDifferences = computed(
   (): DeepDiff.Diff<Record<string, unknown>, Record<string, unknown>>[] | undefined => {
-    if (!canShowDiff.value || !selectedItem.value || !previousItem.value) {
+    if (selectedItemsArray.value.length !== 2) {
       return undefined
     }
 
+    const [item1, item2] = selectedItemsArray.value
+
     // Extract the subset from both items (excluding id, author, comment, created_at)
-    const { id, author, comment, created_at, ...previousSubset } = previousItem.value
+    const { id, author, comment, created_at, ...subset1 } = item1
     const {
       id: _id,
       author: _author,
       comment: _comment,
       created_at: _created_at,
-      ...currentSubset
-    } = selectedItem.value
+      ...subset2
+    } = item2
 
     // Suppress unused variable warnings for destructured variables
     void id
@@ -187,37 +158,35 @@ const scheduleDifferences = computed(
     void _comment
     void _created_at
 
-    return diff(previousSubset, currentSubset)
+    return diff(subset1, subset2)
   },
 )
 
-const selectHistoryItem = (item: ScheduleHistorySchema, index: number) => {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { id, author, comment, created_at, ...scheduleSubset } = item
-  selectedConfig.value = scheduleSubset
-  selectedItemIndex.value = index
-  selectedItem.value = item
-
-  // Auto-switch to diff view if we can show a diff, otherwise show JSON view
-  if (canShowDiff.value) {
-    viewMode.value = 'diff'
-  } else {
-    viewMode.value = 'config'
+const toggleHistoryItemSelection = (item: ScheduleHistorySchema, index: number) => {
+  if (selectedItems.value.has(index)) {
+    // Remove from selection
+    selectedItems.value.delete(index)
+    // If we go below 2 items, hide the diff viewer
+    if (selectedItems.value.size < 2) {
+      showDiffViewer.value = false
+    }
+  } else if (selectedItems.value.size < 2) {
+    // Add to selection (max 2 items)
+    selectedItems.value.add(index)
+    // Automatically show diff viewer when exactly 2 items are selected
+    if (selectedItems.value.size === 2) {
+      showDiffViewer.value = true
+    }
   }
 }
 
+const backToHistoryList = () => {
+  showDiffViewer.value = false
+  selectedItems.value.clear()
+}
+
+// Load more history items
 const loadMore = () => {
   emit('load', { limit: props.paginator.limit, skip: props.history.length })
 }
-
-// Watch history changes and select first item
-watch(
-  () => props.history,
-  (newHistory: ScheduleHistorySchema[]) => {
-    if (newHistory.length > 0) {
-      selectHistoryItem(newHistory[0], 0)
-    }
-  },
-  { immediate: true },
-)
 </script>

--- a/frontend-ui/src/utils/format.ts
+++ b/frontend-ui/src/utils/format.ts
@@ -50,12 +50,12 @@ export function formatDuration(value: number) {
   return dur.toHuman({ maximumSignificantDigits: 1 })
 }
 
-export function formatDt(value?: string) {
-  // display a datetime in a standard format
+export function formatDt(value?: string, format: string = 'fff') {
+  // display a datetime in the provided format (defaults to 'fff')
   if (!value) return ''
   const dt = DateTime.fromISO(value)
   if (!dt.isValid) return value
-  return dt.toFormat('fff')
+  return dt.toFormat(format)
 }
 
 export function formatDurationBetween(start: string, end: string) {


### PR DESCRIPTION
## Changes
- show history items as list that can be selected in any order by the user
- show diff in a seperate window with button to go back to the list entries
- make history items to be responsive and usable on small screens
- make dates more visible

This fixes #1346
This fixes #1348

<img width="494" height="446" alt="Screenshot_20250918_003438" src="https://github.com/user-attachments/assets/3b89d8a2-6006-47be-ad1d-6c7144eebad4" />
<img width="494" height="446" alt="Screenshot_20250918_003432" src="https://github.com/user-attachments/assets/53ba8c14-74ce-4557-ad5a-66d08566c7ba" />
<img width="1177" height="490" alt="Screenshot_20250918_003402" src="https://github.com/user-attachments/assets/9a410cda-3676-4f3c-b35b-ae46f261a4f4" />
<img width="1055" height="548" alt="Screenshot_20250918_003348" src="https://github.com/user-attachments/assets/6a1cee64-2100-4836-846e-b325d06a0b47" />
