### PR TITLE
ask for comments in dialog after editing schedule

### DIFF
--- a/frontend-ui/src/components/ConfirmDialog.vue
+++ b/frontend-ui/src/components/ConfirmDialog.vue
@@ -9,7 +9,9 @@
       </v-card-title>
 
       <v-card-text class="text-body-1">
-        {{ message }}
+        <slot name="content">
+          <span v-if="message">{{ message }}</span>
+        </slot>
       </v-card-text>
 
       <v-card-actions class="pa-4">
@@ -32,7 +34,7 @@ import { computed, ref, watch } from 'vue'
 interface Props {
   modelValue: boolean
   title?: string
-  message: string
+  message?: string
   confirmText?: string
   cancelText?: string
   confirmColor?: string
@@ -44,6 +46,7 @@ interface Props {
 
 const props = withDefaults(defineProps<Props>(), {
   title: 'Please Confirm',
+  message: '',
   confirmText: 'YES',
   cancelText: 'NO',
   confirmColor: 'error',


### PR DESCRIPTION
## Changes
- use `ConfirmDialog` component to ask for comments after editing schedule

This fixes #1349 

<img width="1212" height="745" alt="Screenshot_20250918_004744" src="https://github.com/user-attachments/assets/223b5faf-7751-4081-8ad8-f30540a7725c" />

