### PR TITLE
remove precision from filesizes formatting

### DIFF
--- a/frontend-ui/src/utils/format.ts
+++ b/frontend-ui/src/utils/format.ts
@@ -75,7 +75,7 @@ export function fromNow(value: string) {
 }
 
 export function formattedBytesSize(value: number) {
-  return filesize(value, { base: 2, standard: 'iec', precision: 3 }) // precision 3, display in KiB, MiB,... instead of KB, MB,...
+  return filesize(value, { base: 2, standard: 'iec' }) // display in KiB, MiB,... instead of KB, MB,...
 }
 
 export function getTimezoneDetails() {


### PR DESCRIPTION
## Changes
- remove `precision` while formatting filesizes. This allows the library to handle precision on its own. Default number of decimal places is 2 which is sufficient.
This fixes the issue where sizes show up as `1.01e+3 MiB` as in https://farm.openzim.org/pipeline/48abf1a8-f355-43a2-9491-fd500150b0cc

### Without precison
```node
> filesize.filesize(1058223158, {base: 2, standard: 'iec'})
'1009.2 MiB'
> filesize.filesize(529825922, {base: 2, standard: 'iec'})
'505.28 MiB'
> filesize.filesize(1024*1024, {base: 2, standard: 'iec'})
'1 MiB'
```

### With precison
```node
> filesize.filesize(1024*1024, {base: 2, standard: 'iec', precision: 3})
'1.00 MiB'
> filesize.filesize(1058223158, {base: 2, standard: 'iec', precision: 3})
'1.01e+3 MiB'
> filesize.filesize(529825922, {base: 2, standard: 'iec', precision: 3})
'505 MiB'
```

The library offers options like `round` and `roundingMethod` which we can use to get rid of decimal places if they are undesired.
