### PR TITLE
Fix worker check-in: impersonation + new worker

### DIFF
--- a/backend/tests/routes/test_worker.py
+++ b/backend/tests/routes/test_worker.py
@@ -38,9 +38,9 @@ def test_check_in_worker_not_found(
     client: TestClient,
     access_token: str,
 ):
-    """Test that check_in_worker raises NotFoundError for non-existent worker"""
+    """Test that check_in_worker creates new worker when it does not exists"""
     response = client.put(
-        "/v2/workers/non-existent/check-in",
+        "/v2/workers/a-new-worker/check-in",
         json={
             "selfish": True,
             "cpu": 1,
@@ -51,7 +51,7 @@ def test_check_in_worker_not_found(
         },
         headers={"Authorization": f"Bearer {access_token}"},
     )
-    assert response.status_code == HTTPStatus.NOT_FOUND
+    assert response.status_code == HTTPStatus.NO_CONTENT
 
 
 def test_check_in_worker_deleted(


### PR DESCRIPTION
## Rationale

Fix #1357 
Fix #764 

## Changes

- do not check existing worker status when there is none because it is the first check-in of this worker
- if worker already exists, systematically check that worker is associated with current user before performing any operation to avoid impersonation

Note that the authorization topic has been moved out of #764 to #1358