### PR TITLE
show more columns in recipe history

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -70,6 +70,7 @@ class BaseTaskSchema(BaseModel):
     requested_by: str
     original_schedule_name: str
     context: str
+    priority: int
 
 
 class TaskLightSchema(BaseTaskSchema):

--- a/backend/src/zimfarm_backend/db/tasks.py
+++ b/backend/src/zimfarm_backend/db/tasks.py
@@ -122,6 +122,7 @@ def get_tasks(
             Task.timestamp,
             Task.original_schedule_name,
             Task.context,
+            Task.priority,
             Bundle(  # pyright: ignore[reportUnknownArgumentType]
                 "config",
                 Task.config["resources"].label("resources"),
@@ -150,6 +151,7 @@ def get_tasks(
         timestamp,
         original_schedule_name,
         context,
+        priority,
         config,
         updated_at,
         requested_by,
@@ -166,6 +168,7 @@ def get_tasks(
                 timestamp=timestamp,
                 original_schedule_name=original_schedule_name,
                 context=context,
+                priority=priority,
                 config=ConfigWithOnlyResourcesSchema(
                     resources=ConfigResourcesSchema(
                         cpu=config.resources["cpu"],

--- a/frontend-ui/src/components/PipelineTable.vue
+++ b/frontend-ui/src/components/PipelineTable.vue
@@ -68,7 +68,7 @@
         <template #[`item.completed`]="{ item }">
           <v-tooltip location="bottom">
             <template #activator="{ props }">
-              <span v-bind="props">
+              <span v-bind="props" class="text-no-wrap">
                 <router-link :to="{ name: 'task-detail', params: { id: item.id } }">
                   {{ fromNow(item.updated_at) }}
                 </router-link>
@@ -81,7 +81,7 @@
         <template #[`item.stopped`]="{ item }">
           <v-tooltip location="bottom">
             <template #activator="{ props }">
-              <span v-bind="props">
+              <span v-bind="props" class="text-no-wrap">
                 <router-link :to="{ name: 'task-detail', params: { id: item.id } }">
                   {{ fromNow(item.updated_at) }}
                 </router-link>
@@ -100,7 +100,13 @@
         </template>
 
         <template #[`item.worker`]="{ item }">
-          <code class="text-pink-accent-2" v-if="item.worker_name">{{ item.worker_name }}</code>
+          <router-link
+            v-if="item.worker_name"
+            :to="{ name: 'worker-detail', params: { workerName: item.worker_name } }"
+            class="text-decoration-none"
+          >
+            {{ item.worker_name }}
+          </router-link>
           <span v-else>n/a</span>
         </template>
 

--- a/frontend-ui/src/types/base.ts
+++ b/frontend-ui/src/types/base.ts
@@ -96,6 +96,6 @@ export interface BaseTask {
   updated_at: string
   requested_by: string
   original_schedule_name: string
-  duration?: string
+  context: string
   priority: number
 }

--- a/frontend-ui/src/types/tasks.ts
+++ b/frontend-ui/src/types/tasks.ts
@@ -78,7 +78,6 @@ export interface Task extends BaseTask {
   debug: TaskDebug
   canceled_by: string | null
   container: TaskContainer
-  priority: number
   notification: ScheduleNotification | null
   files: Record<string, TaskFile>
   upload: TaskUpload

--- a/frontend-ui/src/utils/format.ts
+++ b/frontend-ui/src/utils/format.ts
@@ -11,43 +11,16 @@ function getUnits(interval: Interval<true>) {
   return units
 }
 
-function toDurationObj(milliseconds: number) {
-  const items: Record<string, number> = {
-    years: 0,
-    months: 0,
-    days: 0,
-    hours: 0,
-    minutes: 0,
-    seconds: 0,
-    milliseconds: milliseconds,
-  }
-
-  function toObj() {
-    const o: Record<string, number> = {}
-    Object.entries(items).forEach((item) => {
-      const [key, value] = item
-      if (value >= 1 && key != 'milliseconds') o[key] = value
-    })
-    return o
-  }
-
-  function shift(lower: string, upper: string, num: number) {
-    items[upper] = items[lower] / num
-    items[lower] = items[lower] % num
-    return items[upper] < 1
-  }
-  if (shift('milliseconds', 'seconds', 1000)) return toObj()
-  if (shift('seconds', 'minutes', 60)) return toObj()
-  if (shift('minutes', 'hours', 60)) return toObj()
-  if (shift('hours', 'days', 24)) return toObj()
-  if (shift('days', 'months', 30)) return toObj()
-  shift('months', 'years', 12)
-  return toObj()
-}
-
 export function formatDuration(value: number) {
-  const dur = Duration.fromObject(toDurationObj(value))
-  return dur.toHuman({ maximumSignificantDigits: 1 })
+  const dur = Duration.fromMillis(value).shiftTo('days', 'hours', 'minutes')
+  // Filter out zero units
+  const clean = Duration.fromObject(
+    Object.fromEntries(
+      Object.entries(dur.toObject()).filter((entry) => entry[1] && entry[1] !== 0),
+    ),
+  )
+
+  return clean.toHuman({ maximumSignificantDigits: 1 })
 }
 
 export function formatDt(value?: string, format: string = 'fff') {

--- a/frontend-ui/src/views/SchedulesView.vue
+++ b/frontend-ui/src/views/SchedulesView.vue
@@ -3,6 +3,7 @@
 <template>
   <div>
     <SchedulesFilter
+      v-if="ready"
       :filters="filters"
       :categories="categories"
       :languages="languages"
@@ -10,6 +11,7 @@
       @filters-changed="handleFiltersChange"
     />
     <SchedulesTable
+      v-if="ready"
       :requesting-text="requestingText"
       :headers="headers"
       :schedules="schedules"
@@ -24,6 +26,9 @@
       @clear-filters="clearFilters"
       @fetch-schedules="handleFetchSchedules"
     />
+    <div v-else class="d-flex align-center justify-center" style="height: 60vh">
+      <v-progress-circular indeterminate size="70" width="7" color="primary" />
+    </div>
   </div>
 </template>
 
@@ -58,6 +63,7 @@ const schedules = ref<ScheduleLight[]>([])
 const paginator = computed(() => scheduleStore.paginator)
 
 const blockUrlUpdates = ref<boolean>(false)
+const ready = ref<boolean>(false)
 
 const errors = ref<string[]>([])
 
@@ -228,6 +234,9 @@ onMounted(async () => {
   intervalId.value = window.setInterval(async () => {
     await loadData(paginator.value.limit, paginator.value.skip, true)
   }, 60000)
+
+  // Mark as ready to show content - the table will handle initial load via updateOptions
+  ready.value = true
 })
 
 onBeforeUnmount(() => {
@@ -242,6 +251,6 @@ watch(
   () => {
     loadFiltersFromUrl()
   },
-  { deep: true },
+  { deep: true, immediate: true },
 )
 </script>

--- a/frontend-ui/src/views/TaskDetailView.vue
+++ b/frontend-ui/src/views/TaskDetailView.vue
@@ -105,7 +105,14 @@
                   </tr>
                   <tr>
                     <th class="text-left w-20">Worker</th>
-                    <td>{{ task.worker_name }}</td>
+                    <td>
+                      <router-link
+                        :to="{ name: 'worker-detail', params: { workerName: task.worker_name } }"
+                        class="text-decoration-none"
+                      >
+                        {{ task.worker_name }}
+                      </router-link>
+                    </td>
                   </tr>
                   <tr>
                     <th class="text-left w-20">Started On</th>


### PR DESCRIPTION
## Changes
- add columns for worker and duration in recipe history runs.
- add link to workers across ui since there is now a workers detail page
- use no-wrap on task detail links since they are mostly short and wrapping makes them look odd

This fixes #432 
