### PR TITLE
upgrade filesize library to handle precision properly

### DIFF
--- a/frontend-ui/package.json
+++ b/frontend-ui/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "axios": "^1.10.0",
     "deep-diff": "^1.0.2",
-    "filesize": "^10.1.6",
+    "filesize": "^11.0.7",
     "fuse.js": "^7.1.0",
     "jwt-decode": "^4.0.0",
     "luxon": "^3.6.1",

--- a/frontend-ui/src/utils/format.ts
+++ b/frontend-ui/src/utils/format.ts
@@ -75,7 +75,7 @@ export function fromNow(value: string) {
 }
 
 export function formattedBytesSize(value: number) {
-  return filesize(value, { base: 2, standard: 'iec' }) // display in KiB, MiB,... instead of KB, MB,...
+  return filesize(value, { base: 2, standard: 'iec', precision: 3 }) // display in KiB, MiB,... instead of KB, MB,...
 }
 
 export function getTimezoneDetails() {

--- a/frontend-ui/yarn.lock
+++ b/frontend-ui/yarn.lock
@@ -1909,10 +1909,10 @@ file-entry-cache@^8.0.0:
   dependencies:
     flat-cache "^4.0.0"
 
-filesize@^10.1.6:
-  version "10.1.6"
-  resolved "https://registry.yarnpkg.com/filesize/-/filesize-10.1.6.tgz#31194da825ac58689c0bce3948f33ce83aabd361"
-  integrity sha512-sJslQKU2uM33qH5nqewAwVB2QgR6w1aMNsYUp3aN5rMRyXEwJGmZvaWzeJFNTOXWlHQyBFCWrdj3fV/fsTOX8w==
+filesize@^11.0.7:
+  version "11.0.7"
+  resolved "https://registry.yarnpkg.com/filesize/-/filesize-11.0.7.tgz#0603fced3d92716e800a084aeaa8f2a8e4569751"
+  integrity sha512-HozRSaD6ZrUdUVdSI9kJPsI9TzDZb+OZNL0xOWlxkQGfOsjh5Fp1AAI7GObJutOpclSBycHBDEREzwYcXPo8Ew==
 
 fill-range@^7.1.1:
   version "7.1.1"


### PR DESCRIPTION
## Changes
- upgrade filesize library and reset precision to 3. upstream has closed avoidwork/filesize.js#200

This fixes #1105 
<img width="1139" height="569" alt="Screenshot_20250919_134755" src="https://github.com/user-attachments/assets/c86cc8f8-c486-4141-b89b-41c890f24df4" />
