### PR TITLE
show more info on pipeline doing tab

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -67,6 +67,7 @@ class BaseTaskSchema(BaseModel):
     schedule_name: str | None
     worker_name: str
     updated_at: datetime.datetime
+    requested_by: str
     original_schedule_name: str
     context: str
 
@@ -87,7 +88,6 @@ class TaskFullSchema(BaseTaskSchema):
     config: ExpandedScheduleConfigSchema
     events: list[dict[str, str | datetime.datetime]]
     debug: dict[str, Any]
-    requested_by: str
     canceled_by: str | None
     container: dict[str, Any]
     priority: int

--- a/backend/src/zimfarm_backend/db/tasks.py
+++ b/backend/src/zimfarm_backend/db/tasks.py
@@ -127,6 +127,7 @@ def get_tasks(
                 Task.config["resources"].label("resources"),
             ),
             Task.updated_at,
+            Task.requested_by,
             Schedule.name.label("schedule_name"),
             Worker.name.label("worker_name"),
         )
@@ -151,6 +152,7 @@ def get_tasks(
         context,
         config,
         updated_at,
+        requested_by,
         _schedule_name,
         worker_name,
     ) in session.execute(
@@ -172,6 +174,7 @@ def get_tasks(
                     ),
                 ),
                 updated_at=updated_at,
+                requested_by=requested_by,
                 schedule_name=_schedule_name,
                 worker_name=worker_name,
             )

--- a/frontend-ui/src/components/CancelTaskButton.vue
+++ b/frontend-ui/src/components/CancelTaskButton.vue
@@ -1,0 +1,101 @@
+<!-- Full-featured button to cancel a task by its id
+
+  - disabled if not signed-in
+  - displays a confirmation dialog before cancellation
+  - displays a spinner on click
+  - calls the API in the background
+  - displays result as an AlertFeedback -->
+
+<template>
+  <div>
+    <v-btn
+      v-if="canCancelTasks"
+      color="error"
+      variant="outlined"
+      size="small"
+      :loading="isCanceling"
+      :disabled="isCanceling"
+      @click="showConfirmDialog"
+    >
+      <v-icon size="small" class="mr-1">mdi-cancel</v-icon>
+      {{ isCanceling ? 'Canceling...' : 'Cancel' }}
+    </v-btn>
+
+    <ConfirmDialog
+      v-model="showDialog"
+      title="Cancel Task"
+      message="Are you sure you want to cancel this task?"
+      confirm-text="Cancel Task"
+      cancel-text="Keep Running"
+      confirm-color="error"
+      icon="mdi-cancel"
+      icon-color="error"
+      :loading="isCanceling"
+      @confirm="cancelTask"
+      @cancel="hideConfirmDialog"
+    />
+  </div>
+</template>
+
+<script setup lang="ts">
+import ConfirmDialog from '@/components/ConfirmDialog.vue'
+import { useAuthStore } from '@/stores/auth'
+import { useNotificationStore } from '@/stores/notification'
+import { useTasksStore } from '@/stores/tasks'
+import { computed, ref } from 'vue'
+
+// Props
+interface Props {
+  id: string
+}
+
+const props = defineProps<Props>()
+
+// Emits
+const emit = defineEmits<{
+  'task-canceled': [id: string]
+}>()
+
+const tasksStore = useTasksStore()
+const authStore = useAuthStore()
+const notificationStore = useNotificationStore()
+
+const isCanceling = ref(false)
+const showDialog = ref(false)
+
+const canCancelTasks = computed(() => authStore.hasPermission('tasks', 'cancel'))
+
+const showConfirmDialog = () => {
+  showDialog.value = true
+}
+
+const hideConfirmDialog = () => {
+  showDialog.value = false
+}
+
+const cancelTask = async () => {
+  if (isCanceling.value) return
+
+  isCanceling.value = true
+
+  try {
+    const success = await tasksStore.cancelTask(props.id)
+
+    if (success) {
+      notificationStore.showSuccess('Task cancellation requested')
+      emit('task-canceled', props.id)
+    } else {
+      // Show error notifications from the store
+      for (const error of tasksStore.errors) {
+        notificationStore.showError(error)
+      }
+    }
+  } catch (error) {
+    console.error('Failed to cancel task:', error)
+    notificationStore.showError('Failed to cancel task')
+  } finally {
+    isCanceling.value = false
+    hideConfirmDialog()
+  }
+}
+</script>

--- a/frontend-ui/src/components/PipelineTable.vue
+++ b/frontend-ui/src/components/PipelineTable.vue
@@ -55,7 +55,7 @@
         <template #[`item.started`]="{ item }">
           <v-tooltip location="bottom">
             <template #activator="{ props }">
-              <span v-bind="props">
+              <span v-bind="props" class="text-no-wrap">
                 <router-link :to="{ name: 'task-detail', params: { id: item.id } }">
                   {{ fromNow(getTimestampStringForStatus(item.timestamp, 'reserved')) }}
                 </router-link>
@@ -112,6 +112,14 @@
           />
         </template>
 
+        <template #[`item.cancel`]="{ item }">
+          <CancelTaskButton
+            v-if="canCancelTasks"
+            :id="item.id"
+            @task-canceled="emit('loadData', selectedLimit, 0)"
+          />
+        </template>
+
         <template #[`item.duration`]="{ item }">
           {{
             formatDurationBetween(
@@ -142,7 +150,7 @@
         </template>
 
         <template #[`item.requested_by`]="{ item }">
-          {{ (item as any).requested_by }}
+          {{ (item as TaskLight | RequestedTaskLight).requested_by }}
         </template>
       </v-data-table-server>
       <ErrorMessage v-for="error in errors" :key="error" :message="error" />
@@ -151,6 +159,7 @@
 </template>
 
 <script setup lang="ts">
+import CancelTaskButton from '@/components/CancelTaskButton.vue'
 import ErrorMessage from '@/components/ErrorMessage.vue'
 import RemoveRequestedTaskButton from '@/components/RemoveRequestedTaskButton.vue'
 import ResourceBadge from '@/components/ResourceBadge.vue'
@@ -165,6 +174,7 @@ import { ref, watch } from 'vue'
 const props = defineProps<{
   headers: { title: string; value: string }[] // the headers to display
   canUnRequestTasks: boolean // whether the user can unrequest tasks
+  canCancelTasks: boolean // whether the user can cancel tasks
   loading: boolean // whether the table is loading
   loadingText: string // the text to display when the table is loading
   tasks: TaskLight[] | RequestedTaskLight[] // the tasks to display

--- a/frontend-ui/src/components/RemoveRequestedTaskButton.vue
+++ b/frontend-ui/src/components/RemoveRequestedTaskButton.vue
@@ -40,6 +40,7 @@
 <script setup lang="ts">
 import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import { useAuthStore } from '@/stores/auth'
+import { useNotificationStore } from '@/stores/notification'
 import { useRequestedTasksStore } from '@/stores/requestedTasks'
 import { computed, ref } from 'vue'
 
@@ -57,6 +58,7 @@ const emit = defineEmits<{
 
 const requestedTasksStore = useRequestedTasksStore()
 const authStore = useAuthStore()
+const notificationStore = useNotificationStore()
 
 const isRemoving = ref(false)
 const showDialog = ref(false)
@@ -80,9 +82,7 @@ const removeTask = async () => {
     const success = await requestedTasksStore.removeRequestedTask(props.id)
 
     if (success) {
-      // Emit event to parent component
-      // TODO: Set parent.working to false, not sure what this means
-      // TODO: parent.alertSuccess
+      notificationStore.showSuccess('Requested task removed')
       emit('requested-task-removed', props.id)
     }
   } catch (error) {

--- a/frontend-ui/src/types/base.ts
+++ b/frontend-ui/src/types/base.ts
@@ -94,6 +94,7 @@ export interface BaseTask {
   schedule_name: string | null
   worker_name: string
   updated_at: string
+  requested_by: string
   original_schedule_name: string
   duration?: string
   priority: number

--- a/frontend-ui/src/types/requestedTasks.ts
+++ b/frontend-ui/src/types/requestedTasks.ts
@@ -3,6 +3,7 @@ import type { ExpandedScheduleConfig, ScheduleNotification } from '@/types/sched
 
 export interface RequestedTaskLight extends BaseTask {
   config: ConfigWithOnlyOfflinerAndResources
+  requested_by: string
 }
 
 export interface NewRequestedTaskSchemaResponse {

--- a/frontend-ui/src/types/tasks.ts
+++ b/frontend-ui/src/types/tasks.ts
@@ -76,7 +76,6 @@ export interface Task extends BaseTask {
   config: ExpandedScheduleConfig
   events: TaskEvent[]
   debug: TaskDebug
-  requested_by: string
   canceled_by: string | null
   container: TaskContainer
   priority: number

--- a/frontend-ui/src/views/PipelineView.vue
+++ b/frontend-ui/src/views/PipelineView.vue
@@ -14,6 +14,7 @@
     :loading-text="loadingStore.loadingText"
     :errors="errors"
     :canUnRequestTasks="canUnRequestTasks"
+    :canCancelTasks="canCancelTasks"
     :lastRunsLoaded="lastRunsLoaded"
     :schedulesLastRuns="schedulesLastRuns"
     @limit-changed="handleLimitChange"
@@ -60,8 +61,11 @@ const headers = computed(() => {
       return [
         { title: 'Schedule', value: 'schedule_name' },
         { title: 'Started', value: 'started' },
+        { title: 'By', value: 'requested_by' },
+        { title: 'Resources', value: 'resources' },
         { title: 'Worker', value: 'worker' },
-      ]
+        canUnRequestTasks.value ? { title: 'Cancel', value: 'cancel' } : null,
+      ].filter(Boolean) as { title: string; value: string }[]
     case 'done':
       return [
         { title: 'Schedule', value: 'schedule_name' },
@@ -122,6 +126,7 @@ const scheduleStore = useScheduleStore()
 const notificationStore = useNotificationStore()
 
 const canUnRequestTasks = computed(() => authStore.hasPermission('tasks', 'unrequest'))
+const canCancelTasks = computed(() => authStore.hasPermission('tasks', 'cancel'))
 
 const handleFilterChange = (newFilter: string) => {
   currentFilter.value = newFilter


### PR DESCRIPTION
## Changes
- add `Started`, `By`, `Cancel` columns to pipeline `Doing` tab.
    - `Started` points to the tasklink
    - `By` mentions the user who requested the task
    - `Cancel` provides button with confirmation dialog to send request to cancel task (requires permissions)

 This fixes   #949 

Without and with `Cancel` permissions
   
<img width="1531" height="459" alt="Screenshot_20250922_121250" src="https://github.com/user-attachments/assets/d2968585-6939-4820-8da8-c64a7cc80a1e" />
<img width="1199" height="636" alt="Screenshot_20250922_121227" src="https://github.com/user-attachments/assets/9ce3abaf-d4e7-4646-8280-93829f7e874d" />

