### PR TITLE
use slug strings for relaxed offliner schemas

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/fields.py
+++ b/backend/src/zimfarm_backend/common/schemas/fields.py
@@ -199,6 +199,16 @@ ZIMFileName = Annotated[
 
 OptionalZIMFileName = ZIMFileName | None
 
+SlugString = Annotated[
+    str,
+    Field(
+        pattern=r"^[A-Za-z0-9._-]+$",
+    ),
+    WrapValidator(skip_validation),
+]
+
+OptionalSlugString = SlugString | None
+
 ZIMName = Annotated[
     str,
     Field(pattern=r"^([a-z0-9\-\.]+_)([a-z\-]+_)([a-z0-9\-\.]+)$"),

--- a/backend/src/zimfarm_backend/common/schemas/offliners/nautilus.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/nautilus.py
@@ -9,6 +9,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalNotEmptyString,
     OptionalSecretUrl,
     OptionalSkipableUrl,
+    OptionalSlugString,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMOutputFolder,
@@ -142,7 +143,7 @@ class NautilusFlagsSchemaRelaxed(NautilusFlagsSchema):
     Typically used for nautilus.kiwix.org
     """
 
-    zim_file: OptionalNotEmptyString = OptionalField(
+    zim_file: OptionalSlugString = OptionalField(
         title="ZIM filename",
         description="ZIM file name (based on --name if not provided).",
     )

--- a/backend/src/zimfarm_backend/common/schemas/offliners/zimit.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/zimit.py
@@ -5,11 +5,11 @@ from pydantic import Field, WrapValidator
 
 from zimfarm_backend.common.schemas import CamelModel
 from zimfarm_backend.common.schemas.fields import (
-    NotEmptyString,
     OptionalField,
     OptionalNotEmptyString,
     OptionalPercentage,
     OptionalSkipableUrl,
+    OptionalSlugString,
     OptionalZIMDescription,
     OptionalZIMFileName,
     OptionalZIMLangCode,
@@ -17,6 +17,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalZIMOutputFolder,
     OptionalZIMProgressFile,
     OptionalZIMTitle,
+    SlugString,
     ZIMName,
     enum_member,
 )
@@ -596,12 +597,12 @@ class ZimitFlagsSchemaRelaxed(ZimitFlagsFullSchema):
     """
 
     offliner_id: Literal["zimit"] = Field(alias="offliner_id")
-    zim_file: OptionalNotEmptyString = OptionalField(
+    zim_file: OptionalSlugString = OptionalField(
         title="ZIM filename",
         description="ZIM file name (based on --name if not provided).",
         alias="zim-file",
     )
-    name: NotEmptyString = Field(
+    name: SlugString = Field(
         title="Name",
         description="Name of the ZIM. "
         "Used to compose filename if not otherwise defined",


### PR DESCRIPTION
## Changes
- define `SlugString` type and use for validating relaxed versions of offliners as opposed to bare strings with no validations.

This fixes #1010 
