### PR TITLE
compute single duration for total duration in milliseconds

### DIFF
--- a/frontend-ui/src/utils/offliner.ts
+++ b/frontend-ui/src/utils/offliner.ts
@@ -83,20 +83,21 @@ interface MultipleScheduleDuration {
   minWorkers: WorkerScheduleDuration[]
   maxWorkers: WorkerScheduleDuration[]
 }
-export function single_duration(value: number, worker: string, on: string): SingleScheduleDuration {
-  return {
-    single: true,
-    value: value,
-    formattedDuration: formatDuration(value * 1000),
-    worker: worker,
-    on: on,
-  }
-}
 
 export function buildScheduleDuration(
   duration: ScheduleDuration | null,
 ): SingleScheduleDuration | MultipleScheduleDuration | null {
   if (!duration) return null
+
+  function single_duration(value: number, worker: string, on: string): SingleScheduleDuration {
+    return {
+      single: true,
+      value: value,
+      formattedDuration: formatDuration(value * 1000),
+      worker: worker,
+      on: on,
+    }
+  }
 
   if (!duration.available && duration.default) {
     return single_duration(duration.default.value, 'default', duration.default.on)
@@ -214,7 +215,13 @@ export function buildTotalDurationDict(
 
   // If all tasks have the same duration, return single duration
   if (minTask.duration === maxTask.duration) {
-    return single_duration(minTask.duration, minTask.worker, minTask.on)
+    return {
+      single: true,
+      value: minTask.duration,
+      formattedDuration: formatDuration(minTask.duration),
+      worker: minTask.worker,
+      on: minTask.on,
+    }
   }
 
   // Group workers by duration for min/max, ensuring no duplicate workers


### PR DESCRIPTION
## Rationale
the `single_duration` function assumes `duration` would be in `seconds` (the values come from the backend). So, it converts to milliseconds before forwarding to luxon. However, using it in `buildTotalDurationDict` proves buggy becuase those durations are already in milliseconds. This causes issuse like #1375 where 7,800,000 gets multiplied by 1000, causing it to give 90 days as return value. Without this extra multiplication, the value would be 2 hours, 10 minutes (as expected)

## Changes
- move `single_duration` helper function inside the `buildScheduleDuration` as that's where it's helpful
- compute the formatted duration directly from the duration in `buildTotalDurationDict`

This fixes #1375 
