### PR TITLE
display characters limit on schedule editor

### DIFF
--- a/frontend-ui/src/components/ScheduleEditor.vue
+++ b/frontend-ui/src/components/ScheduleEditor.vue
@@ -312,6 +312,8 @@
               v-if="field.component === 'switch'"
               v-model="editFlags[field.dataKey]"
               density="compact"
+              :details="field.description ?? undefined"
+              persistent-hint
             />
             <v-select
               v-else-if="field.component === 'multiselect'"
@@ -326,6 +328,8 @@
               :rules="getFieldRules(field)"
               :hide-details="'auto'"
               :validate-on="'eager blur'"
+              :hint="field.description ?? undefined"
+              persistent-hint
             />
             <v-select
               v-else-if="field.component === 'select'"
@@ -338,6 +342,8 @@
               :rules="getFieldRules(field)"
               :hide-details="'auto'"
               :validate-on="'blur'"
+              :hint="field.description ?? undefined"
+              persistent-hint
             />
             <v-text-field
               v-else-if="field.component === 'number'"
@@ -351,6 +357,8 @@
               :rules="getFieldRules(field)"
               :hide-details="'auto'"
               :validate-on="'blur'"
+              :hint="field.description ?? undefined"
+              persistent-hint
             />
             <v-text-field
               v-else-if="field.component === 'url'"
@@ -363,6 +371,8 @@
               :rules="getFieldRules(field)"
               :hide-details="'auto'"
               :validate-on="'blur'"
+              :hint="field.description ?? undefined"
+              persistent-hint
             />
             <v-text-field
               v-else-if="field.component === 'email'"
@@ -375,6 +385,8 @@
               :rules="getFieldRules(field)"
               :hide-details="'auto'"
               :validate-on="'blur'"
+              :hint="field.description ?? undefined"
+              persistent-hint
             />
             <v-text-field
               v-else-if="field.component === 'color'"
@@ -387,6 +399,8 @@
               :rules="getFieldRules(field)"
               :hide-details="'auto'"
               :validate-on="'blur'"
+              :hint="field.description ?? undefined"
+              persistent-hint
             />
             <v-textarea
               v-else-if="field.component === 'textarea'"
@@ -395,10 +409,15 @@
               variant="outlined"
               :placeholder="field.placeholder"
               :required="field.required"
+              :counter="field.max_length ? true : undefined"
+              :maxlength="field.max_length ? field.max_length : undefined"
+              :persistent-counter="field.max_length ? true : undefined"
               auto-grow
               :rules="getFieldRules(field)"
               :hide-details="'auto'"
               :validate-on="'blur'"
+              :hint="field.description ?? undefined"
+              persistent-hint
             />
             <v-text-field
               v-else
@@ -407,11 +426,14 @@
               variant="outlined"
               :placeholder="field.placeholder"
               :required="field.required"
+              :counter="field.max_length ? true : undefined"
+              :maxlength="field.max_length ? field.max_length : undefined"
               :rules="getFieldRules(field)"
               :hide-details="'auto'"
               :validate-on="'blur'"
+              :hint="field.description ?? undefined"
+              persistent-hint
             />
-            <v-text class="text-caption">{{ field.description }}</v-text>
           </td>
         </tr>
       </tbody>

--- a/frontend-ui/src/components/SwitchButton.vue
+++ b/frontend-ui/src/components/SwitchButton.vue
@@ -9,6 +9,8 @@
         :density="density"
         :hide-details="hideDetails"
         @update:model-value="handleUpdate"
+        :hint="hint"
+        :persistent-hint="persistentHint"
       />
       <span class="ml-2 text-body-2 text-medium-emphasis">
         {{ modelValue ? 'Enabled' : 'Disabled' }}
@@ -28,7 +30,9 @@ interface Props {
   color?: string
   disabled?: boolean
   density?: 'default' | 'compact' | 'comfortable'
-  hideDetails?: boolean
+  hideDetails?: boolean | 'auto'
+  hint?: string
+  persistentHint?: boolean
 }
 
 interface Emits {


### PR DESCRIPTION
## Changes
- show counter for text fields if they have a max length
- show flag description in hint instead so it aligns nicely with the counter
This fixes #1025 

<img width="855" height="155" alt="Screenshot_20250929_115000" src="https://github.com/user-attachments/assets/85822fda-ef56-4fe4-816d-55c35e573db6" />

