### PR TITLE
drop support for SSH keys in PEM format

### DIFF
--- a/backend/V1_TO_V2_MIGRATION.md
+++ b/backend/V1_TO_V2_MIGRATION.md
@@ -82,7 +82,7 @@ Zimfarm Backend v2 represents a significant modernization of the codebase, migra
 
 - FastAPI dependency injection for authentication
 - Uses `cryptography` library for cryptographic functions
-- Supports SSH keys in RSA and PEM formats
+- Supports SSH keys generated with RSA, ECDSA and Ed25519 algorithms
 - Token payload `expires_in` renamed to `expires_time` and is a datetime isoformat string
 
 ### 7. Models

--- a/backend/src/zimfarm_backend/exceptions.py
+++ b/backend/src/zimfarm_backend/exceptions.py
@@ -1,4 +1,4 @@
-class PEMPublicKeyLoadError(Exception):
-    """Unable to deserialize a public key from PEM encoded data"""
+class PublicKeyLoadError(Exception):
+    """Unable to load a public key from data"""
 
     pass

--- a/backend/src/zimfarm_backend/routes/auth/logic.py
+++ b/backend/src/zimfarm_backend/routes/auth/logic.py
@@ -21,7 +21,7 @@ from zimfarm_backend.db.refresh_token import (
     get_refresh_token,
 )
 from zimfarm_backend.db.user import get_user_by_username
-from zimfarm_backend.exceptions import PEMPublicKeyLoadError
+from zimfarm_backend.exceptions import PublicKeyLoadError
 from zimfarm_backend.routes.auth.models import (
     CredentialsIn,
     OAuth2CredentialsWithPassword,
@@ -169,7 +169,7 @@ def authenticate_user_with_ssh_keys(
             ):
                 authenticated = True
                 break
-        except PEMPublicKeyLoadError as exc:
+        except PublicKeyLoadError as exc:
             logger.exception("error while verifying message using public key")
             raise ForbiddenError("Unable to load public_key") from exc
 

--- a/backend/src/zimfarm_backend/routes/users/logic.py
+++ b/backend/src/zimfarm_backend/routes/users/logic.py
@@ -30,7 +30,7 @@ from zimfarm_backend.db.user import delete_user as db_delete_user
 from zimfarm_backend.db.user import get_users as db_get_users
 from zimfarm_backend.db.user import update_user as db_update_user
 from zimfarm_backend.db.user import update_user_password as db_update_user_password
-from zimfarm_backend.exceptions import PEMPublicKeyLoadError
+from zimfarm_backend.exceptions import PublicKeyLoadError
 from zimfarm_backend.routes.dependencies import get_current_user
 from zimfarm_backend.routes.http_errors import (
     BadRequestError,
@@ -188,7 +188,7 @@ def create_user_key(
 
     try:
         public_key = load_public_key(bytes(ssh_key.key, encoding="ascii"))
-    except PEMPublicKeyLoadError as e:
+    except PublicKeyLoadError as e:
         raise BadRequestError("Invalid public key") from e
 
     fingerprint = get_public_key_fingerprint(public_key)

--- a/backend/src/zimfarm_backend/utils/token.py
+++ b/backend/src/zimfarm_backend/utils/token.py
@@ -16,10 +16,8 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PublicKey,
 )
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
-from cryptography.hazmat.primitives.asymmetric.types import PublicKeyTypes
 from cryptography.hazmat.primitives.serialization import (
     SSHPublicKeyTypes,
-    load_pem_public_key,
     load_ssh_public_key,
 )
 
@@ -28,7 +26,7 @@ from zimfarm_backend.common.constants import (
     JWT_TOKEN_EXPIRY_DURATION,
     JWT_TOKEN_ISSUER,
 )
-from zimfarm_backend.exceptions import PEMPublicKeyLoadError
+from zimfarm_backend.exceptions import PublicKeyLoadError
 
 
 def generate_access_token(
@@ -175,22 +173,19 @@ def load_public_key(
     - Ed25519 (OpenSSH format)
     """
 
-    public_key: SSHPublicKeyTypes | PublicKeyTypes | None = None
+    public_key: SSHPublicKeyTypes | None = None
     try:
         public_key = load_ssh_public_key(key)
     except (ValueError, UnsupportedAlgorithm):
-        try:
-            public_key = load_pem_public_key(key)
-        except (ValueError, UnsupportedAlgorithm):
-            pass
+        pass
 
     if public_key is None:
-        raise PEMPublicKeyLoadError("Unable to load public key")
+        raise PublicKeyLoadError("Unable to load public key")
 
     if not isinstance(
         public_key, RSAPublicKey | EllipticCurvePublicKey | Ed25519PublicKey
     ):
-        raise PEMPublicKeyLoadError("Unsupported public key type.")
+        raise PublicKeyLoadError("Unsupported public key type.")
     return public_key
 
 

--- a/backend/tests/test_token.py
+++ b/backend/tests/test_token.py
@@ -5,7 +5,7 @@ import pytest
 from _pytest.python_api import RaisesContext
 from cryptography.hazmat.primitives.asymmetric import dsa
 
-from zimfarm_backend.exceptions import PEMPublicKeyLoadError
+from zimfarm_backend.exceptions import PublicKeyLoadError
 from zimfarm_backend.utils.token import get_public_key_type, load_public_key
 
 
@@ -42,19 +42,13 @@ wB4xA8f+g/OqcmUOM/1gT2SPiJ9SQkolYriDBfCfcuzWlcqQdOlFrrmtnWOh3Er+
 vMLud8dyKMud/T1up4PPavUCAwEAAQ==
 -----END PUBLIC KEY-----
 """,
-            does_not_raise(),
-            id="valid-rsa-pem_key",
-        ),
-        # Valid public ECDSA key in PEM format
-        pytest.param(
-            "-----BEGIN PUBLIC KEY-----\nMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEPgktY6fr6OHPZbZLypwrk511Lg7Z6S6B\nNSTqVYl/9oyxDLCW4sfIffpfVLQyfeOTMSG9NiAqonEwC+jPOsHNwRQIKWzXOScl\nT8Jc8Ikt4K/lLVGO0oRH7Gl2Mbzbr8z5\n-----END PUBLIC KEY-----\n",
-            does_not_raise(),
-            id="valid-rsa-pem-key",
+            pytest.raises(PublicKeyLoadError),
+            id="valid-rsa-but-in-pem-format",
         ),
         # Invalid key
         pytest.param(
             "ssh-rsa NOTAREALBASE64 user@example.com",
-            pytest.raises(PEMPublicKeyLoadError),
+            pytest.raises(PublicKeyLoadError),
             id="invalid-key",
         ),
         # Valid Ed25519 key


### PR DESCRIPTION
## Changes
- drop support of PEM format
- adjust UI to be able to directly input SSH key in a textbox

This fixes #1275

<img width="1096" height="276" alt="Screenshot_20250930_040834" src="https://github.com/user-attachments/assets/11419eb6-c3c7-412f-82e7-22bfec60e776" />

