### PR TITLE
verify messages using pem public key

### DIFF
--- a/backend/src/zimfarm_backend/utils/token.py
+++ b/backend/src/zimfarm_backend/utils/token.py
@@ -16,8 +16,10 @@ from cryptography.hazmat.primitives.asymmetric.ed25519 import (
     Ed25519PublicKey,
 )
 from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey, RSAPublicKey
+from cryptography.hazmat.primitives.asymmetric.types import PublicKeyTypes
 from cryptography.hazmat.primitives.serialization import (
     SSHPublicKeyTypes,
+    load_pem_public_key,
     load_ssh_public_key,
 )
 
@@ -173,11 +175,14 @@ def load_public_key(
     - Ed25519 (OpenSSH format)
     """
 
-    public_key: SSHPublicKeyTypes | None = None
+    public_key: SSHPublicKeyTypes | PublicKeyTypes | None = None
     try:
         public_key = load_ssh_public_key(key)
     except (ValueError, UnsupportedAlgorithm):
-        pass
+        try:
+            public_key = load_pem_public_key(key)
+        except (ValueError, UnsupportedAlgorithm):
+            pass
 
     if public_key is None:
         raise PublicKeyLoadError("Unable to load public key")

--- a/backend/tests/test_token.py
+++ b/backend/tests/test_token.py
@@ -42,8 +42,8 @@ wB4xA8f+g/OqcmUOM/1gT2SPiJ9SQkolYriDBfCfcuzWlcqQdOlFrrmtnWOh3Er+
 vMLud8dyKMud/T1up4PPavUCAwEAAQ==
 -----END PUBLIC KEY-----
 """,
-            pytest.raises(PublicKeyLoadError),
-            id="valid-rsa-but-in-pem-format",
+            does_not_raise(),
+            id="valid-rsa-in-pem-format",
         ),
         # Invalid key
         pytest.param(


### PR DESCRIPTION
## Rationale
It turns out that even though we have dropped support for registration using PEM keys, it is still necessary to allow verification with them https://github.com/openzim/zimfarm/blob/caf07a51462e4d08f00595c0f7b6cfba34389cf5/backend/src/zimfarm_backend/routes/auth/logic.py#L165-L169

The above snippet verifies with `ssh_key.pkc8_key`

This fixes #1384