### PR TITLE
display offliner definition version

### DIFF
--- a/frontend-ui/src/views/ScheduleDetailView.vue
+++ b/frontend-ui/src/views/ScheduleDetailView.vue
@@ -430,13 +430,19 @@
                     </td>
                   </tr>
                   <tr>
+                    <th class="text-left">Offliner Definition</th>
+                    <td>
+                      <code>{{ schedule.version }}</code>
+                    </td>
+                  </tr>
+                  <tr>
                     <th class="text-left">Platform</th>
                     <td>
                       <code>{{ platform || '-' }}</code>
                     </td>
                   </tr>
                   <tr>
-                    <th class="text-left">Warehouse path</th>
+                    <th class="text-left">Warehouse Path</th>
                     <td>
                       <code>{{ warehousePath }}</code>
                     </td>

--- a/frontend-ui/src/views/TaskDetailView.vue
+++ b/frontend-ui/src/views/TaskDetailView.vue
@@ -276,6 +276,12 @@
                     </td>
                   </tr>
                   <tr v-if="task.config">
+                    <th class="text-left w-20">Offliner Definition</th>
+                    <td>
+                      <code>{{ task.version }}</code>
+                    </td>
+                  </tr>
+                  <tr v-if="task.config">
                     <th class="text-left w-20">Resources</th>
                     <td>
                       <ResourceBadge kind="cpu" :value="task.config.resources.cpu" />


### PR DESCRIPTION
## Changes
- show offliner definition version in schedule config and task debug tabs

This fixes #1388 
<img width="1005" height="382" alt="Screenshot_20251002_113843" src="https://github.com/user-attachments/assets/cb63bbd4-02bb-40de-95f1-94ba6283383f" />
<img width="1005" height="382" alt="Screenshot_20251002_113832" src="https://github.com/user-attachments/assets/a44f9baf-c8dd-44ca-ace1-e2aadb495d41" />
