### PR TITLE
revise ilike comparisons to match only at end

### DIFF
--- a/backend/src/zimfarm_backend/db/schedule.py
+++ b/backend/src/zimfarm_backend/db/schedule.py
@@ -265,7 +265,7 @@ def get_schedules(
             (Schedule.category.in_(categories or []) | (categories is None)),
             (Schedule.language_code.in_(lang or []) | (lang is None)),
             (Schedule.tags.contains(tags or []) | (tags is None)),
-            (Schedule.name.ilike(f"%{name}%") | (name is None)),
+            (Schedule.name.ilike(f"{name}%") | (name is None)),
         )
         .offset(skip)
         .limit(limit)


### PR DESCRIPTION
## Rationale
Previously, the API matched names when fetching schedules like so https://github.com/openzim/zimfarm/blob/9daa7a59c2b1762f5fc06939d6181ea00b53a44f/dispatcher/backend/src/routes/schedules/schedule.py#L102-L104

However, this caused issues like #1131 because `c++` contains special characters which when injected is not a valid regex. Resorting to `re.escape` would invalidate the regex. This did not surface in the v2 API because I switched to `ilike` with `%` before and after the name.

In light of #1188 , I have decided to remove the leading `%` for the search. This means matching is done in an exact fashion for the first few characters in `name`. This avoids cases like #1131  and also allows #1188 to work as expected.

## Changes
- remove leading `%` in `ilike` expression, allowing for exact matches at the beginning of the query