### PR TITLE
update offliner spec if create fails with unique constraint

### DIFF
--- a/backend/src/zimfarm_backend/routes/offliners/logic.py
+++ b/backend/src/zimfarm_backend/routes/offliners/logic.py
@@ -26,7 +26,9 @@ from zimfarm_backend.db.offliner_definition import (
 from zimfarm_backend.routes.dependencies import gen_dbsession
 from zimfarm_backend.routes.http_errors import UnauthorizedError
 from zimfarm_backend.routes.models import ListResponse
-from zimfarm_backend.routes.offliners.models import OfflinerDefinitionCreateSchema
+from zimfarm_backend.routes.offliners.models import (
+    OfflinerDefinitionCreateSchema,
+)
 
 router = APIRouter(prefix="/offliners", tags=["offliners"])
 

--- a/backend/tests/db/test_offliner_definition.py
+++ b/backend/tests/db/test_offliner_definition.py
@@ -9,10 +9,7 @@ from zimfarm_backend.common import getnow
 from zimfarm_backend.common.enums import DockerImageName
 from zimfarm_backend.common.schemas.offliners.models import OfflinerSpecSchema
 from zimfarm_backend.common.schemas.orms import OfflinerDefinitionSchema, OfflinerSchema
-from zimfarm_backend.db.exceptions import (
-    RecordAlreadyExistsError,
-    RecordDoesNotExistError,
-)
+from zimfarm_backend.db.exceptions import RecordDoesNotExistError
 from zimfarm_backend.db.offliner_definition import (
     create_offliner_definition,
     get_offliner_definition,
@@ -72,7 +69,7 @@ def test_create_offliner_definition_with_duplicate_version(
     mwoffliner_definition: OfflinerDefinitionSchema,  # noqa: ARG001 (needed for side effect)
     mwoffliner: OfflinerSchema,
 ):
-    with pytest.raises(RecordAlreadyExistsError):
+    with does_not_raise():
         create_offliner_definition(
             dbsession, mwoffliner_flags, mwoffliner.id, version="initial"
         )

--- a/backend/tests/routes/test_auth.py
+++ b/backend/tests/routes/test_auth.py
@@ -106,7 +106,9 @@ def test_refresh_access_token_expired_token(
             [],
         ),
         (
-            getnow().isoformat(),
+            # Before CI fully sets up, default timer has expired, so, add
+            # additional 5 minutes
+            (getnow() + datetime.timedelta(minutes=5)).isoformat(),
             HTTPStatus.OK,
             ["access_token", "token_type", "expires_time"],
         ),


### PR DESCRIPTION
## Changes
- Adapt create_offliner_definition endpoint to update the spec if insertion fails due to unique constraint violation. This allows overwriting the `dev` versions of scrapers by CI workflow
