### PR TITLE
define model for task files

### DIFF
--- a/backend/src/zimfarm_backend/common/external.py
+++ b/backend/src/zimfarm_backend/common/external.py
@@ -26,7 +26,11 @@ from zimfarm_backend.common.constants import (
     WASABI_WHITELIST_STATEMENT_ID,
     WHITELISTED_IPS,
 )
-from zimfarm_backend.common.schemas.orms import TaskFullSchema
+from zimfarm_backend.common.schemas.orms import (
+    CMSStatusSchema,
+    TaskFileSchema,
+    TaskFullSchema,
+)
 from zimfarm_backend.db import dbsession
 from zimfarm_backend.db.tasks import get_task_by_id
 
@@ -184,20 +188,20 @@ def advertise_book_to_cms(task: TaskFullSchema, file_name: str):
     file_data = task.files[file_name]
 
     # skip if already advertised to CMS
-    if file_data.get("cms"):
+    if file_data.cms:
         # cms query already succeeded
-        if file_data["cms"].get("succeeded"):
+        if file_data.cms.succeeded:
             return
 
     # prepare payload and submit request to CMS
     download_prefix = f"{CMS_ZIM_DOWNLOAD_URL}{task.config.warehouse_path}"
-    file_data["cms"] = {
-        "status_code": -1,
-        "succeeded": False,
-        "on": getnow(),
-        "book_id": None,
-        "title_ident": None,
-    }
+    file_data.cms = CMSStatusSchema(
+        status_code=-1,
+        succeeded=False,
+        on=getnow(),
+        book_id=None,
+        title_ident=None,
+    )
     try:
         resp = requests.post(
             CMS_ENDPOINT,
@@ -209,20 +213,20 @@ def advertise_book_to_cms(task: TaskFullSchema, file_name: str):
         logger.exception(exc)
     else:
         status_code = HTTPStatus(resp.status_code)
-        file_data["cms"]["status_code"] = status_code.value
-        file_data["cms"]["succeeded"] = status_code == HTTPStatus.CREATED
+        file_data.cms.status_code = status_code.value
+        file_data.cms.succeeded = status_code == HTTPStatus.CREATED
         if status_code.is_success:
             try:
                 data = resp.json()
-                file_data["cms"]["book_id"] = data.get("uuid")
-                file_data["cms"]["title_ident"] = data.get("title")
+                file_data.cms.book_id = data.get("uuid")
+                file_data.cms.title_ident = data.get("title")
             except Exception as exc:
                 logger.error(f"Unable to parse CMS response: {exc}")
                 logger.exception(exc)
         else:
             logger.error(
                 f"CMS returned an error {resp.status_code} for book"
-                f"{file_data['info']['id']}"
+                f"{file_data.info['id']}"
             )
 
     # record request result
@@ -230,17 +234,17 @@ def advertise_book_to_cms(task: TaskFullSchema, file_name: str):
 
 
 def get_openzimcms_payload(
-    file: dict[str, typing.Any], download_prefix: str
+    file: TaskFileSchema, download_prefix: str
 ) -> dict[str, typing.Any]:
     payload = {
-        "id": file["info"]["id"],
-        "period": file["info"].get("metadata", {}).get("Date"),
-        "counter": file["info"].get("counter"),
-        "article_count": file["info"].get("article_count"),
-        "media_count": file["info"].get("media_count"),
-        "size": file["info"].get("size"),
-        "metadata": file["info"].get("metadata"),
-        "url": f"{download_prefix}/{file['name']}",
-        "zimcheck": file.get("check_details", {}),
+        "id": file.info["id"],
+        "period": file.info.get("metadata", {}).get("Date"),
+        "counter": file.info.get("counter"),
+        "article_count": file.info.get("article_count"),
+        "media_count": file.info.get("media_count"),
+        "size": file.info.get("size"),
+        "metadata": file.info.get("metadata"),
+        "url": f"{download_prefix}/{file.name}",
+        "zimcheck": file.check_details or {},
     }
     return payload

--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -82,6 +82,34 @@ class TaskLightSchema(BaseTaskSchema):
     config: ConfigWithOnlyResourcesSchema
 
 
+class CMSStatusSchema(BaseModel):
+    status_code: int | None = None
+    succeeded: bool | None = None
+    on: datetime.datetime | None = None
+    book_id: UUID | None = None
+    title_ident: str | None = None
+
+
+class TaskFileSchema(BaseModel):
+    """
+    Schema for reading the files associated with a task
+    """
+
+    name: str
+    size: int | None = None
+    status: str
+    cms: CMSStatusSchema | None = None
+    created_timestamp: datetime.datetime | None = None
+    uploaded_timestamp: datetime.datetime | None = None
+    failed_timestamp: datetime.datetime | None = None
+    check_timestamp: datetime.datetime | None = None
+
+    check_result: int | None = None
+    check_log: str | None = None
+    check_details: dict[str, Any] | None = None
+    info: dict[str, Any] = Field(default_factory=dict)
+
+
 class TaskFullSchema(BaseTaskSchema):
     """
     Schema for reading a task model with all fields
@@ -94,7 +122,7 @@ class TaskFullSchema(BaseTaskSchema):
     container: dict[str, Any]
     priority: int
     notification: ScheduleNotificationSchema | None
-    files: dict[str, Any]
+    files: dict[str, TaskFileSchema]
     upload: dict[str, Any]
     offliner_definition_id: UUID = Field(exclude=True)
     offliner: str

--- a/backend/src/zimfarm_backend/db/tasks.py
+++ b/backend/src/zimfarm_backend/db/tasks.py
@@ -19,6 +19,7 @@ from zimfarm_backend.common.schemas.orms import (
     OfflinerDefinitionSchema,
     RequestedTaskFullSchema,
     RunningTask,
+    TaskFileSchema,
     TaskFullSchema,
     TaskLightSchema,
 )
@@ -111,7 +112,10 @@ def get_task_by_id_or_none(session: OrmSession, task_id: UUID) -> TaskFullSchema
             container=row.container,
             priority=row.priority,
             notification=row.notification or None,
-            files=row.files,
+            files={
+                key: TaskFileSchema.model_validate(value)
+                for key, value in row.files.items()
+            },
             upload=row.upload,
             updated_at=row.updated_at,
             original_schedule_name=row.original_schedule_name,


### PR DESCRIPTION
## Rationale
The task `files` schema was a `dict[str, Any]`. This meant that deep within it, the `created_timestamp` and `uploaded_timestamp` which are serialized to datetime objects by the custom `zimfarm_loads` function are  not detected by the API datetime serializer https://github.com/openzim/zimfarm/blob/0b2638bad42a6a2038267f1d6af3a75b6564fd03/backend/src/zimfarm_backend/common/schemas/__init__.py#L8-L23

This further meant that when we want to compute the duration between when a file was created, it compares a `naive` datetime (without the `Z` suffix) to the `events` datetime which has the `Z` suffix. This leads to no data shown for `Created After` on the UI as the `end` time is greater than the `start` time. This is the cause of #1416 and is evident in other task details too

By building a model of the task files, Pydantic can detect that the field is a datetime object and serialize it accordingly. This means that on the UI, when the `formatBetween` function is called, both datetime strings are datetime-aware

## Changes
- define pydantic schema for Task files with defaults set to None as data in the DB may be null or not and we don't want validation errors

This fixes #1416 