### PR TITLE
remove route to get initial offliner definiton

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/offliners/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/offliners/logic.py
@@ -58,32 +58,6 @@ async def get_offliners(
     )
 
 
-@router.get("/{offliner_id}")
-async def get_initial_offliner_version(
-    offliner_id: Annotated[str, Path()],
-    session: Annotated[OrmSession, Depends(gen_dbsession)],
-) -> JSONResponse:
-    """Get a specific offliner"""
-
-    # find the schema class that matches the offliner
-    offliner = db_get_offliner(session, offliner_id)
-    offliner_definition = db_get_offliner_definition(
-        session, offliner_id=offliner_id, version="initial"
-    )
-    schema_cls = build_offliner_model(offliner, offliner_definition.schema_)
-
-    flags = schema_to_flags(schema_cls)
-
-    return JSONResponse(
-        content={
-            "flags": [flag.model_dump(mode="json", by_alias=True) for flag in flags],
-            "help": (  # dynamic + sourced from backend because it might be custom
-                f"https://github.com/openzim/{offliner}/wiki/Frequently-Asked-Questions"
-            ),
-        }
-    )
-
-
 @router.post("")
 async def create_offliner(
     request: OfflinerCreateSchema,

--- a/backend/src/zimfarm_backend/api/routes/schedules/models.py
+++ b/backend/src/zimfarm_backend/api/routes/schedules/models.py
@@ -41,7 +41,7 @@ class ScheduleCreateSchema(BaseModel):
     periodicity: SchedulePeriodicity
     tags: list[NotEmptyString] = Field(default_factory=list)
     enabled: bool
-    version: str = "initial"  # version of offliner to use for validation
+    version: NotEmptyString
     config: dict[str, Any]  # will be validated in the route
     notification: ScheduleNotificationSchema | None = None
     context: str | None = None

--- a/backend/tests/routes/test_schedules.py
+++ b/backend/tests/routes/test_schedules.py
@@ -168,6 +168,7 @@ def test_get_similar_schedules(
                 },
                 "enabled": True,
                 "periodicity": SchedulePeriodicity.manually.value,
+                "version": "initial",
             },
             HTTPStatus.UNPROCESSABLE_ENTITY,
             id="invalid-config-missing-offliner-id",
@@ -201,6 +202,7 @@ def test_get_similar_schedules(
                 },
                 "enabled": True,
                 "periodicity": SchedulePeriodicity.manually.value,
+                "version": "initial",
             },
             HTTPStatus.UNPROCESSABLE_ENTITY,
             id="invalid-config-extra-keys",
@@ -267,6 +269,7 @@ def test_get_similar_schedules(
                 "enabled": True,
                 "periodicity": SchedulePeriodicity.manually.value,
                 "context": "test",
+                "version": "initial",
             },
             HTTPStatus.OK,
             id="valid-config",
@@ -874,6 +877,7 @@ def test_create_duplicate_schedule(
             ),
             "enabled": True,
             "periodicity": SchedulePeriodicity.manually.value,
+            "version": "initial",
         },
     )
     assert response.status_code == HTTPStatus.CONFLICT


### PR DESCRIPTION
## Changes
- remove `GET /offliners/{offliner_id}` endpoint
- add route to create offliner via API

This closes #1391
