### PR TITLE
Do not validate anything in offliner configuration when asked for

### DIFF
--- a/backend/src/zimfarm_backend/db/offliner_definition.py
+++ b/backend/src/zimfarm_backend/db/offliner_definition.py
@@ -2,7 +2,7 @@ from copy import deepcopy
 from typing import Any
 from uuid import UUID
 
-from pydantic import BaseModel
+from pydantic import BaseModel, RootModel
 from sqlalchemy import func, select, update
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session
@@ -67,12 +67,15 @@ def create_offliner_instance(
     skip_validation: bool = True,
 ) -> BaseModel:
     """Create the offliner instance from the offliner definition and data"""
-    if isinstance(offliner_definition, OfflinerDefinition):
-        offliner_definition = create_offliner_definition_schema(offliner_definition)
-    return build_offliner_model(
-        offliner,
-        offliner_definition.schema_,
-    ).model_validate(data, context={"skip_validation": skip_validation})
+    if skip_validation:
+        return RootModel[dict[str, Any]].model_validate(data)
+    else:
+        if isinstance(offliner_definition, OfflinerDefinition):
+            offliner_definition = create_offliner_definition_schema(offliner_definition)
+        return build_offliner_model(
+            offliner,
+            offliner_definition.schema_,
+        ).model_validate(data, context={"skip_validation": False})
 
 
 def get_offliner_definition_or_none(

--- a/backend/src/zimfarm_backend/routes/schedules/logic.py
+++ b/backend/src/zimfarm_backend/routes/schedules/logic.py
@@ -381,7 +381,9 @@ def update_schedule(
     if (
         request.offliner
         and request.offliner
-        != schedule_config.offliner.offliner_id  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+        != schedule_config.offliner.root[  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+            "offliner_id"
+        ]
     ):
         # Case 1: Attempting to change the offliner
         if not request.flags:
@@ -443,7 +445,9 @@ def update_schedule(
             session,
             cast(
                 str,
-                schedule_config.offliner.offliner_id,  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+                schedule_config.offliner.root[  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+                    "offliner_id"
+                ],
             ),
         )
         if request.version:

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -895,6 +895,7 @@ def create_schedule(
         tags: list[str] | None = None,
         context: str | None = None,
         schedule_config: ScheduleConfigSchema | None = None,
+        raw_schedule_config: dict[str, Any] | None = None,
         worker: Worker | None = None,
         archived: bool = False,
     ) -> Schedule:
@@ -906,8 +907,12 @@ def create_schedule(
             name=name,
             tags=tags or ["nopic"],
             category=category,
-            config=schedule_config.model_dump(
-                mode="json", context={"show_secrets": True}
+            config=(
+                raw_schedule_config
+                if raw_schedule_config
+                else schedule_config.model_dump(
+                    mode="json", context={"show_secrets": True}
+                )
             ),
             enabled=True,
             language_code=language.code,


### PR DESCRIPTION
When we `skip_validation` in `create_offliner_instance`, we need to mostly completely by-pass pydantic validation logic because we can end-up with a very old / odd offliner config which is not aligned with current offliner definition. We should not mind about this since the goal is to display / return config "as it was".