### PR TITLE
allow extra fields while reading db

### DIFF
--- a/backend/src/zimfarm_backend/common/constants.py
+++ b/backend/src/zimfarm_backend/common/constants.py
@@ -100,8 +100,8 @@ SLACK_USERNAME = getenv("SLACK_USERNAME")
 SLACK_EMOJI = getenv("SLACK_EMOJI")
 SLACK_ICON = getenv("SLACK_ICON")
 
-# string to replace hidden secrets with
-SECRET_REPLACEMENT = "--------"  # nosec
+# length of secret strings
+SECRET_STRING_LENGTH = int(getenv("SECRET_STRING_LENGTH", default=24))
 
 # ###
 # workers whitelist management

--- a/backend/src/zimfarm_backend/common/schemas/fields.py
+++ b/backend/src/zimfarm_backend/common/schemas/fields.py
@@ -16,6 +16,7 @@ from pydantic import (
 )
 from pydantic_core.core_schema import SerializationInfo
 
+from zimfarm_backend.common.constants import SECRET_STRING_LENGTH
 from zimfarm_backend.common.enums import Platform, WarehousePath
 
 
@@ -116,13 +117,15 @@ ZIMMetadataString = Annotated[
 ]
 
 
-def show_secrets(value: Any, handler: Any, info: SerializationInfo) -> Any:
+def show_secrets(value: Any, _: Any, info: SerializationInfo) -> Any:
     """Show secret values in serialization"""
     context = info.context
+    value = value if isinstance(value, SecretStr) else SecretStr(value)
     if context and context.get("show_secrets"):
-        if isinstance(value, SecretStr):
-            return value.get_secret_value()
-    return handler(value, info)
+        value = value.get_secret_value()
+    else:
+        value = "*" * SECRET_STRING_LENGTH
+    return value
 
 
 def skip_validation(

--- a/backend/src/zimfarm_backend/common/schemas/offliners/builder.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/builder.py
@@ -5,6 +5,7 @@ from itertools import chain
 from typing import Annotated, Any, Literal, Optional, cast
 
 from pydantic import (
+    ConfigDict,
     EmailStr,
     Field,
     WrapValidator,
@@ -203,6 +204,8 @@ def generate_similarity_data(
 def build_offliner_model(
     offliner: OfflinerSchema,
     schema: OfflinerSpecSchema,
+    *,
+    extra: Literal["allow", "ignore", "forbid"] = "allow",
 ):
     fields: dict[str, Annotated[Any, Any]] = {}
     for flag_name, flag_schema in schema.flags.items():
@@ -229,5 +232,6 @@ def build_offliner_model(
         offliner_id=(Literal[offliner.id], Field(alias="offliner_id")),
         __base__=get_base_model_cls(offliner.base_model),
         __validators__={**field_validators, **model_validators},
+        __config__=ConfigDict(extra=extra),
         **fields,
     )

--- a/backend/src/zimfarm_backend/db/offliner_definition.py
+++ b/backend/src/zimfarm_backend/db/offliner_definition.py
@@ -1,5 +1,5 @@
 from copy import deepcopy
-from typing import Any
+from typing import Any, Literal
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -65,14 +65,16 @@ def create_offliner_instance(
     offliner_definition: OfflinerDefinitionSchema | OfflinerDefinition,
     data: dict[str, Any],
     skip_validation: bool = True,
+    extra: Literal["allow", "ignore", "forbid"] = "allow",
 ) -> BaseModel:
     """Create the offliner instance from the offliner definition and data"""
     if isinstance(offliner_definition, OfflinerDefinition):
         offliner_definition = create_offliner_definition_schema(offliner_definition)
-    return build_offliner_model(
-        offliner,
-        offliner_definition.schema_,
-    ).model_validate(data, context={"skip_validation": skip_validation})
+    model = build_offliner_model(offliner, offliner_definition.schema_, extra=extra)
+    if skip_validation:
+        return model.model_construct(**data)
+    else:
+        return model.model_validate(data, context={"skip_validation": skip_validation})
 
 
 def get_offliner_definition_or_none(
@@ -207,6 +209,7 @@ def update_offliner_flags(
         offliner_definition=offliner_definition,
         data=new_data,
         skip_validation=True,
+        extra="allow",
     ).model_dump(mode="json")
 
 

--- a/backend/src/zimfarm_backend/routes/schedules/logic.py
+++ b/backend/src/zimfarm_backend/routes/schedules/logic.py
@@ -156,6 +156,7 @@ def create_schedule(
                 offliner_definition=offliner_definition,
                 data=request.config["offliner"],
                 skip_validation=False,
+                extra="ignore",
             ),
         }
     )
@@ -418,6 +419,7 @@ def update_schedule(
                     offliner_definition=offliner_definition,
                     data={**request.flags, "offliner_id": request.offliner},
                     skip_validation=False,
+                    extra="ignore",
                 ),
             }
         )
@@ -471,6 +473,7 @@ def update_schedule(
                     offliner_definition=offliner_definition,
                     data={**request.flags, "offliner_id": offliner_definition.offliner},
                     skip_validation=False,
+                    extra="ignore",
                 ),
             }
         )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -895,6 +895,7 @@ def create_schedule(
         tags: list[str] | None = None,
         context: str | None = None,
         schedule_config: ScheduleConfigSchema | None = None,
+        raw_schedule_config: dict[str, Any] | None = None,
         worker: Worker | None = None,
         archived: bool = False,
     ) -> Schedule:
@@ -906,8 +907,12 @@ def create_schedule(
             name=name,
             tags=tags or ["nopic"],
             category=category,
-            config=schedule_config.model_dump(
-                mode="json", context={"show_secrets": True}
+            config=(
+                raw_schedule_config
+                if raw_schedule_config
+                else schedule_config.model_dump(
+                    mode="json", context={"show_secrets": True}
+                )
             ),
             enabled=True,
             language_code=language.code,


### PR DESCRIPTION
## Rationale
Previously, offliner models had a default of `ignore` (default Pydantic extra settings). This leads to very old tasks that do not meet the definition to fail because they do not contain the newer fields which are required. By hooking into the `create_offliner_instance` model and setting a default of `allow`, we allow extra fields by default since most actions are read operations. However, `extra` is set to `ignore` when creating/updating schedules since this is the source of truth for tasks/requested tasks.

## Changes
- override ConfigDict in `create_offliner_instance` with default of `allow`
- `ignore` extra fields while creating/updating schedules
- use `model_construct` to skip validation entirely. This means, we need to further customize how secrets are shown because they can be raw strings or `SecretStr`

This closes #1430 
