### PR TITLE
default to reserved timestamp for canceled tasks

### DIFF
--- a/frontend-ui/src/components/PipelineTable.vue
+++ b/frontend-ui/src/components/PipelineTable.vue
@@ -129,7 +129,11 @@
         <template #[`item.duration`]="{ item }">
           {{
             formatDurationBetween(
-              getTimestampStringForStatus(item.timestamp, 'started'),
+              getTimestampStringForStatus(
+                item.timestamp,
+                'started',
+                getTimestampStringForStatus(item.timestamp, 'reserved'),
+              ),
               item.updated_at,
             )
           }}


### PR DESCRIPTION
## Rationale
When canceled tasks are shown on the pipeline failed table, they are shown with 700 months duration because the `getTimestampStringForStatus` fetches the `started` timestamp and subtracts it from `updated_at` to get the duration. However, since some of these tasks haven't started, their default timestamp shown by the UI is the unix epoch. By falling back to the `reserved` which gets set immediately a task has been created, we have a reasonable default for such tasks that have been canceled https://github.com/openzim/zimfarm/blob/61d22c801f0a26a505c738db6750f0040234bb56/backend/src/zimfarm_backend/routes/tasks/logic.py#L133-L143

This fixes #1428 

## Changes
- default to `reserved` timestamp while getting timestamp string for failed tasks as some of them never even started.