### PR TITLE
redefine permissions to access resource

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -408,3 +408,62 @@ class OfflinerSchema(BaseModel):
     docker_image_name: DockerImageName
     command_name: str
     ci_secret_hash: str | None = Field(exclude=True)
+
+
+class BaseUserSchema(BaseModel):
+    """
+    Base schema for reading a user model
+    """
+
+    username: str
+
+
+class UserSchema(BaseUserSchema):
+    """
+    Schema for reading a user model
+    """
+
+    email: str | None
+    role: str | None
+    scope: dict[str, Any] | None = Field(default=None)
+
+
+class BaseSshKeySchema(BaseModel):
+    """
+    Base schema for reading a ssh key model
+    """
+
+    key: str
+    name: str
+    type: str
+
+
+class SshKeyRead(BaseSshKeySchema):
+    """
+    Schema for reading a ssh key model
+    """
+
+    added: datetime.datetime
+    fingerprint: str
+
+
+class BaseUserWithSshKeysSchema(BaseUserSchema, BaseSshKeySchema):
+    """
+    Base schema for reading a user model with its ssh keys
+    """
+
+
+class SshKeyList(BaseModel):
+    """
+    Schema for reading a list of ssh keys
+    """
+
+    ssh_keys: list[SshKeyRead]
+
+
+class UserSchemaWithSshKeys(UserSchema):
+    """
+    Schema for reading a user model with its ssh keys
+    """
+
+    ssh_keys: list[SshKeyRead]

--- a/backend/src/zimfarm_backend/db/user.py
+++ b/backend/src/zimfarm_backend/db/user.py
@@ -8,6 +8,7 @@ from sqlalchemy.orm import selectinload
 
 from zimfarm_backend.common.roles import ROLES, RoleEnum
 from zimfarm_backend.common.schemas import BaseModel
+from zimfarm_backend.common.schemas.orms import UserSchema
 from zimfarm_backend.db.exceptions import (
     RecordAlreadyExistsError,
     RecordDoesNotExistError,
@@ -90,6 +91,15 @@ def update_user_password(
 class UserList(BaseModel):
     nb_records: int
     users: list[User]
+
+
+def create_user_schema(user: User) -> UserSchema:
+    return UserSchema(
+        username=user.username,
+        email=user.email,
+        role=user.role,
+        scope=ROLES.get(user.role, user.scope),
+    )
 
 
 def get_users(

--- a/backend/src/zimfarm_backend/routes/offliners/logic.py
+++ b/backend/src/zimfarm_backend/routes/offliners/logic.py
@@ -6,7 +6,6 @@ from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session as OrmSession
 from werkzeug.security import check_password_hash, generate_password_hash
 
-from zimfarm_backend.common.roles import RoleEnum
 from zimfarm_backend.common.schemas.fields import (
     LimitFieldMax200,
     SkipField,
@@ -29,6 +28,7 @@ from zimfarm_backend.db.offliner_definition import (
 from zimfarm_backend.db.offliner_definition import (
     get_offliner_versions as db_get_offliner_versions,
 )
+from zimfarm_backend.db.user import check_user_permission
 from zimfarm_backend.routes.dependencies import gen_dbsession, get_current_user
 from zimfarm_backend.routes.http_errors import UnauthorizedError
 from zimfarm_backend.routes.models import ListResponse
@@ -90,9 +90,7 @@ async def create_offliner(
     current_user: User = Depends(get_current_user),
 ) -> Response:
     """Create an offliner"""
-    # register new offliners? Because existing permissions overlap and it might not be
-    # feasible for someone who can create a schedule to create an offliner.
-    if current_user.role != RoleEnum.ADMIN:
+    if not check_user_permission(current_user, namespace="offliners", name="create"):
         raise UnauthorizedError("You do not have permissions to create an offliner.")
 
     db_create_offliner(

--- a/backend/src/zimfarm_backend/routes/schedules/logic.py
+++ b/backend/src/zimfarm_backend/routes/schedules/logic.py
@@ -213,7 +213,7 @@ def get_schedules_backup(
     """Get a list of schedules"""
     if not (
         current_user
-        and check_user_permission(current_user, namespace="schedules", name="update")
+        and check_user_permission(current_user, namespace="schedules", name="secrets")
     ):
         exclude_notifications = True
     else:
@@ -223,7 +223,7 @@ def get_schedules_backup(
     # does not matter
     if not (
         current_user
-        and check_user_permission(current_user, namespace="schedules", name="update")
+        and check_user_permission(current_user, namespace="schedules", name="secrets")
     ):
         show_secrets = False
     else:
@@ -251,7 +251,7 @@ def restore_archived_schedules(
 ) -> Response:
     if not (
         current_user
-        and check_user_permission(current_user, namespace="schedules", name="update")
+        and check_user_permission(current_user, namespace="schedules", name="archive")
     ):
         raise UnauthorizedError("You are not allowed to restore schedules")
 
@@ -292,13 +292,13 @@ def get_schedule(
 
     if not (
         current_user
-        and check_user_permission(current_user, namespace="schedules", name="update")
+        and check_user_permission(current_user, namespace="schedules", name="secrets")
     ):
         schedule.notification = None
 
     if not (
         current_user
-        and check_user_permission(current_user, namespace="schedules", name="update")
+        and check_user_permission(current_user, namespace="schedules", name="secrets")
     ):
         show_secrets = False
     else:
@@ -708,7 +708,7 @@ def archive_schedule(
     """Archive a schedule"""
     if not (
         current_user
-        and check_user_permission(current_user, namespace="schedules", name="delete")
+        and check_user_permission(current_user, namespace="schedules", name="archive")
     ):
         raise UnauthorizedError("You are not allowed to archive a schedule")
 
@@ -735,7 +735,7 @@ def restore_archived_schedule(
     """Restore an archived schedule"""
     if not (
         current_user
-        and check_user_permission(current_user, namespace="schedules", name="delete")
+        and check_user_permission(current_user, namespace="schedules", name="archive")
     ):
         raise UnauthorizedError("You are not allowed to restore a schedule")
 
@@ -780,7 +780,7 @@ def get_schedule_history(
     skip: Annotated[SkipField, Query()] = 0,
     limit: Annotated[LimitFieldMax200, Query()] = 200,
 ) -> ListResponse[ScheduleHistorySchema]:
-    if not check_user_permission(current_user, namespace="schedules", name="update"):
+    if not check_user_permission(current_user, namespace="schedules", name="secrets"):
         raise UnauthorizedError("You are not allowed to view a schedule's history")
 
     schedule = db_get_schedule(session, schedule_name=schedule_name)
@@ -806,7 +806,7 @@ def get_schedule_history_entry(
     session: OrmSession = Depends(gen_dbsession),
     current_user: User = Depends(get_current_user),
 ) -> ScheduleHistorySchema:
-    if not check_user_permission(current_user, namespace="schedules", name="update"):
+    if not check_user_permission(current_user, namespace="schedules", name="secrets"):
         raise UnauthorizedError("You are not allowed to view a schedule's history")
 
     history_entry = db_get_schedule_history_entry(

--- a/backend/src/zimfarm_backend/routes/tasks/logic.py
+++ b/backend/src/zimfarm_backend/routes/tasks/logic.py
@@ -85,7 +85,7 @@ async def get_task(
     task = db_get_task(db_session, task_id)
     if not (
         current_user
-        and check_user_permission(current_user, namespace="tasks", name="create")
+        and check_user_permission(current_user, namespace="tasks", name="secrets")
     ):
         task.notification = None
         show_secrets = False

--- a/backend/src/zimfarm_backend/routes/users/models.py
+++ b/backend/src/zimfarm_backend/routes/users/models.py
@@ -1,70 +1,8 @@
-import datetime
-from typing import Any
-
-from pydantic import EmailStr, Field, computed_field, field_validator
+from pydantic import EmailStr, computed_field, field_validator
 
 from zimfarm_backend.common.roles import RoleEnum
 from zimfarm_backend.common.schemas import BaseModel
 from zimfarm_backend.common.schemas.fields import NotEmptyString
-
-
-class BaseUserSchema(BaseModel):
-    """
-    Base schema for reading a user model
-    """
-
-    username: str
-
-
-class UserSchema(BaseUserSchema):
-    """
-    Schema for reading a user model
-    """
-
-    email: str | None
-    role: str
-    scope: dict[str, Any] | None = Field(default=None)
-
-
-class BaseSshKeySchema(BaseModel):
-    """
-    Base schema for reading a ssh key model
-    """
-
-    key: str
-    name: str
-    type: str
-
-
-class SshKeyRead(BaseSshKeySchema):
-    """
-    Schema for reading a ssh key model
-    """
-
-    added: datetime.datetime
-    fingerprint: str
-
-
-class BaseUserWithSshKeysSchema(BaseUserSchema, BaseSshKeySchema):
-    """
-    Base schema for reading a user model with its ssh keys
-    """
-
-
-class SshKeyList(BaseModel):
-    """
-    Schema for reading a list of ssh keys
-    """
-
-    ssh_keys: list[SshKeyRead]
-
-
-class UserSchemaWithSshKeys(UserSchema):
-    """
-    Schema for reading a user model with its ssh keys
-    """
-
-    ssh_keys: list[SshKeyRead]
 
 
 class KeySchema(BaseModel):

--- a/backend/src/zimfarm_backend/routes/workers/logic.py
+++ b/backend/src/zimfarm_backend/routes/workers/logic.py
@@ -67,7 +67,7 @@ async def update_worker(
     """Update a worker."""
     worker = db_get_worker(session, worker_name=name)
 
-    if not (check_user_permission(current_user, namespace="users", name="update")):
+    if not (check_user_permission(current_user, namespace="workers", name="update")):
         raise UnauthorizedError("You are not allowed to access this resource")
 
     if worker.deleted:
@@ -103,6 +103,9 @@ async def check_in_worker(
     current_user: Annotated[User, Depends(get_current_user)],
 ) -> Response:
     """Check in a worker."""
+    if not check_user_permission(current_user, namespace="workers", name="create"):
+        raise UnauthorizedError("You are not allowed to check in a worker")
+
     worker = db_get_worker_or_none(session, worker_name=name)
 
     if worker is not None:

--- a/frontend-ui/src/components/RemoveRequestedTaskButton.vue
+++ b/frontend-ui/src/components/RemoveRequestedTaskButton.vue
@@ -63,7 +63,7 @@ const notificationStore = useNotificationStore()
 const isRemoving = ref(false)
 const showDialog = ref(false)
 
-const canUnRequestTasks = computed(() => authStore.hasPermission('tasks', 'unrequest'))
+const canUnRequestTasks = computed(() => authStore.hasPermission('requested_tasks', 'delete'))
 
 const showConfirmDialog = () => {
   showDialog.value = true

--- a/frontend-ui/src/components/ScheduleActionButton.vue
+++ b/frontend-ui/src/components/ScheduleActionButton.vue
@@ -184,8 +184,8 @@ const cleanedSelectedWorker = computed(() =>
 const requestedTaskId = computed(() => props.requestedTask?.id || null)
 
 // Permission computed properties
-const canRequestTasks = computed(() => authStore.hasPermission('tasks', 'request'))
-const canUnRequestTasks = computed(() => authStore.hasPermission('tasks', 'unrequest'))
+const canRequestTasks = computed(() => authStore.hasPermission('requested_tasks', 'create'))
+const canUnRequestTasks = computed(() => authStore.hasPermission('requested_tasks', 'delete'))
 const canCancelTasks = computed(() => authStore.hasPermission('tasks', 'cancel'))
 
 // Methods

--- a/frontend-ui/src/views/ArchivedSchedulesView.vue
+++ b/frontend-ui/src/views/ArchivedSchedulesView.vue
@@ -22,5 +22,5 @@ import { computed } from 'vue'
 const authStore = useAuthStore()
 
 // Computed properties
-const canRestore = computed(() => authStore.hasPermission('schedules', 'update'))
+const canRestore = computed(() => authStore.hasPermission('schedules', 'archive'))
 </script>

--- a/frontend-ui/src/views/PipelineView.vue
+++ b/frontend-ui/src/views/PipelineView.vue
@@ -125,7 +125,7 @@ const loadingStore = useLoadingStore()
 const scheduleStore = useScheduleStore()
 const notificationStore = useNotificationStore()
 
-const canUnRequestTasks = computed(() => authStore.hasPermission('tasks', 'unrequest'))
+const canUnRequestTasks = computed(() => authStore.hasPermission('requested_tasks', 'delete'))
 const canCancelTasks = computed(() => authStore.hasPermission('tasks', 'cancel'))
 
 const handleFilterChange = (newFilter: string) => {

--- a/frontend-ui/src/views/ScheduleDetailView.vue
+++ b/frontend-ui/src/views/ScheduleDetailView.vue
@@ -615,7 +615,7 @@
 
         <!-- Archive Tab -->
         <v-window-item value="archive">
-          <div v-if="canDeleteSchedules" class="pa-4">
+          <div v-if="canArchiveSchedules" class="pa-4">
             <ArchiveItem
               :name="scheduleName"
               :is-archived="schedule?.archived || false"
@@ -809,9 +809,10 @@ const totalDurationDict = computed(() => {
 })
 
 // Permission computed properties
-const canRequestTasks = computed(() => authStore.hasPermission('tasks', 'request'))
+const canRequestTasks = computed(() => authStore.hasPermission('requested_tasks', 'create'))
 const canUpdateSchedules = computed(() => authStore.hasPermission('schedules', 'update'))
 const canCreateSchedules = computed(() => authStore.hasPermission('schedules', 'create'))
+const canArchiveSchedules = computed(() => authStore.hasPermission('schedules', 'archive'))
 const canDeleteSchedules = computed(() => authStore.hasPermission('schedules', 'delete'))
 
 // History-related computed properties

--- a/frontend-ui/src/views/SchedulesView.vue
+++ b/frontend-ui/src/views/SchedulesView.vue
@@ -28,5 +28,5 @@ import { computed } from 'vue'
 const authStore = useAuthStore()
 
 // Computed properties
-const canRequestTasks = computed(() => authStore.hasPermission('tasks', 'request'))
+const canRequestTasks = computed(() => authStore.hasPermission('requested_tasks', 'create'))
 </script>

--- a/frontend-ui/src/views/TaskDetailView.vue
+++ b/frontend-ui/src/views/TaskDetailView.vue
@@ -609,7 +609,7 @@ const zimfarmArtifactsUrl = computed(() => (task.value ? artifactsUrl(task.value
 
 // Permission computed properties
 const canCancelTasks = computed(() => authStore.hasPermission('tasks', 'cancel'))
-const canCreateTasks = computed(() => authStore.hasPermission('tasks', 'create'))
+const canViewTaskSecrets = computed(() => authStore.hasPermission('tasks', 'secrets'))
 
 // Methods
 const createdAfter = (file: TaskFile, taskData: Task) => {
@@ -672,7 +672,7 @@ const scrollLogsToBottom = () => {
 
 const refreshData = async () => {
   loadingStore.startLoading('Fetching task...')
-  const response = await tasksStore.fetchTask(props.id, !canCreateTasks.value)
+  const response = await tasksStore.fetchTask(props.id, canViewTaskSecrets.value)
   if (response) {
     task.value = response
     // Use nextTick to ensure the DOM has updated before scrolling

--- a/frontend-ui/src/views/WorkerDetailView.vue
+++ b/frontend-ui/src/views/WorkerDetailView.vue
@@ -464,7 +464,7 @@ const editContexts = ref<Array<{ name: string; ip: string | null }>>([])
 // Confirmation dialog state
 const showConfirmDialog = ref(false)
 
-const canUpdateWorkers = computed(() => authStore.hasPermission('users', 'update'))
+const canUpdateWorkers = computed(() => authStore.hasPermission('workers', 'update'))
 
 const hasChanges = computed(() => {
   if (!worker.value) return false


### PR DESCRIPTION
## Rationale
Previous permissions overlapped e.g permission to check in worker verified if a user could create another user. By defining new permissions specifically for each resource, the permissions system is further fine-grained. It further lays the foundation for #1397 where we need specific permissions to be able to view a worker's secret details in the UI.

## Changes
- add new permissions to further distinguish resources access/update
- add permissions to reveal secrets
- redesign view for permissions list

<img width="1152" height="472" alt="Screenshot_20251023_035527" src="https://github.com/user-attachments/assets/a24660d2-da35-4cba-8ec3-59817bd202bb" />


This closes #1358 
This closes #1393 
