### PR TITLE
fix bug in schedule editor reset button

### DIFF
--- a/frontend-ui/src/components/ScheduleEditor.vue
+++ b/frontend-ui/src/components/ScheduleEditor.vue
@@ -10,7 +10,7 @@
         Update Offliner details
       </v-btn>
       <v-btn
-        type="reset"
+        type="button"
         :disabled="!hasChanges"
         :color="hasChanges ? 'dark' : 'secondary'"
         variant="outlined"
@@ -473,7 +473,7 @@
         Update Offliner details
       </v-btn>
       <v-btn
-        type="reset"
+        type="button"
         :disabled="!hasChanges"
         :color="hasChanges ? 'dark' : 'secondary'"
         variant="outlined"
@@ -1219,6 +1219,7 @@ const handleSubmit = async () => {
 const handleReset = () => {
   if (props.schedule) {
     editSchedule.value = JSON.parse(JSON.stringify(props.schedule))
+    editFlags.value = JSON.parse(JSON.stringify(props.schedule.config.offliner))
     // reset the flags and fields
     handleOfflinerVersionChange(props.schedule.config.offliner.offliner_id, props.schedule.version)
   }


### PR DESCRIPTION
## Rationale
The reset button contains a button of type `reset` which [resets](https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/input/reset) the form's values in an undesirable way as it clears everything. Also, previously, while handling reset, offliner flags were not reset to original before checking if there was a version change. That call cached the http request and didn't update the flag definitions. This meant that if the version didn't change, the edited flags were still in place instead of being reverted

## Changes
- change reset button type from `reset` to `button`
- reset schedule edit flags to original flags while handling reset