### PR TITLE
fix typos in healthcheck publish job

### DIFF
--- a/.github/workflows/Publish.yml
+++ b/.github/workflows/Publish.yml
@@ -26,7 +26,7 @@ jobs:
       watcher: ${{ steps.filter.outputs.watcher }}
       task_worker: ${{ steps.filter.outputs.task_worker }}
       worker_manager: ${{ steps.filter.outputs.worker_manager }}
-      healtcheck: ${{ steps.filter.outputs.healthcheck }}
+      healthcheck: ${{ steps.filter.outputs.healthcheck }}
 
     steps:
       - uses: actions/checkout@v5
@@ -297,7 +297,7 @@ jobs:
           image-name: openzim/zimfarm-healthcheck
           on-master: latest
           restrict-to: openzim/zimfarm
-          context: healtcheck
+          context: healthcheck
           registries: ghcr.io
           credentials: GHCRIO_USERNAME=${{ secrets.GHCR_USERNAME }}
             GHCRIO_TOKEN=${{ secrets.GHCR_TOKEN }}

--- a/healthcheck/README.md
+++ b/healthcheck/README.md
@@ -4,7 +4,7 @@ This service monitors the status of Zimfarm services and components and displays
 
 ### Environment variables
 
-- ZIMFARM_API_URL: Zimfarm backend API URL
-- ZIMFARM_USERNAME: Username to authenticate with on Zimfarm
-- ZIMFARM_PASSWORD: Password of user to authenticate with on Zimfarm
-- ZIMFARM_DATABASE_URL: Zimfarm database connection URL, including the driver, user credentials, host and port e.g `postgresql+psycopg://zimfarm:zimpass@postgresdb:5432/zimfarm`
+- ZIMFARM_API_URL: Zimfarm backend API URL.
+- ZIMFARM_USERNAME: Username to authenticate with on Zimfarm.
+- ZIMFARM_PASSWORD: Password of user to authenticate with on Zimfarm.
+- ZIMFARM_DATABASE_URL: Zimfarm database connection URL, including the driver, user credentials, host and port e.g `postgresql+psycopg://zimfarm:zimpass@postgresdb:5432/zimfarm`.


### PR DESCRIPTION
## Changes
- rename `healtcheck` to `healthcheck` in CI job to publish Docker builds

This fixes #1462
