### PR TITLE
support http for S3 uploads

### DIFF
--- a/uploader/Dockerfile
+++ b/uploader/Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.13-slim-bookworm
 LABEL zimfarm=true
-LABEL org.opencontainers.image.source https://github.com/openzim/zimfarm
+LABEL org.opencontainers.image.source=https://github.com/openzim/zimfarm
 
 RUN apt-get update -y && \
     apt-get install -y --no-install-recommends ssh && \
@@ -13,9 +13,9 @@ COPY openzim_uploader/__init__.py /usr/local/bin/uploader
 RUN chmod +x /usr/local/bin/uploader
 RUN touch /usr/share/marker
 
-ENV HOST_KNOW_FILE /etc/ssh/known_hosts
-ENV MARKER_FILE /usr/share/marker
-ENV SCP_BIN_PATH /usr/bin/scp
-ENV SFTP_BIN_PATH /usr/bin/sftp
+ENV HOST_KNOW_FILE=/etc/ssh/known_hosts
+ENV MARKER_FILE=/usr/share/marker
+ENV SCP_BIN_PATH=/usr/bin/scp
+ENV SFTP_BIN_PATH=/usr/bin/sftp
 
 CMD ["uploader"]

--- a/uploader/setup.py
+++ b/uploader/setup.py
@@ -16,7 +16,7 @@ def read(*names, **kwargs):
 
 setup(
     name="openzim_uploader",
-    version="1.2",
+    version="1.3",
     summary="SCP/SFTP helper for openZIM uploads to our dropbox",
     description="SCP/SFTP helper for openZIM uploads to our dropbox",
     long_description=read("README.md"),


### PR DESCRIPTION
## Rationale
The uploader uploads items to S3 using only HTTPS. This proves undesirable especially while testing locally with another object store like Minio and you don't want to set up HTTPS. This PR aims to address this challenge by providing two additional ways of specifying the HTTP scheme to be used with S3: `s3+http` and `s3+https`. Default of `s3` is HTTPS for backwards compatibility.

## Changes
- Define S3 urls with http scheme