### PR TITLE
use artifacts expiration globs during task creation

### DIFF
--- a/backend/src/zimfarm_backend/db/tasks.py
+++ b/backend/src/zimfarm_backend/db/tasks.py
@@ -83,6 +83,7 @@ def get_task_by_id_or_none(session: OrmSession, task_id: UUID) -> TaskFullSchema
                 {
                     "warehouse_path": row.config["warehouse_path"],
                     "resources": row.config["resources"],
+                    "platform": row.config.get("platform"),
                     "offliner": create_offliner_instance(
                         offliner=get_offliner(session, row.offliner),
                         offliner_definition=OfflinerDefinitionSchema(
@@ -102,6 +103,7 @@ def get_task_by_id_or_none(session: OrmSession, task_id: UUID) -> TaskFullSchema
                     "mount_point": row.config["mount_point"],
                     "command": row.config["command"],
                     "str_command": row.config["str_command"],
+                    "artifacts_globs": row.config.get("artifacts_globs", []),
                 },
                 context={"skip_validation": True},
             ),

--- a/backend/src/zimfarm_backend/routes/tasks/logic.py
+++ b/backend/src/zimfarm_backend/routes/tasks/logic.py
@@ -103,7 +103,6 @@ async def get_task(
         offliner_definition=offliner_definition,
         show_secrets=show_secrets,
     )
-
     return JSONResponse(
         content=task.model_dump(mode="json", context={"show_secrets": show_secrets})
     )


### PR DESCRIPTION
## Rationale
Previously, the artifacts globs were ignored while creating tasks. This meant that no artifacts would ever be created because the list was always empty. By using the same artifacts globs when the requested task was created, we ensure the globs goes through the task worker

## Changes
- use artifacts globs during task creation

This fixes #1035
