### PR TITLE
retry requests on specific exceptions

### DIFF
--- a/worker/src/zimfarm_worker/common/constants.py
+++ b/worker/src/zimfarm_worker/common/constants.py
@@ -191,3 +191,9 @@ DOCKER_API_RETRIES = int(getenv("DOCKER_API_RETRIES", default=5))
 DOCKER_API_RETRY_SECONDS = humanfriendly.parse_timespan(
     getenv("DOCKER_API_RETRY_DURATION", default="5s")
 )
+
+# number of times to retry a call to the webapi
+REQUEST_RETRIES = int(getenv("REQUEST_RETRIES", default=5))
+REQUEST_RETRY_SECONDS = humanfriendly.parse_timespan(
+    getenv("REQUEST_RETRY_DURATION", default="3s")
+)


### PR DESCRIPTION
## Rationale

In #1307, for some unknown reasons, the requests from the worker to the API throws errors either due to file size being too large or bad gateway. While the former can be configured at the nginx level, the latter is difficult to troubleshoot. Given the errors are transient, the PR applies a retry mechanism for requests to the backend.

## Changes
- retry requests to the API on specific exceptions
