### PR TITLE
make role and scope mutually exclusive

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -425,7 +425,7 @@ class UserSchema(BaseUserSchema):
 
     email: str | None
     role: str | None
-    scope: dict[str, Any] | None = Field(default=None)
+    scope: dict[str, dict[str, bool]]
 
 
 class BaseSshKeySchema(BaseModel):

--- a/backend/src/zimfarm_backend/routes/users/logic.py
+++ b/backend/src/zimfarm_backend/routes/users/logic.py
@@ -146,7 +146,11 @@ def update_user(
             raise UnauthorizedError("You are not allowed to access this resource")
 
     db_update_user(
-        db_session, user_id=user.id, email=user_schema.email, role=user_schema.role
+        db_session,
+        user_id=user.id,
+        email=user_schema.email,
+        role=user_schema.role,
+        scope=user_schema.scope,
     )
     return Response(status_code=HTTPStatus.NO_CONTENT)
 

--- a/backend/src/zimfarm_backend/routes/users/models.py
+++ b/backend/src/zimfarm_backend/routes/users/models.py
@@ -1,4 +1,6 @@
-from pydantic import EmailStr, computed_field, field_validator
+from typing import Self
+
+from pydantic import EmailStr, computed_field, field_validator, model_validator
 
 from zimfarm_backend.common.roles import RoleEnum
 from zimfarm_backend.common.schemas import BaseModel
@@ -54,3 +56,10 @@ class UserUpdateSchema(BaseModel):
 
     email: EmailStr | None = None
     role: RoleEnum | None = None
+    scope: dict[str, dict[str, bool]] | None = None
+
+    @model_validator(mode="after")
+    def check_exclusive_fields(self) -> Self:
+        if self.role is not None and self.scope is not None:
+            raise ValueError("Only one of role/scope must be set")
+        return self

--- a/frontend-ui/src/constants.ts
+++ b/frontend-ui/src/constants.ts
@@ -14,7 +14,15 @@ export default {
   NOTIFICATION_ERROR_DURATION: 8000, // 8 seconds for errors
   NOTIFICATION_SUCCESS_DURATION: 3000, // 3 seconds for success
   // User roles
-  ROLES: ['admin', 'editor', 'editor-requester', 'manager', 'processor', 'worker'] as const,
+  ROLES: [
+    'admin',
+    'editor',
+    'editor-requester',
+    'manager',
+    'processor',
+    'worker',
+    'custom',
+  ] as const,
   MEMORY_VALUES: [
     536870912, // 512MiB
     1073741824, // 1GiB

--- a/frontend-ui/src/stores/user.ts
+++ b/frontend-ui/src/stores/user.ts
@@ -114,10 +114,16 @@ export const useUserStore = defineStore('user', () => {
     }
   }
 
-  const updateUser = async (username: string, payload: { role?: string; email?: string }) => {
+  const updateUser = async (
+    username: string,
+    payload: { role?: string; email?: string; scope?: Record<string, Record<string, boolean>> },
+  ) => {
     const service = await authStore.getApiService('users')
     try {
-      await service.patch<{ role?: string; email?: string }, null>(`/${username}`, payload)
+      await service.patch<
+        { role?: string; email?: string; scope?: Record<string, Record<string, boolean>> },
+        null
+      >(`/${username}`, payload)
       errors.value = []
       return true
     } catch (error) {

--- a/frontend-ui/src/views/UserView.vue
+++ b/frontend-ui/src/views/UserView.vue
@@ -359,8 +359,12 @@ const changePassword = async (password: string) => {
   loadingStore.stopLoading()
 }
 
-const updateUser = async (payload: { role?: string; email?: string }) => {
-  if (!(payload.role || payload.email)) return
+const updateUser = async (payload: {
+  role?: string
+  email?: string
+  scope?: Record<string, Record<string, boolean>>
+}) => {
+  if (!(payload.role || payload.email || payload.scope)) return
 
   loadingStore.startLoading('updating user…')
   const success = await userStore.updateUser(props.username, payload)


### PR DESCRIPTION
## Rationale
This PR makes enhances the user roles by making sure that known roles have no scope at DB level while custom scopes contain specific scope. It also provides the UI with the capability of updating a specific user not just from a known role but fine-tuning their permissions for custom role.


## Changes
- update user role/scope from API/UI
- list all user permissions for a resource by merging their permissions with the one from the ADMIN role instead of returning the subset that they have
- set scope to `None` when assigning a pre-defined role
- set role to custom when assigning scope

Below is a screenshot listing all permissions for a user even when they don't have that permission set on their scope. This happens because of the merge functionality that merges a user's scope or the scope attached to their role to the admin scope which contains every permission. 

<img width="1623" height="655" alt="Screenshot_20251028_165314" src="https://github.com/user-attachments/assets/7626885d-c435-4848-aa78-424da69748e6" />


This fixes #1472 
This closes #1465
This closes #1471 
