### PR TITLE
allow setting contexts while creating schedules

### DIFF
--- a/backend/src/zimfarm_backend/routes/schedules/logic.py
+++ b/backend/src/zimfarm_backend/routes/schedules/logic.py
@@ -193,6 +193,7 @@ def create_schedule(
         notification=request.notification,
         periodicity=request.periodicity,
         comment=request.comment,
+        context=request.context.strip() if request.context else None,
     )
 
     return JSONResponse(

--- a/backend/src/zimfarm_backend/routes/schedules/models.py
+++ b/backend/src/zimfarm_backend/routes/schedules/models.py
@@ -44,7 +44,7 @@ class ScheduleCreateSchema(BaseModel):
     version: str = "initial"  # version of offliner to use for validation
     config: dict[str, Any]  # will be validated in the route
     notification: ScheduleNotificationSchema | None = None
-    context: NotEmptyString | None = None
+    context: str | None = None
     comment: str | None = None
 
 

--- a/backend/tests/db/test_schedule.py
+++ b/backend/tests/db/test_schedule.py
@@ -131,11 +131,13 @@ def test_create_schedule(
         notification=None,
         periodicity=SchedulePeriodicity.manually,
         offliner_definition=mwoffliner_definition,
+        context="test",
     )
 
     assert schedule.name == "test_schedule"
     assert schedule.category == ScheduleCategory.other
     assert schedule.language_code == "eng"
+    assert schedule.context == "test"
     assert schedule.config == schedule_config.model_dump(
         mode="json", context={"show_secrets": True}
     )


### PR DESCRIPTION
## Rationale
Fix bug where request context that is set while creating schedule is not used

## Changes
- add request context while calling db code to create schedule

This fixes #1477 
