### PR TITLE
add check for zimfarm frontend availability

### DIFF
--- a/healthcheck/README.md
+++ b/healthcheck/README.md
@@ -5,6 +5,7 @@ This service monitors the status of Zimfarm services and components and displays
 ### Environment variables
 
 - ZIMFARM_API_URL: Zimfarm backend API URL.
+- ZIMFARM_FRONTEND_URL: Zimfarm frontend UI URL.
 - ZIMFARM_USERNAME: Username to authenticate with on Zimfarm.
 - ZIMFARM_PASSWORD: Password of user to authenticate with on Zimfarm.
 - ZIMFARM_DATABASE_URL: Zimfarm database connection URL, including the driver, user credentials, host and port e.g `postgresql+psycopg://zimfarm:zimpass@postgresdb:5432/zimfarm`.

--- a/healthcheck/src/healthcheck/constants.py
+++ b/healthcheck/src/healthcheck/constants.py
@@ -23,6 +23,7 @@ DEBUG = parse_bool(getenv("DEBUG", default="false"))
 REQUESTS_TIMEOUT = parse_timespan(getenv("REQUESTS_TIMEOUT", default="1m"))
 
 ZIMFARM_API_URL = getenv("ZIMFARM_API_URL", mandatory=True)
+ZIMFARM_FRONTEND_URL = getenv("ZIMFARM_FRONTEND_URL", mandatory=True)
 ZIMFARM_USERNAME = getenv("ZIMFARM_USERNAME", mandatory=True)
 ZIMFARM_PASSWORD = getenv("ZIMFARM_PASSWORD", mandatory=True)
 ZIMFARM_DATABASE_URL = getenv("ZIMFARM_DATABASE_URL", mandatory=True)

--- a/healthcheck/src/healthcheck/router.py
+++ b/healthcheck/src/healthcheck/router.py
@@ -11,6 +11,7 @@ from healthcheck.status.auth import authenticate
 from healthcheck.status.database import (
     check_database_connection,
 )
+from healthcheck.status.frontend import check_frontend
 from healthcheck.status.workers import get_workers_status
 
 router = APIRouter(prefix="/healthcheck", tags=["healthcheck"])
@@ -38,9 +39,10 @@ for name, func in filters:
 
 @router.get("")
 async def healthcheck(request: Request) -> HTMLResponse:
-    auth_check, db_check, workers_check = await gather(
+    auth_check, db_check, frontend_check, workers_check = await gather(
         authenticate(),
         check_database_connection(),
+        check_frontend(),
         get_workers_status(),
     )
 
@@ -48,6 +50,7 @@ async def healthcheck(request: Request) -> HTMLResponse:
         [
             auth_check.success,
             db_check.success,
+            frontend_check.success,
             workers_check.success,
         ]
     )
@@ -59,6 +62,7 @@ async def healthcheck(request: Request) -> HTMLResponse:
             "global_status": global_status,
             "auth": auth_check,
             "database": db_check,
+            "frontend": frontend_check,
             "workers": workers_check,
         },
         status_code=HTTPStatus.OK if global_status else HTTPStatus.SERVICE_UNAVAILABLE,

--- a/healthcheck/src/healthcheck/status/__init__.py
+++ b/healthcheck/src/healthcheck/status/__init__.py
@@ -1,7 +1,25 @@
+import logging
 from http import HTTPStatus
 from typing import Generic, TypeVar
 
 from pydantic import BaseModel
+
+from healthcheck.constants import DEBUG
+
+# This is a special logger for status checks. It accepts the custom `checkname`.
+# The field is set via extra whenever called to populate the log record.
+# As per the docs, if any custom fields are omitted, the message will not
+# be logged because a string formatting exception will occur.
+status_logger = logging.getLogger("healthcheck.status")
+# prevent propagation to the root logger
+status_logger.propagate = False
+status_logger.setLevel(logging.DEBUG if DEBUG else logging.INFO)
+handler = logging.StreamHandler()
+handler.setFormatter(
+    logging.Formatter("[%(asctime)s: %(levelname)s : %(checkname)s] %(message)s")
+)
+status_logger.addHandler(handler)
+
 
 T = TypeVar("T")
 

--- a/healthcheck/src/healthcheck/status/auth.py
+++ b/healthcheck/src/healthcheck/status/auth.py
@@ -3,8 +3,8 @@ import datetime
 from pydantic import BaseModel
 
 from healthcheck.constants import ZIMFARM_API_URL, ZIMFARM_PASSWORD, ZIMFARM_USERNAME
-from healthcheck.requests import query_api
 from healthcheck.status import Result
+from healthcheck.status.requests import query_api
 
 
 class Token(BaseModel):
@@ -22,6 +22,7 @@ async def authenticate() -> Result[Token]:
         f"{ZIMFARM_API_URL}/auth/authorize",
         method="POST",
         payload={"username": ZIMFARM_USERNAME, "password": ZIMFARM_PASSWORD},
+        check_name="zimfarm-api-authentication",
     )
     return Result(
         success=response.success,

--- a/healthcheck/src/healthcheck/status/frontend.py
+++ b/healthcheck/src/healthcheck/status/frontend.py
@@ -1,0 +1,137 @@
+import re
+from http import HTTPStatus
+
+import aiohttp
+from pydantic import BaseModel
+
+from healthcheck.constants import REQUESTS_TIMEOUT, ZIMFARM_FRONTEND_URL
+from healthcheck.status import Result
+from healthcheck.status import status_logger as logger
+
+
+class FrontendInfo(BaseModel):
+    """Information about the frontend availability."""
+
+    url: str
+    status: str
+    has_valid_title: bool
+
+
+async def check_frontend() -> Result[FrontendInfo]:
+    """Check if the Zimfarm frontend is accessible and working correctly.
+
+    Checks:
+    - No SSL issues (valid certificate)
+    - HTTP status code is 200
+    - Content is an HTML document
+    - HTML document title is "Zimfarm"
+    """
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                ZIMFARM_FRONTEND_URL,
+                timeout=aiohttp.ClientTimeout(total=REQUESTS_TIMEOUT),
+            ) as resp:
+                # Check status code
+                if resp.status != HTTPStatus.OK:
+                    logger.warning(
+                        f"Frontend returned status code {resp.status} instead of 200",
+                        extra={"checkname": "zimfarm-frontend-status"},
+                    )
+                    return Result(
+                        success=False,
+                        status_code=HTTPStatus(resp.status),
+                        data=FrontendInfo(
+                            url=ZIMFARM_FRONTEND_URL,
+                            status=f"HTTP {resp.status}",
+                            has_valid_title=False,
+                        ),
+                    )
+
+                content_type = resp.headers.get("Content-Type", "")
+                if "text/html" not in content_type.lower():
+                    logger.warning(
+                        f"Frontend returned Content-Type '{content_type}' "
+                        "instead of text/html",
+                        extra={"checkname": "zimfarm-frontend-status"},
+                    )
+                    return Result(
+                        success=False,
+                        status_code=HTTPStatus.OK,
+                        data=FrontendInfo(
+                            url=ZIMFARM_FRONTEND_URL,
+                            status="Not HTML content",
+                            has_valid_title=False,
+                        ),
+                    )
+
+                text = await resp.text()
+                title_match = re.search(r"<title>Zimfarm</title>", text)
+
+                if not title_match:
+                    logger.warning(
+                        "Frontend HTML does not contain expected title",
+                        extra={"checkname": "zimfarm-frontend-status"},
+                    )
+                    return Result(
+                        success=False,
+                        status_code=HTTPStatus.OK,
+                        data=FrontendInfo(
+                            url=ZIMFARM_FRONTEND_URL,
+                            status="Invalid title",
+                            has_valid_title=False,
+                        ),
+                    )
+
+                return Result(
+                    success=True,
+                    status_code=HTTPStatus.OK,
+                    data=FrontendInfo(
+                        url=ZIMFARM_FRONTEND_URL,
+                        status="online",
+                        has_valid_title=True,
+                    ),
+                )
+
+    except aiohttp.ClientSSLError as e:
+        logger.exception(
+            "SSL error when connecting to frontend",
+            extra={"checkname": "zimfarm-frontend-status"},
+        )
+        return Result(
+            success=False,
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+            data=FrontendInfo(
+                url=ZIMFARM_FRONTEND_URL,
+                status=f"SSL error: {e!s}",
+                has_valid_title=False,
+            ),
+        )
+    except aiohttp.ClientError as e:
+        logger.exception(
+            "Client error when connecting to frontend",
+            extra={"checkname": "zimfarm-frontend-status"},
+        )
+        return Result(
+            success=False,
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+            data=FrontendInfo(
+                url=ZIMFARM_FRONTEND_URL,
+                status=f"Connection error: {e!s}",
+                has_valid_title=False,
+            ),
+        )
+    except Exception:
+        logger.exception(
+            "Unexpected error when checking frontend",
+            extra={"checkname": "zimfarm-frontend-status"},
+        )
+        return Result(
+            success=False,
+            status_code=HTTPStatus.SERVICE_UNAVAILABLE,
+            data=FrontendInfo(
+                url=ZIMFARM_FRONTEND_URL,
+                status="offline",
+                has_valid_title=False,
+            ),
+        )

--- a/healthcheck/src/healthcheck/templates/healthcheck.html
+++ b/healthcheck/src/healthcheck/templates/healthcheck.html
@@ -122,6 +122,13 @@
             </td>
           </tr>
           <tr>
+            <th>Frontend</th>
+            <td>Can request Zimfarm UI homepage</td>
+            <td class="text-right {{ frontend.success|status_class }}">
+              {{ frontend.success|status_text }}
+            </td>
+          </tr>
+          <tr>
             <th>Workers</th>
             <td>At least one worker is currently connected and online</td>
             <td class="text-right {{ workers.success|status_class }}">


### PR DESCRIPTION
## Rationale
This PR adds checks to see if the zimfarm frontend is available. 
<img width="1781" height="555" alt="Screenshot_20251030_115709" src="https://github.com/user-attachments/assets/88f50141-2a23-48a1-b81d-d0f1ee62df16" />


## Changes
- define seperate logger with custom formatter and pass names of checks to logging messages
- add check to fetch zimfarm homepage and examine if it's title string matches `Zimfarm`

This closes #1473
This closes #1470 