### PR TITLE
redirect home page to healthcheck

### DIFF
--- a/healthcheck/src/healthcheck/main.py
+++ b/healthcheck/src/healthcheck/main.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from fastapi import APIRouter, FastAPI
+from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
 from healthcheck.router import router
@@ -9,7 +10,7 @@ from healthcheck.router import router
 def create_app(*, debug: bool = True):
     app = FastAPI(
         debug=debug,
-        docs_url="/",
+        docs_url="/docs",
         title="Zimfarm Healthcheck Service",
         version="1.0.0",
         description=(
@@ -21,6 +22,11 @@ def create_app(*, debug: bool = True):
     main_router.include_router(router=router)
 
     app.include_router(router=main_router)
+
+    # Redirect root path to healthcheck
+    @app.get("/", include_in_schema=False)
+    async def root():  # pyright: ignore[reportUnusedFunction]
+        return RedirectResponse(url="/healthcheck")
 
     # Serve package static files at /static (if present)
     static_dir = Path(__file__).parent / "static"

--- a/healthcheck/src/healthcheck/router.py
+++ b/healthcheck/src/healthcheck/router.py
@@ -36,7 +36,7 @@ for name, func in filters:
     templates.env.filters[name] = func  # type: ignore
 
 
-@router.get("/")
+@router.get("")
 async def healthcheck(request: Request) -> HTMLResponse:
     auth_check, db_check, workers_check = await gather(
         authenticate(),


### PR DESCRIPTION
## Changes
- redirect home page access to `/healthcheck` endpont
- remove trailing slash (`/`) in healthcheck endpoint

This closes #1469
