### PR TITLE
prevent overrriding cancel_requested events

### DIFF
--- a/worker/src/zimfarm_worker/manager/worker.py
+++ b/worker/src/zimfarm_worker/manager/worker.py
@@ -265,11 +265,16 @@ class WorkerManager(BaseWorker):
                 continue  # already handling cancellation
 
             self.update_task_data(task_ident)
-            if self.tasks.get(task_ident, {}).get("status") in [
-                CANCELED,
-                CANCELING,
-                CANCEL_REQUESTED,
-            ]:
+            logger.debug(f"Checking if task {task_ident} should be cancelled...")
+            event_codes = {
+                event["code"]
+                for event in self.tasks.get(task_ident, {}).get("events", [])
+            }
+            cancel_events = {CANCEL_REQUESTED, CANCELED}
+            if (
+                self.tasks.get(task_ident, {}).get("status") in cancel_events
+                or event_codes & cancel_events
+            ):
                 self.cancel_and_remove_task(task_ident)
 
     def cancel_and_remove_task(self, task_ident: TaskIdent):


### PR DESCRIPTION
## Rationale
Currently, task events can be overriden by other task events. While most updates happen in defined manner once started by a worer, it is problematic if an already picked up task is requested for cancellation because the worker will continue with the task as if things were normal. By returning to the worker, the status of the task each time they make a patch, it serves as a form of communication to let the worker know that the update went according to what they expected. For now, we simply check if the status is not cancel_requested because that's one not sent by the worker and the point of conflict. 

## Changes
- return status of tasks after `PATCH` request
- exit gracefully from task worker if after patching, status is cancel_requested.

This closes #937
