### PR TITLE
enhance masking of task secrets

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -110,6 +110,55 @@ class TaskFileSchema(BaseModel):
     info: dict[str, Any] = Field(default_factory=dict)
 
 
+class TaskContainerProgressSchema(BaseModel):
+    partial_zim: bool | None = None
+    overall: int | None = None
+    done: int | None = None
+
+
+class TaskContainerMemoryStatsSchema(BaseModel):
+    max_usage: int | None = None
+
+
+class TaskContainerStatsSchema(BaseModel):
+    memory: TaskContainerMemoryStatsSchema = Field(
+        default_factory=TaskContainerMemoryStatsSchema
+    )
+
+
+class TaskContainerSchema(BaseModel):
+    """
+    Schema for reading the container information of a task
+    """
+
+    log: str | None = None
+    image: str | None = None
+    stats: dict[str, Any] | None = None
+    artifacts: str | None = None
+    stderr: str | None = None
+    stdout: str | None = None
+    command: list[str] = Field(default_factory=list)
+    progress: TaskContainerProgressSchema | None = Field(
+        default_factory=TaskContainerProgressSchema
+    )
+    exit_code: int | None = None
+
+
+class TaskUploadConfigSchema(BaseModel):
+    expiration: int | None = None
+    upload_uri: str | None = None
+
+
+class ZimUploadConfigSchema(TaskUploadConfigSchema):
+    zimcheck: str | None = None
+
+
+class TaskUploadSchema(BaseModel):
+    zim: ZimUploadConfigSchema | None = None
+    logs: TaskUploadConfigSchema | None = None
+    artifacts: TaskUploadConfigSchema | None = None
+
+
 class TaskFullSchema(BaseTaskSchema):
     """
     Schema for reading a task model with all fields
@@ -119,11 +168,11 @@ class TaskFullSchema(BaseTaskSchema):
     events: list[dict[str, str | datetime.datetime]]
     debug: dict[str, Any]
     canceled_by: str | None
-    container: dict[str, Any]
+    container: TaskContainerSchema = Field(default_factory=TaskContainerSchema)
     priority: int
     notification: ScheduleNotificationSchema | None
     files: dict[str, TaskFileSchema]
-    upload: dict[str, Any]
+    upload: TaskUploadSchema
     offliner_definition_id: UUID = Field(exclude=True)
     offliner: str
     version: str
@@ -163,7 +212,7 @@ class RequestedTaskFullSchema(BaseRequestedTaskSchema):
 
     config: ExpandedScheduleConfigSchema
     events: list[dict[str, str | datetime.datetime]]
-    upload: dict[str, Any]
+    upload: TaskUploadSchema
     notification: ScheduleNotificationSchema | None
     rank: int | None = None
     schedule_id: UUID | None = Field(exclude=True)

--- a/backend/src/zimfarm_backend/common/upload.py
+++ b/backend/src/zimfarm_backend/common/upload.py
@@ -1,0 +1,73 @@
+import pathlib
+import urllib.parse
+
+from zimfarm_backend import logger
+from zimfarm_backend.common.constants import SECRET_STRING_LENGTH
+from zimfarm_backend.common.schemas.orms import RequestedTaskFullSchema, TaskFullSchema
+
+
+def rebuild_uri(uri: urllib.parse.ParseResult, query: str | None = None):
+    scheme = uri.scheme
+    username = uri.username
+    password = uri.password
+    hostname = uri.hostname or ""
+    port = uri.port
+    path = uri.path
+    netloc = ""
+    if username:
+        netloc += username
+    if password:
+        netloc += f":{password}"
+    if username or password:
+        netloc += "@"
+    netloc += hostname
+    if port:
+        netloc += f":{port}"
+    query = query or uri.query
+    fragment = uri.fragment
+    return urllib.parse.urlparse(
+        urllib.parse.urlunparse([scheme, netloc, path, fragment, query, fragment])
+    )
+
+
+def safe_upload_uri(
+    upload_uri: str, *, keys: list[str], show_secrets: bool = True
+) -> str:
+    """Get a new URI by hiding/showing values of keys in query parameters"""
+    try:
+        uri = urllib.parse.urlparse(upload_uri)
+        pathlib.Path(uri.path)
+    except Exception as exc:
+        logger.exception(f"invalid upload URI: `{upload_uri}` ({exc}).")
+        return upload_uri
+
+    params = urllib.parse.parse_qs(uri.query)
+    param_keys = params.keys()
+    for key in keys:
+        if key in param_keys and not show_secrets:
+            params[key] = [SECRET_STRING_LENGTH * "*"]
+
+    return urllib.parse.unquote(
+        rebuild_uri(uri, query=urllib.parse.urlencode(params, doseq=True)).geturl()
+    )
+
+
+def build_task_upload_uris(
+    task: TaskFullSchema | RequestedTaskFullSchema,
+    *,
+    keys: list[str],
+    show_secrets: bool = True,
+) -> TaskFullSchema | RequestedTaskFullSchema:
+    if task.upload.zim and task.upload.zim.upload_uri:
+        task.upload.zim.upload_uri = safe_upload_uri(
+            task.upload.zim.upload_uri, keys=keys, show_secrets=show_secrets
+        )
+    if task.upload.logs and task.upload.logs.upload_uri:
+        task.upload.logs.upload_uri = safe_upload_uri(
+            task.upload.logs.upload_uri, keys=keys, show_secrets=show_secrets
+        )
+    if task.upload.artifacts and task.upload.artifacts.upload_uri:
+        task.upload.artifacts.upload_uri = safe_upload_uri(
+            task.upload.artifacts.upload_uri, keys=keys, show_secrets=show_secrets
+        )
+    return task

--- a/backend/src/zimfarm_backend/db/requested_task.py
+++ b/backend/src/zimfarm_backend/db/requested_task.py
@@ -35,6 +35,7 @@ from zimfarm_backend.common.schemas.orms import (
     RequestedTaskFullSchema,
     RequestedTaskLightSchema,
     ScheduleDurationSchema,
+    TaskUploadSchema,
 )
 from zimfarm_backend.db import count_from_stmt
 from zimfarm_backend.db.exceptions import RecordDoesNotExistError
@@ -738,7 +739,7 @@ def create_requested_task_full_schema(
         worker_name=requested_task.worker.name if requested_task.worker else None,
         context=requested_task.context,
         events=requested_task.events,
-        upload=requested_task.upload,
+        upload=TaskUploadSchema.model_validate(requested_task.upload),
         notification=(
             ScheduleNotificationSchema.model_validate(requested_task.notification)
             if requested_task.notification

--- a/backend/src/zimfarm_backend/db/tasks.py
+++ b/backend/src/zimfarm_backend/db/tasks.py
@@ -19,9 +19,11 @@ from zimfarm_backend.common.schemas.orms import (
     OfflinerDefinitionSchema,
     RequestedTaskFullSchema,
     RunningTask,
+    TaskContainerSchema,
     TaskFileSchema,
     TaskFullSchema,
     TaskLightSchema,
+    TaskUploadSchema,
 )
 from zimfarm_backend.db.exceptions import (
     RecordAlreadyExistsError,
@@ -111,14 +113,14 @@ def get_task_by_id_or_none(session: OrmSession, task_id: UUID) -> TaskFullSchema
             debug=row.debug,
             requested_by=row.requested_by,
             canceled_by=row.canceled_by,
-            container=row.container,
+            container=TaskContainerSchema.model_validate(row.container),
             priority=row.priority,
             notification=row.notification or None,
             files={
                 key: TaskFileSchema.model_validate(value)
                 for key, value in row.files.items()
             },
-            upload=row.upload,
+            upload=TaskUploadSchema.model_validate(row.upload),
             updated_at=row.updated_at,
             original_schedule_name=row.original_schedule_name,
             schedule_name=row.schedule_name,
@@ -242,7 +244,7 @@ def create_task(
             else {}
         ),
         files={},
-        upload=requested_task.upload,
+        upload=requested_task.upload.model_dump(mode="json"),
         original_schedule_name=requested_task.original_schedule_name,
         context=requested_task.context,
     )

--- a/backend/src/zimfarm_backend/routes/requested_tasks/logic.py
+++ b/backend/src/zimfarm_backend/routes/requested_tasks/logic.py
@@ -27,6 +27,7 @@ from zimfarm_backend.common.schemas.orms import (
     RequestedTaskFullSchema,
     RequestedTaskLightSchema,
 )
+from zimfarm_backend.common.upload import build_task_upload_uris
 from zimfarm_backend.common.utils import task_event_handler
 from zimfarm_backend.db import gen_dbsession, gen_manual_dbsession
 from zimfarm_backend.db.models import User
@@ -313,6 +314,10 @@ def get_requested_task(
         show_secrets = False
     else:
         show_secrets = not hide_secrets
+
+    requested_task = build_task_upload_uris(
+        requested_task, keys=["secretAccessKey", "keyId"], show_secrets=show_secrets
+    )
 
     return JSONResponse(
         content=requested_task.model_dump(

--- a/backend/src/zimfarm_backend/routes/tasks/logic.py
+++ b/backend/src/zimfarm_backend/routes/tasks/logic.py
@@ -17,6 +17,7 @@ from zimfarm_backend.common.schemas.models import (
     calculate_pagination_metadata,
 )
 from zimfarm_backend.common.schemas.orms import TaskLightSchema
+from zimfarm_backend.common.upload import build_task_upload_uris
 from zimfarm_backend.common.utils import task_event_handler
 from zimfarm_backend.db.models import User
 from zimfarm_backend.db.offliner import get_offliner as db_get_offliner
@@ -102,6 +103,10 @@ async def get_task(
         offliner=offliner,
         offliner_definition=offliner_definition,
         show_secrets=show_secrets,
+    )
+    task.container.command = task.config.command
+    task = build_task_upload_uris(
+        task, keys=["secretAccessKey", "keyId"], show_secrets=show_secrets
     )
     return JSONResponse(
         content=task.model_dump(mode="json", context={"show_secrets": show_secrets})

--- a/backend/tests/test_upload.py
+++ b/backend/tests/test_upload.py
@@ -1,0 +1,290 @@
+# ruff: noqa: E501
+import urllib.parse
+from unittest.mock import MagicMock
+
+import pytest
+
+from zimfarm_backend.common.constants import SECRET_STRING_LENGTH
+from zimfarm_backend.common.upload import (
+    build_task_upload_uris,
+    rebuild_uri,
+    safe_upload_uri,
+)
+
+
+@pytest.mark.parametrize(
+    "uri_string,query,expected_url",
+    [
+        pytest.param(
+            "https://example.com/path",
+            None,
+            "https://example.com/path",
+            id="simple-uri-no-query",
+        ),
+        pytest.param(
+            "https://example.com/path?key=value",
+            None,
+            "https://example.com/path?key=value",
+            id="uri-with-existing-query",
+        ),
+        pytest.param(
+            "https://example.com/path",
+            "newkey=newvalue",
+            "https://example.com/path?newkey=newvalue",
+            id="uri-with-new-query",
+        ),
+        pytest.param(
+            "https://example.com/path?oldkey=oldvalue",
+            "newkey=newvalue",
+            "https://example.com/path?newkey=newvalue",
+            id="uri-replacing-query",
+        ),
+        pytest.param(
+            "https://user:pass@example.com/path",
+            None,
+            "https://user:pass@example.com/path",
+            id="uri-with-credentials",
+        ),
+        pytest.param(
+            "https://user@example.com/path",
+            None,
+            "https://user@example.com/path",
+            id="uri-with-username-only",
+        ),
+        pytest.param(
+            "https://example.com:8080/path",
+            None,
+            "https://example.com:8080/path",
+            id="uri-with-port",
+        ),
+        pytest.param(
+            "https://user:pass@example.com:8080/path?key=value",
+            "newkey=newvalue",
+            "https://user:pass@example.com:8080/path?newkey=newvalue",
+            id="uri-with-all-components",
+        ),
+        pytest.param(
+            "s3://bucket/path",
+            None,
+            "s3://bucket/path",
+            id="s3-uri",
+        ),
+        pytest.param(
+            "sftp://user@host/path",
+            None,
+            "sftp://user@host/path",
+            id="sftp-uri",
+        ),
+    ],
+)
+def test_rebuild_uri(uri_string: str, query: str | None, expected_url: str):
+    """Test rebuild_uri function with various URI configurations."""
+    uri = urllib.parse.urlparse(uri_string)
+    result = rebuild_uri(uri, query=query)
+    assert result.geturl() == expected_url
+
+
+@pytest.mark.parametrize(
+    "upload_uri,keys,show_secrets,expected",
+    [
+        pytest.param(
+            "https://example.com/path?apikey=secret123",
+            ["apikey"],
+            False,
+            f"https://example.com/path?apikey={'*' * SECRET_STRING_LENGTH}",
+            id="hide-single-secret",
+        ),
+        pytest.param(
+            "https://example.com/path?apikey=secret123",
+            ["apikey"],
+            True,
+            "https://example.com/path?apikey=secret123",
+            id="show-single-secret",
+        ),
+        pytest.param(
+            "https://example.com/path?apikey=secret123&token=mytoken",
+            ["apikey", "token"],
+            False,
+            f"https://example.com/path?apikey={'*' * SECRET_STRING_LENGTH}&token={'*' * SECRET_STRING_LENGTH}",
+            id="hide-multiple-secrets",
+        ),
+        pytest.param(
+            "https://example.com/path?apikey=secret123&token=mytoken",
+            ["apikey", "token"],
+            True,
+            "https://example.com/path?apikey=secret123&token=mytoken",
+            id="show-multiple-secrets",
+        ),
+        pytest.param(
+            "https://example.com/path?apikey=secret123&public=value",
+            ["apikey"],
+            False,
+            f"https://example.com/path?apikey={'*' * SECRET_STRING_LENGTH}&public=value",
+            id="hide-secret-keep-public",
+        ),
+        pytest.param(
+            "https://example.com/path?public=value",
+            ["apikey"],
+            False,
+            "https://example.com/path?public=value",
+            id="no-matching-secret-key",
+        ),
+        pytest.param(
+            "https://example.com/path",
+            ["apikey"],
+            False,
+            "https://example.com/path",
+            id="no-query-parameters",
+        ),
+        pytest.param(
+            "s3://bucket/path?key=secret&accesskey=mykey",
+            ["key", "accesskey"],
+            False,
+            f"s3://bucket/path?key={'*' * SECRET_STRING_LENGTH}&accesskey={'*' * SECRET_STRING_LENGTH}",
+            id="s3-uri-with-secrets",
+        ),
+        pytest.param(
+            "sftp://user@host/path?password=secret",
+            ["password"],
+            False,
+            f"sftp://user@host/path?password={'*' * SECRET_STRING_LENGTH}",
+            id="sftp-uri-with-password",
+        ),
+        pytest.param(
+            "https://example.com/path?key=value1&key=value2",
+            ["key"],
+            False,
+            f"https://example.com/path?key={'*' * SECRET_STRING_LENGTH}",
+            id="multiple-values-same-key",
+        ),
+    ],
+)
+def test_safe_upload_uri(
+    upload_uri: str, *, keys: list[str], show_secrets: bool, expected: str
+):
+    """Test safe_upload_uri function with various URIs and secret keys."""
+    result = safe_upload_uri(upload_uri, keys=keys, show_secrets=show_secrets)
+    assert result == expected
+
+
+@pytest.mark.parametrize(
+    "upload_uri,keys,show_secrets,expected",
+    [
+        pytest.param(
+            "invalid-uri-without-scheme",
+            ["apikey"],
+            False,
+            "invalid-uri-without-scheme",
+            id="invalid-uri-returns-original",
+        ),
+        pytest.param(
+            "https://[invalid-host]/path",
+            ["apikey"],
+            False,
+            "https://[invalid-host]/path",
+            id="invalid-host-returns-original",
+        ),
+    ],
+)
+def test_safe_upload_uri_with_invalid_input(
+    upload_uri: str, *, keys: list[str], show_secrets: bool, expected: str
+):
+    """Test safe_upload_uri function handles invalid URIs gracefully."""
+    result = safe_upload_uri(upload_uri, keys=keys, show_secrets=show_secrets)
+    assert result == expected
+
+
+def test_build_task_upload_uris_hide_secrets():
+    """Test build_task_upload_uris hides secrets in all upload URIs."""
+    task = MagicMock()
+    task.upload.zim.upload_uri = "sftp://uploader@example.com:22/zim?apikey=secret123"
+    task.upload.logs.upload_uri = (
+        "s3://s3.us-east-1.example.com/?token=mytoken&bucketName=zim-bucket"
+    )
+    task.upload.artifacts.upload_uri = (
+        "s3://s3.us-east-1.example.com/?token=mytoken&bucketName=artifacts-bucket"
+    )
+
+    keys = ["apikey", "token", "accesskey"]
+    result = build_task_upload_uris(task, keys=keys, show_secrets=False)
+
+    expected_mask = "*" * SECRET_STRING_LENGTH
+    assert (
+        result.upload.zim
+        and result.upload.zim.upload_uri
+        == f"sftp://uploader@example.com:22/zim?apikey={expected_mask}"
+    )
+    assert (
+        result.upload.logs
+        and result.upload.logs.upload_uri
+        == f"s3://s3.us-east-1.example.com/?token={expected_mask}&bucketName=zim-bucket"
+    )
+    assert (
+        result.upload.artifacts
+        and result.upload.artifacts.upload_uri
+        == f"s3://s3.us-east-1.example.com/?token={expected_mask}&bucketName=artifacts-bucket"
+    )
+
+
+def test_build_task_upload_uris_show_secrets():
+    """Test build_task_upload_uris shows secrets when requested."""
+    task = MagicMock()
+    task.upload.zim.upload_uri = "sftp://uploader@example.com:22/zim?apikey=secret123"
+    task.upload.logs.upload_uri = (
+        "s3://s3.us-east-1.example.com/?token=mytoken&bucketName=logs-bucket"
+    )
+    task.upload.artifacts.upload_uri = (
+        "s3://s3.us-east-1.example.com/?accesskey=mykey&bucketName=artifacts-bucket"
+    )
+
+    keys = ["apikey", "token", "accesskey"]
+    result = build_task_upload_uris(task, keys=keys, show_secrets=True)
+
+    # Check that secrets are visible
+    assert (
+        result.upload.zim
+        and result.upload.zim.upload_uri
+        == "sftp://uploader@example.com:22/zim?apikey=secret123"
+    )
+    assert (
+        result.upload.logs
+        and result.upload.logs.upload_uri
+        == "s3://s3.us-east-1.example.com/?token=mytoken&bucketName=logs-bucket"
+    )
+    assert (
+        result.upload.artifacts
+        and result.upload.artifacts.upload_uri
+        == "s3://s3.us-east-1.example.com/?accesskey=mykey&bucketName=artifacts-bucket"
+    )
+
+
+def test_build_task_upload_uris_no_secrets_in_uri():
+    """Test build_task_upload_uris with URIs that don't contain any secrets."""
+
+    task = MagicMock()
+    task.upload.zim.upload_uri = "sftp://uploader@example.com:22/zim"
+    task.upload.logs.upload_uri = (
+        "s3://s3.us-east-1.example.com/?bucketName=logs-bucket"
+    )
+    task.upload.artifacts.upload_uri = (
+        "s3://s3.us-east-1.example.com/?bucketName=artifacts-bucket"
+    )
+
+    keys = ["apikey", "token", "accesskey"]
+    result = build_task_upload_uris(task, keys=keys, show_secrets=False)
+
+    # URIs should remain unchanged
+    assert (
+        result.upload.zim
+        and result.upload.zim.upload_uri == "sftp://uploader@example.com:22/zim"
+    )
+    assert (
+        result.upload.logs
+        and result.upload.logs.upload_uri
+        == "s3://s3.us-east-1.example.com/?bucketName=logs-bucket"
+    )
+    assert (
+        result.upload.artifacts
+        and result.upload.artifacts.upload_uri
+        == "s3://s3.us-east-1.example.com/?bucketName=artifacts-bucket"
+    )

--- a/frontend-ui/src/utils/offliner.ts
+++ b/frontend-ui/src/utils/offliner.ts
@@ -277,9 +277,9 @@ function uploadUrl(uri: string, filename: string) {
   const scheme = url.protocol.replace(/:$/, '')
 
   if (['http', 'https'].indexOf(scheme) == -1)
-    url = new URL(url.href.replace(new RegExp('^' + url.protocol), 'https:'))
+    url = new URL(url.href.replace(url.protocol, 'https:'))
 
-  if (scheme == 's3') {
+  if (['s3', 's3+http', 's3+https'].includes(scheme)) {
     let log_url = url.protocol + '//' + url.host + url.pathname
     const bucketName = url.searchParams.get('bucketName')
     if (bucketName) log_url += bucketName + '/'

--- a/frontend-ui/src/views/TaskDetailView.vue
+++ b/frontend-ui/src/views/TaskDetailView.vue
@@ -672,7 +672,7 @@ const scrollLogsToBottom = () => {
 
 const refreshData = async () => {
   loadingStore.startLoading('Fetching task...')
-  const response = await tasksStore.fetchTask(props.id, canViewTaskSecrets.value)
+  const response = await tasksStore.fetchTask(props.id, !canViewTaskSecrets.value)
   if (response) {
     task.value = response
     // Use nextTick to ensure the DOM has updated before scrolling


### PR DESCRIPTION
## Rationale
The task container often contains the raw commands of the task since it is set by the task manager during a `PATCH` task. While returning  this data to clients, the command is shown as is. This is problematic as it does not mask the secrets. By defining models for the tasks container and upload data, we improve the information hiding since we know where they are set.

## Changes
- overwrite container command list with reconstructed command while fetching task
- hide secrets in upload uri's
- fix bug that makes frontend always send `hide_secrets=True`

This fixes #1487 
