### PR TITLE
measure task resources

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -113,14 +113,18 @@ class TaskContainerProgressSchema(BaseModel):
     total: int | None = None
 
 
-class TaskContainerMemoryStatsSchema(BaseModel):
-    max_usage: int | None = None
+class TaskResourceUsageSchema(BaseModel):
+    max_usage: int | float | None = Field(default=None, alias="max")
 
 
-class TaskContainerStatsSchema(BaseModel):
-    memory: TaskContainerMemoryStatsSchema = Field(
-        default_factory=TaskContainerMemoryStatsSchema
-    )
+class TaskCPUUsageSchema(TaskResourceUsageSchema):
+    avg_usage: float | None = Field(default=None, alias="avg")
+
+
+class TaskStatsSchema(BaseModel):
+    memory: TaskResourceUsageSchema = Field(default_factory=TaskResourceUsageSchema)
+    cpu: TaskCPUUsageSchema = Field(default_factory=TaskCPUUsageSchema)
+    disk: TaskResourceUsageSchema = Field(default_factory=TaskResourceUsageSchema)
 
 
 class TaskContainerSchema(BaseModel):
@@ -130,7 +134,7 @@ class TaskContainerSchema(BaseModel):
 
     log: str | None = None
     image: str | None = None
-    stats: dict[str, Any] | None = None
+    stats: TaskStatsSchema | None = None
     artifacts: str | None = None
     stderr: str | None = None
     stdout: str | None = None

--- a/frontend-ui/src/types/tasks.ts
+++ b/frontend-ui/src/types/tasks.ts
@@ -32,6 +32,15 @@ export interface TaskFile {
   info?: TaskFileInfo
 }
 
+export interface TaskResourceUsage {
+  max?: number | null
+}
+
+export interface TaskCPUUsage {
+  max?: number
+  avg?: number
+}
+
 export interface TaskContainer {
   command: string[]
   exit_code?: number
@@ -46,9 +55,9 @@ export interface TaskContainer {
     total: number
   } | null
   stats?: {
-    memory?: {
-      max_usage?: number | null
-    }
+    memory?: TaskResourceUsage
+    disk?: TaskResourceUsage
+    cpu?: TaskCPUUsage
   }
 }
 

--- a/frontend-ui/src/views/TaskDetailView.vue
+++ b/frontend-ui/src/views/TaskDetailView.vue
@@ -324,13 +324,55 @@
                       <code class="text-pink-accent-2">{{ taskContainer.exit_code }}</code>
                     </td>
                   </tr>
-                  <tr v-if="maxMemory != null">
+                  <tr v-if="hasStats">
                     <th class="text-left w-20">Stats</th>
                     <td>
-                      <v-chip size="small" class="mr-2">
-                        <v-icon size="small" class="mr-1">mdi-memory</v-icon>
-                        {{ maxMemory }} (max)
-                      </v-chip>
+                      <div class="d-flex flex-wrap ga-2">
+                        <v-tooltip
+                          v-if="maxMemory"
+                          text="Maximum memory used during task execution"
+                        >
+                          <template #activator="{ props }">
+                            <v-chip v-bind="props" size="small">
+                              <v-icon size="small" class="mr-1">mdi-memory</v-icon>
+                              {{ maxMemory }} (max)
+                            </v-chip>
+                          </template>
+                        </v-tooltip>
+                        <v-tooltip
+                          v-if="maxDisk"
+                          text="Maximum disk space used during task execution"
+                        >
+                          <template #activator="{ props }">
+                            <v-chip v-bind="props" size="small">
+                              <v-icon size="small" class="mr-1">mdi-harddisk</v-icon>
+                              {{ maxDisk }} (max)
+                            </v-chip>
+                          </template>
+                        </v-tooltip>
+                        <v-tooltip
+                          v-if="hasCpuStats && cpuStats && cpuStats.max !== null"
+                          text="Maximum CPU usage percentage during task execution"
+                        >
+                          <template #activator="{ props }">
+                            <v-chip v-bind="props" size="small">
+                              <v-icon size="small" class="mr-1">mdi-cpu-64-bit</v-icon>
+                              {{ cpuStats.max.toFixed(1) }}% (max)
+                            </v-chip>
+                          </template>
+                        </v-tooltip>
+                        <v-tooltip
+                          v-if="hasCpuStats && cpuStats && cpuStats.avg !== null"
+                          text="Average CPU usage percentage during task execution"
+                        >
+                          <template #activator="{ props }">
+                            <v-chip v-bind="props" size="small">
+                              <v-icon size="small" class="mr-1">mdi-chart-line</v-icon>
+                              {{ cpuStats.avg.toFixed(1) }}% (avg)
+                            </v-chip>
+                          </template>
+                        </v-tooltip>
+                      </div>
                     </td>
                   </tr>
                   <tr v-if="taskProgress">
@@ -578,10 +620,35 @@ const canCancel = computed(() => {
 
 const maxMemory = computed(() => {
   try {
-    return formattedBytesSize(taskContainer.value?.stats?.memory?.max_usage || 0)
+    return formattedBytesSize(taskContainer.value?.stats?.memory?.max || 0)
   } catch {
     return null
   }
+})
+
+const maxDisk = computed(() => {
+  try {
+    return formattedBytesSize(taskContainer.value?.stats?.disk?.max || 0)
+  } catch {
+    return null
+  }
+})
+
+const cpuStats = computed(() => {
+  const stats = taskContainer.value?.stats?.cpu
+  if (!stats) return null
+  return {
+    max: stats.max ?? null,
+    avg: stats.avg ?? null,
+  }
+})
+
+const hasCpuStats = computed(() => {
+  return cpuStats.value && (cpuStats.value.max !== null || cpuStats.value.avg !== null)
+})
+
+const hasStats = computed(() => {
+  return maxMemory.value || maxDisk.value || hasCpuStats.value
 })
 
 const monitoringUrl = computed(() => {


### PR DESCRIPTION
## Rationale
This PR adds support for measuring resources used by the scraper. For the CPU stats, it uses the [Exponentially Weighted Moving Average](https://corporatefinanceinstitute.com/resources/career-map/sell-side/capital-markets/exponentially-weighted-moving-average-ewma/) to measure the percentage of CPU usage, along with the maximum CPU percentage used.

Also, max disk usage is computed by adding the filesizes of the files in the scraper mount directory.
<img width="907" height="146" alt="Screenshot_20251114_133311" src="https://github.com/user-attachments/assets/959a58d7-2345-4623-98b5-12a1a56e074a" />
<img width="907" height="146" alt="Screenshot_20251114_133301" src="https://github.com/user-attachments/assets/de48227d-024b-4899-8320-4dcc99af2120" />

## Changes
- add functions  to compute CPU and Disk stats
- show stats in UI


This closes #1423 