### PR TITLE
parse resource values as binary multiples of bytes

### DIFF
--- a/worker/src/zimfarm_worker/common/constants.py
+++ b/worker/src/zimfarm_worker/common/constants.py
@@ -69,7 +69,7 @@ DOCKER_CLIENT_TIMEOUT = 180  # 3mn for read timeout on docker API socket
 
 # configuration
 ZIMFARM_DISK_SPACE = as_pos_int(
-    humanfriendly.parse_size(getenv("ZIMFARM_DISK", default=str(2**34)))
+    humanfriendly.parse_size(getenv("ZIMFARM_DISK", default=str(2**34)), binary=True)
 )
 
 PHYSICAL_CPU = multiprocessing.cpu_count()
@@ -92,7 +92,9 @@ ZIMFARM_TASK_CPUSET = zimfarm_task_cpuset
 
 PHYSICAL_MEMORY = psutil.virtual_memory().total
 ZIMFARM_MEMORY = as_pos_int(
-    humanfriendly.parse_size(getenv("ZIMFARM_MEMORY", default=str(PHYSICAL_MEMORY)))
+    humanfriendly.parse_size(
+        getenv("ZIMFARM_MEMORY", default=str(PHYSICAL_MEMORY)), binary=True
+    )
 )
 CORDONED = parse_bool(getenv("CORDONED", default="False"))
 


### PR DESCRIPTION
## Rationale
Worker resources are often parsed using `parse_size` function of the humanfriendly library. By default, these sizes are parsed in base 10 which might make a worker unable to execute a task. For example:
```py
from humanfriendly import parse_size
>>> parse_size('20Gb')
20000000000

>>> parse_size('20Gb', binary=True)
21474836480
```
This seems to be the cause of openzim/wp1#1027 where a worker has 20Gb but can't execute a task with 20Gb