### PR TITLE
capture exceptions in healthcheck requests

### DIFF
--- a/healthcheck/src/healthcheck/main.py
+++ b/healthcheck/src/healthcheck/main.py
@@ -4,6 +4,7 @@ from fastapi import APIRouter, FastAPI
 from fastapi.responses import RedirectResponse
 from fastapi.staticfiles import StaticFiles
 
+from healthcheck.constants import DEBUG
 from healthcheck.router import router
 
 
@@ -36,4 +37,4 @@ def create_app(*, debug: bool = True):
     return app
 
 
-app = create_app()
+app = create_app(debug=DEBUG)

--- a/healthcheck/src/healthcheck/status/requests.py
+++ b/healthcheck/src/healthcheck/status/requests.py
@@ -16,6 +16,7 @@ class Response:
     status_code: HTTPStatus
     success: bool
     json: dict[str, Any]
+    error: str | None = None
 
 
 async def query_api(
@@ -63,13 +64,18 @@ async def query_api(
                     success=resp.ok,
                     json=json_data,
                 )
-            except (JSONDecodeError, Exception):
+            except (JSONDecodeError, Exception) as exc:
                 logger.exception(
                     "unexpected error while decoding server response: "
                     f"{await resp.text()}",
                     extra={"checkname": check_name},
                 )
-                raise
+                return Response(
+                    status_code=HTTPStatus(resp.status),
+                    success=False,
+                    json={},
+                    error=str(exc),
+                )
             else:
                 if not response.success:
                     logger.warning(


### PR DESCRIPTION
## Rationale
This PR captures exceptions that typically arise from making HTTP calls and returns a `Response` object instead of re-raising the error. This way, the function is always guaranteed a `Response` no matter the error.

## Changes
- return `Response` object when exceptions occur in external HTTP requests
- use debug environment variable while` creating app instance

This fixes #1512 
