### PR TITLE
add endpoint to view an offliner spec

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/offliners/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/offliners/logic.py
@@ -22,6 +22,7 @@ from zimfarm_backend.common.schemas.models import (
 )
 from zimfarm_backend.common.schemas.offliners.builder import build_offliner_model
 from zimfarm_backend.common.schemas.offliners.serializer import schema_to_flags
+from zimfarm_backend.common.schemas.orms import OfflinerDefinitionSchema
 from zimfarm_backend.db.models import User
 from zimfarm_backend.db.offliner import create_offliner as db_create_offliner
 from zimfarm_backend.db.offliner import get_all_offliners
@@ -172,3 +173,12 @@ async def get_offliner(
             ),
         }
     )
+
+
+@router.get("/{offliner_id}/{version}/spec")
+async def get_offliner_spec(
+    offliner_id: Annotated[str, Path()],
+    version: Annotated[str, Path()],
+    session: Annotated[OrmSession, Depends(gen_dbsession)],
+) -> OfflinerDefinitionSchema:
+    return db_get_offliner_definition(session, offliner_id=offliner_id, version=version)

--- a/backend/tests/routes/test_offliners.py
+++ b/backend/tests/routes/test_offliners.py
@@ -111,3 +111,12 @@ def test_update_offliner_definition(
         },
     )
     assert response.status_code == expected_status_code
+
+
+def test_get_offliner_spec(
+    client: TestClient,
+    mwoffliner: OfflinerSchema,
+    mwoffliner_definition: OfflinerDefinitionSchema,  # noqa: ARG001
+):
+    response = client.get(f"/v2/offliners/{mwoffliner.id}/initial/spec")
+    assert response.status_code == HTTPStatus.OK


### PR DESCRIPTION
## Rationale
Services like zimit and WP1 often need to fetch the offliner specs from the scraper-specific repos. However, this can become problematic when the version they specify is out of sync (from the `create_offliners.sh` helper script). Even more is that they are constrained to at most one version because the scraper repo will only contain one version. By exposing an endpoint on zimfarm for them to get the spec for any particular version, they can test with any version of their choice.

## Changes
- add endpoint to retrieve offliner spec version
