### PR TITLE
create schedule history while using update_scraper_version script

### DIFF
--- a/backend/src/zimfarm_backend/db/offliner_definition.py
+++ b/backend/src/zimfarm_backend/db/offliner_definition.py
@@ -210,7 +210,7 @@ def update_offliner_flags(
         data=new_data,
         skip_validation=True,
         extra="allow",
-    ).model_dump(mode="json")
+    ).model_dump(mode="json", context={"show_secrets": True})
 
 
 def update_offliner_definition(

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       dockerfile: api.Dockerfile
     container_name: zf_backend
     volumes:
+      - ../backend/maint-scripts:/app/maint-scripts
       - ../backend/src/zimfarm_backend:/usr/local/lib/python3.13/site-packages/zimfarm_backend
     ports:
       - 127.0.0.1:8000:80


### PR DESCRIPTION
## Rationale
The `update_scraper_version` does not create schedule histories after updating a schedule image tag or offliner definition. By hooking into the existing `update_schedule` function, we can ensure that schedule histories will be created when update is made either via API or CLI script.

## Changes
- call db `update_schedule` from CLI script to update scraper versions
- seperate code to update schedule and requested task
- show secrets while dumping to database in update name mappings function

This fixes #1526