### PR TITLE
skip loading task files in save_event handler

### DIFF
--- a/backend/src/zimfarm_backend/common/external.py
+++ b/backend/src/zimfarm_backend/common/external.py
@@ -218,7 +218,7 @@ def advertise_book_to_cms(session: so.Session, task: TaskFullSchema, file_name: 
             )
 
     # record request result
-    task.files[file_name] = create_or_update_task_file(
+    create_or_update_task_file(
         session,
         FileCreateUpdateSchema(
             task_id=task.id,

--- a/backend/src/zimfarm_backend/common/utils.py
+++ b/backend/src/zimfarm_backend/common/utils.py
@@ -122,9 +122,7 @@ def save_event(
 ):
     """save event and its accompanying data to database"""
 
-    task = session.scalars(
-        select(Task).options(so.selectinload(Task.files)).where(Task.id == task_id)
-    ).one_or_none()
+    task = session.scalars(select(Task).where(Task.id == task_id)).one_or_none()
     if task is None:
         raise RecordDoesNotExistError(f"Task {task_id} does not exist")
     schedule = task.schedule

--- a/backend/src/zimfarm_backend/db/tasks.py
+++ b/backend/src/zimfarm_backend/db/tasks.py
@@ -367,7 +367,7 @@ def get_task_file(session: OrmSession, task_id: UUID, filename: str) -> TaskFile
 def create_or_update_task_file(
     session: OrmSession,
     request: FileCreateUpdateSchema,
-) -> TaskFileSchema:
+):
     """Create or update a task file using insert with on conflict update."""
     values = request.model_dump(exclude_unset=True)
     stmt = insert(File).values(**values)
@@ -376,4 +376,3 @@ def create_or_update_task_file(
         set_={**request.model_dump(exclude_unset=True, exclude={"task_id", "name"})},
     )
     session.execute(stmt)
-    return get_task_file(session, request.task_id, request.name)


### PR DESCRIPTION
## Rationale
In the events handler, the task is loaded along with its files. Also, the call to `create_or_update_file` fetches the updated files. These two scenarios happening concurrently could be the plausible cause of #1530 when file events come in rapidly. 

By skipping the option to load files along with a task and using postgresql's returning clause on `upsert`, we can mitigate this happening as we don't need to load the task files anymore.

## Changes
- avoid loading task files in `save_event` handlers
- use postgresql's returning statement to get the updated file

Will not link the issue to be closed by this PR until we can be sure it doesn't happen again.
