### PR TITLE
set nginx cache rules for files

### DIFF
--- a/frontend-ui/nginx-default.conf
+++ b/frontend-ui/nginx-default.conf
@@ -15,4 +15,21 @@ server {
     location @rewrites {
         rewrite ^(.+)$ /index.html last;
     }
+
+    location = /index.html {
+	add_header Cache-Control "no-cache";
+    }
+
+
+    location ~* \.json$ {
+	add_header Cache-Control "no-cache";
+    }
+
+    location ~* \.(js|css)$ {
+	add_header Cache-Control "public, max-age=2592000, immutable";
+    }
+
+    location ~* \.(png|jpg|jpeg|gif|webp|ico|svg)$ {
+	add_header Cache-Control "public, max-age=2592000";
+    }
 }


### PR DESCRIPTION
## Rationale
This PR sets up cache control headers for assets and resources served by nginx. 

## Changes
- add cache control headers for css/js/image files
- no cache for html and json files

This fixes #537
