### PR TITLE
avoid updating archived schedules from update_scraper_version script

### DIFF
--- a/backend/maint-scripts/update_scraper_version.py
+++ b/backend/maint-scripts/update_scraper_version.py
@@ -104,7 +104,8 @@ def update_schedules(
 
     for obj in session.execute(
         sa.select(Schedule).where(
-            Schedule.config["offliner"]["offliner_id"].astext == offliner.id
+            Schedule.config["offliner"]["offliner_id"].astext == offliner.id,
+            Schedule.archived.is_(False),
         )
     ).scalars():
         schedule = create_schedule_full_schema(obj, offliner)


### PR DESCRIPTION
## Rationale
By omitting archived schedules while selecting schedules to update via the `update_scraper_version` maintenance script, we avoid updating the image tags and offliner definition versions of archived schedules.


## Changes
- filter out archived schedules from query to select schedules to update

This fixes #1549
