### PR TITLE
show woker ip address to permitted users

### DIFF
--- a/backend/maint-scripts/monthly_report_tasks.py
+++ b/backend/maint-scripts/monthly_report_tasks.py
@@ -5,6 +5,7 @@ import csv
 import datetime
 import os
 from pathlib import Path
+from typing import Any
 
 import requests
 from dateutil.relativedelta import relativedelta
@@ -28,7 +29,11 @@ file_prefix = os.getenv("FILE_PREFIX", "zimfarm_tasks_")
 offliners = os.getenv("OFFLINERS", "zimit").split(",")
 
 
-def get_event_value(events, code, default=None):
+def get_event_value(
+    events: list[dict[str, str | datetime.datetime]],
+    code: str,
+    default: Any | None = None,
+):
     matching_events = [event for event in events if event["code"] == code]
     if matching_events:
         return matching_events[0]["timestamp"]

--- a/frontend-ui/src/components/WorkersTable.vue
+++ b/frontend-ui/src/components/WorkersTable.vue
@@ -82,6 +82,15 @@
               >
                 {{ item.status }}
               </v-chip>
+              <!-- IP discrepancy indicator -->
+              <v-tooltip v-if="item.ip_changed" location="bottom">
+                <template #activator="{ props }">
+                  <v-icon v-bind="props" size="small" color="warning" class="ml-1">
+                    mdi-alert-circle-outline
+                  </v-icon>
+                </template>
+                <span>IP discrepancy detected between worker IP and context IPs</span>
+              </v-tooltip>
               <!-- Local scheduling status -->
               <v-chip
                 v-if="item.cordoned"

--- a/frontend-ui/src/types/workers.ts
+++ b/frontend-ui/src/types/workers.ts
@@ -9,6 +9,8 @@ interface BaseWorker {
   cordoned: boolean
   admin_disabled: boolean
   contexts: Record<string, string | null>
+  last_ip?: string
+  ip_changed: boolean
 }
 
 export interface Worker extends BaseWorker {

--- a/frontend-ui/src/views/WorkerDetailView.vue
+++ b/frontend-ui/src/views/WorkerDetailView.vue
@@ -175,8 +175,29 @@
                     density="comfortable"
                     class="text-caption text-uppercase"
                   >
-                    {{ ctx }}
+                    <template v-if="canUpdateWorkers && ip"> {{ ctx }}: {{ ip }} </template>
+                    <template v-else>
+                      {{ ctx }}
+                    </template>
                   </v-chip>
+                </div>
+
+                <v-divider class="my-3" />
+
+                <div class="text-subtitle-2 mb-2 d-flex align-center">
+                  <v-icon size="small" class="mr-1">mdi-ip-network</v-icon>
+                  Last IP
+                  <v-tooltip v-if="worker.ip_changed" location="bottom">
+                    <template #activator="{ props }">
+                      <v-icon v-bind="props" size="small" color="warning" class="ml-1">
+                        mdi-alert-circle-outline
+                      </v-icon>
+                    </template>
+                    <span>IP discrepancy detected between worker IP and context IPs</span>
+                  </v-tooltip>
+                </div>
+                <div class="text-body-2">
+                  {{ worker.last_ip || 'N/A' }}
                 </div>
 
                 <v-divider class="my-3" />


### PR DESCRIPTION
## Rationale
This PR shows worker and contexts IP addresses to users with privileged access to secrets while hiding it for all other users. It shows an alert info when the contexts have an IP but worker's IP does not match any of the IP's in the context.

Screenshots for  authorized and unauthorized users viewing worker details
<img width="474" height="255" alt="Screenshot_20251204_174311" src="https://github.com/user-attachments/assets/23ba1a92-714b-4e37-af4f-26ce299bec9a" />
<img width="961" height="239" alt="Screenshot_20251204_174258" src="https://github.com/user-attachments/assets/b0dd6917-2d28-4141-bfb9-d4b3559ce2b2" />
<img width="446" height="250" alt="Screenshot_20251204_174325" src="https://github.com/user-attachments/assets/94b606fb-140f-4da2-85f0-406c11623182" />


## Changes
- hide worker details by taking in a `show_secrets` property and customizing the serialization based on the value of this field. The alternative of calling `model_dump` with context isn't really applicable here as those are not custom types and there are multiple places where we want the field as they are (without serialization)
- show context IPs in UI alongisde worker IP for users who can read worker secrets

This closes #1397
