### PR TITLE
return response even when query_api throws exception

### DIFF
--- a/worker/src/zimfarm_worker/common/requests.py
+++ b/worker/src/zimfarm_worker/common/requests.py
@@ -81,6 +81,10 @@ def query_api(
         )
     except (JSONDecodeError, Exception):
         logger.exception(
-            f"unexpected error while decoding server response: {resp.text}"
+            f"unexpected error while making request to {url} : {resp.text}"
         )
-        raise
+        return Response(
+            status_code=resp.status_code,
+            success=resp.ok,
+            json={},
+        )


### PR DESCRIPTION
## Changes
- return `Response` object even when query api fails. This implies the task manager would ignore any errors that could arise from sending a request to the API.
- change logging level from exception to warning

See https://github.com/openzim/zimfarm/issues/1307#issuecomment-3616045792

This fixes #1307 