### PR TITLE
use system theme

### DIFF
--- a/frontend-ui/package.json
+++ b/frontend-ui/package.json
@@ -26,7 +26,7 @@
     "vue-cookies": "^1.8.6",
     "vue-matomo": "^4.2.0",
     "vue-router": "^4.5.1",
-    "vuetify": "^3.8.11"
+    "vuetify": "^3.11.2"
   },
   "devDependencies": {
     "@mdi/font": "^7.4.47",

--- a/frontend-ui/src/components/NavBar.vue
+++ b/frontend-ui/src/components/NavBar.vue
@@ -77,6 +77,7 @@
 </template>
 
 <script setup lang="ts">
+import Loading from '@/components/Loading.vue'
 import UserButton from '@/components/UserButton.vue'
 import { ref } from 'vue'
 

--- a/frontend-ui/src/components/WorkersTable.vue
+++ b/frontend-ui/src/components/WorkersTable.vue
@@ -231,6 +231,7 @@ import type { Worker } from '@/types/workers'
 import { formatDt, fromNow } from '@/utils/format'
 import { computed, inject, onMounted, ref, watch } from 'vue'
 import type { VueCookies } from 'vue-cookies'
+import { useTheme } from 'vuetify'
 
 const props = defineProps<{
   workerHeaders: { title: string; value: string }[]
@@ -251,6 +252,7 @@ const emit = defineEmits<{
 const limits = [10, 20, 50, 100]
 const selectedLimit = ref(props.paginator.limit)
 const expanded = ref<string[]>([])
+const theme = useTheme()
 
 const expandedAll = computed(
   () => props.workers.length > 0 && props.workers.every((w) => expanded.value.includes(w.name)),
@@ -350,7 +352,8 @@ function getRowProps({
 }): RowProps {
   const row = internalItem?.raw ?? item
   if (row?.kind === 'task') {
-    return { class: 'bg-grey-lighten-4' }
+    const isDark = theme.global.current.value.dark
+    return { class: isDark ? 'bg-grey-darken-3' : 'bg-grey-lighten-4' }
   }
   return {}
 }

--- a/frontend-ui/src/main.ts
+++ b/frontend-ui/src/main.ts
@@ -25,6 +25,9 @@ const app = createApp(App)
 const vuetify = createVuetify({
   components,
   directives,
+  theme: {
+    defaultTheme: 'system',
+  },
 })
 
 const pinia = createPinia()

--- a/frontend-ui/yarn.lock
+++ b/frontend-ui/yarn.lock
@@ -3349,10 +3349,10 @@ vue@^3.5.17:
     "@vue/server-renderer" "3.5.21"
     "@vue/shared" "3.5.21"
 
-vuetify@^3.8.11:
-  version "3.10.0"
-  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-3.10.0.tgz#1171ed0339968cca1c59d9a0be58e4f518e61903"
-  integrity sha512-cgtssO0yriqwEdOd6jGfUqUUztunxYPDhyY+iog0Q8i5WEa+3+eQ/dGpXeFoU80qMVm0k6uPd8aJpc5wEVXu3g==
+vuetify@^3.11.2:
+  version "3.11.2"
+  resolved "https://registry.yarnpkg.com/vuetify/-/vuetify-3.11.2.tgz#dd345af4cc4b4deaea525bb69904f51a7dcc7b9c"
+  integrity sha512-1lL0qN6JIdbx6xGYpo6dnx378EfC0t4EotPJdP4go8ThmIdRO3xLva1ALxhxi5lSYTht4R9OVk9miVnwVfDx3A==
 
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
## Rationale
This PR chooses the color scheme of the UI based on system scheme


## Changes
- upgrade vuetify to 3.11. 3.9 introduced support for setting system theme
- select colors of secondary table used when showing worker tasks

This closes #1452