### PR TITLE
extend flags to have kind and add blob as supported type

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/offliners/models.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/models.py
@@ -37,7 +37,9 @@ class FlagSchema(BaseFlagSchema):
         "list-of-string-enum",
         "list-of-url",
         "list-of-email",
+        "blob",
     ]
+    kind: Literal["image", "css"] | None = None
     choices: list[str] | list[Choice] | None = None
     alias: str | None = None
     relaxed_pattern: str | None = Field(validation_alias="relaxedPattern", default=None)
@@ -61,6 +63,17 @@ class FlagSchema(BaseFlagSchema):
         """Validate that a frozen field has a default"""
         if self.frozen and not self.default:
             raise ValueError("Frozen fields should have a default")
+
+        return self
+
+    @model_validator(mode="after")
+    def check_type(self) -> Self:
+        """Validate that only blob types have a kind"""
+        if self.type == "blob" and not self.kind:
+            raise ValueError("Blob types must specify a kind")
+
+        if self.type != "blob" and self.kind:
+            raise ValueError("Only blob types should specify a kind")
 
         return self
 

--- a/backend/tests/test_offliner_flag.py
+++ b/backend/tests/test_offliner_flag.py
@@ -1,0 +1,48 @@
+import pytest
+from pydantic import ValidationError
+
+from zimfarm_backend.common.schemas.offliners.models import FlagSchema
+
+
+def test_blob_type_with_valid_kind():
+    """Test that blob type with kind is valid"""
+    flag = FlagSchema(
+        label="Logo Image",
+        description="Upload a logo image",
+        type="blob",
+        kind="image",
+    )
+    assert flag.type == "blob"
+    assert flag.kind == "image"
+
+
+def test_blob_type_without_kind_raises_error():
+    """Test that blob type without kind raises ValidationError"""
+    with pytest.raises(ValidationError):
+        FlagSchema(
+            label="Some Blob",
+            description="A blob without kind",
+            type="blob",
+        )
+
+
+def test_non_blob_type_without_kind_valid():
+    """Test that non-blob types without kind are valid"""
+    flag = FlagSchema(
+        label="Website URL",
+        description="The URL to scrape",
+        type="url",
+    )
+    assert flag.type == "url"
+    assert flag.kind is None
+
+
+def test_non_blob_type_with_kind_raises_error():
+    """Test that non-blob type with kind raises ValidationError"""
+    with pytest.raises(ValidationError):
+        FlagSchema(
+            label="Website URL",
+            description="The URL to scrape",
+            type="url",
+            kind="image",
+        )


### PR DESCRIPTION
## Rationale
In order to simplify the uploading of files, zimfarm API needs to know certain things about the file. By extending the flag object to have a `kind` attribute and `type` to include `blob`, the api has enough information to upload the file while creating/updating a recipe

## Changes
- add `blob` as supported type
- add `kind` attribute to flag objects

This closes #1557 
