### PR TITLE
fix issues with monitor parent restarting multiple times

### DIFF
--- a/backend/src/zimfarm_backend/db/user.py
+++ b/backend/src/zimfarm_backend/db/user.py
@@ -119,6 +119,7 @@ def get_users(
         .where(User.deleted.is_(False))
         .offset(skip)
         .limit(limit)
+        .order_by(User.username.asc(), User.id.asc())
     )
 
     results = UserList(nb_records=0, users=[])

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -276,6 +276,3 @@ services:
 volumes:
   pg_data_zimfarm:
   minio_data_zimfarm:
-  netdatalib:
-  netdatacache:
-  netdataconfig:

--- a/frontend-ui/public/config.json
+++ b/frontend-ui/public/config.json
@@ -5,5 +5,5 @@
   "MATOMO_HOST": "https://stats.kiwix.org",
   "MATOMO_SITE_ID": 8,
   "MATOMO_TRACKER_FILE_NAME": "matomo",
-  "MONITORING_URL": "https://monitoring.openzim.org"
+  "MONITORING_URL": "https://monitoring.openzim.org/v3"
 }

--- a/monitor/parent/Dockerfile
+++ b/monitor/parent/Dockerfile
@@ -14,18 +14,13 @@ COPY update-stream-whitelist.sh /usr/local/bin/update-stream-whitelist.sh
 COPY regen-stream-conf.py /usr/local/bin/regen-stream-conf
 COPY entrypoint.sh /usr/local/bin/entrypoint
 
-# disable all external modules and setup cron
+# disable all external modules
 RUN printf "enabled: no\n" | tee /etc/netdata/python.d.conf /etc/netdata/go.d.conf /etc/netdata/node.d.conf \
     && printf "#!/bin/bash\nrm -rf /var/cache/netdata/* && kill 1\n" > /usr/local/bin/reset-netdata \
     && chmod a+x /usr/local/bin/reset-netdata \
     && chmod a+x /usr/local/bin/regen-stream-conf \
     && chmod a+x /usr/local/bin/update-stream-whitelist.sh \
     && touch /etc/netdata/.opt-out-from-anonymous-statistics \
-    && echo "DOCKER_USR=netdata" > /etc/cron.d/update-stream-whitelist \
-    && echo "NETDATA_LISTENER_PORT=19999" >> /etc/cron.d/update-stream-whitelist \
-    && echo "*/15 * * * * root /usr/local/bin/update-stream-whitelist.sh >> /var/log/cron.log 2>&1" >> /etc/cron.d/update-stream-whitelist \
-    && chmod 0644 /etc/cron.d/update-stream-whitelist \
-    && touch /etc/netdata/stream.conf \
     && chmod a+x /usr/local/bin/entrypoint \
     && wget -q https://github.com/Yelp/dumb-init/releases/download/v1.2.5/dumb-init_1.2.5_x86_64 \
     && mv dumb-init_1.2.5_x86_64 /usr/bin/dumb-init \

--- a/monitor/parent/entrypoint.sh
+++ b/monitor/parent/entrypoint.sh
@@ -40,7 +40,20 @@ fi
 
 # Run update-stream-whitelist on startup
 echo "Running initial stream whitelist update"
-/usr/local/bin/update-stream-whitelist.sh &
+/usr/local/bin/update-stream-whitelist.sh
+
+# Setup cron job with environment variables
+echo "Setting up cron job with environment variables"
+cat > /etc/cron.d/update-stream-whitelist <<EOF
+DOCKER_USR=${DOCKER_USR}
+NETDATA_LISTENER_PORT=${NETDATA_LISTENER_PORT}
+ZIMFARM_API_URL=${ZIMFARM_API_URL}
+ZIMFARM_USERNAME=${ZIMFARM_USERNAME}
+ZIMFARM_PASSWORD=${ZIMFARM_PASSWORD}
+
+*/15 * * * * root /usr/local/bin/update-stream-whitelist.sh >> /var/log/cron.log 2>&1
+EOF
+chmod 0644 /etc/cron.d/update-stream-whitelist
 
 # Start cron in the background
 echo "Starting cron daemon"

--- a/monitor/parent/update-stream-whitelist.sh
+++ b/monitor/parent/update-stream-whitelist.sh
@@ -7,7 +7,27 @@ function md5of {
 }
 
 echo "Updating stream configuration"
-regen-stream-conf > $STREAMCONFPATH.new
+
+# Run regen-stream-conf and capture exit code
+if ! /usr/local/bin/regen-stream-conf > $STREAMCONFPATH.new; then
+    echo "ERROR: regen-stream-conf failed, keeping existing configuration"
+    rm -f $STREAMCONFPATH.new
+    exit 1
+fi
+
+# Check if the output file is empty or too small (probable error)
+if [ ! -s "$STREAMCONFPATH.new" ]; then
+    echo "ERROR: regen-stream-conf produced empty output, keeping existing configuration"
+    rm -f $STREAMCONFPATH.new
+    exit 1
+fi
+
+if [ ! -f "$STREAMCONFPATH" ]; then
+    echo "No stream.conf exists, installing fresh"
+    mv "$STREAMCONFPATH.new" "$STREAMCONFPATH"
+    exit 0
+fi
+
 
 if [ ! "$(md5of $STREAMCONFPATH)" = "$(md5of $STREAMCONFPATH.new)" ]; then
     echo "workers keys updated. restarting netdata"


### PR DESCRIPTION
## Changes
- sort users by username to ensure order remains the same. This is one reason why monitor is restarting since the users are returned in any other and the md5 checksum of the `stream.conf` file would be different
- generate `stream.conf` in `entrypoint.sh` first before starting netdata for the first time
- avoid touching `stream.conf` in Dockerfile since it's going to be generated in `entrypoint.sh`. This avoids killing the container and restarting it
- point monitoring url to v3 UI which does not have a  login screen
- add error handling to output of regen-stream.conf file
- set up cronjob in entrypoint.sh instead with env variables
