### PR TITLE
enhance ui to upload blobs from schedule editor

### DIFF
--- a/backend/src/zimfarm_backend/common/constants.py
+++ b/backend/src/zimfarm_backend/common/constants.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from typing import Any
 
-from humanfriendly import parse_timespan
+from humanfriendly import parse_size, parse_timespan
 
 from zimfarm_backend.common.enums import SchedulePeriodicity
 
@@ -174,3 +174,4 @@ ALEMBIC_UPGRADE_HEAD_ON_START = parse_bool(
 BLOB_STORAGE_URL = getenv("BLOB_STORAGE_URL")
 BLOB_STORAGE_USERNAME = getenv("BLOB_STORAGE_USERNAME")
 BLOB_STORAGE_PASSWORD = getenv("BLOB_STORAGE_PASSWORD")
+BLOB_MAX_SIZE = parse_size(getenv("BLOB_MAX_SIZE", default="1MB"), binary=True)

--- a/backend/src/zimfarm_backend/common/schemas/fields.py
+++ b/backend/src/zimfarm_backend/common/schemas/fields.py
@@ -26,6 +26,10 @@ class GraphemeStr(str):
         return len(regex.findall(r"\X", self))
 
 
+class BlobStr(str):
+    pass
+
+
 def to_grapheme_str(value: str):
     return GraphemeStr(value)
 

--- a/backend/src/zimfarm_backend/common/schemas/offliners/builder.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/builder.py
@@ -113,6 +113,9 @@ def generate_field_type(offliner: str, flag: FlagSchema, label: str):
         # otherwise, it invalidates the required validation
         default=... if flag.required and flag.default is None else flag.default,
         frozen=parse_bool(flag.frozen),
+        # Add additional information to the pydantic field to be used while determing
+        # flag details.
+        json_schema_extra={"kind": flag.kind, "type": flag.type},
     )
     match flag.type:
         case "string-enum" | "list-of-string-enum":

--- a/backend/tests/test_offliner_serializer.py
+++ b/backend/tests/test_offliner_serializer.py
@@ -1,7 +1,7 @@
 from typing import Any
 
 import pytest
-from pydantic import AnyUrl, BaseModel, EmailStr, SecretStr
+from pydantic import BaseModel, SecretStr
 
 from zimfarm_backend.common.enums import TaskStatus
 from zimfarm_backend.common.schemas.fields import (
@@ -16,32 +16,9 @@ from zimfarm_backend.common.schemas.fields import (
 )
 from zimfarm_backend.common.schemas.offliners.serializer import (
     get_enum_choices,
-    get_field_type,
     is_secret,
     schema_to_flags,
 )
-
-
-@pytest.mark.parametrize(
-    "field_type,expected_type",
-    [
-        (int, "integer"),
-        (str, "string"),
-        (bool, "boolean"),
-        (AnyUrl, "url"),
-        (EmailStr, "email"),
-        (SecretStr, "string"),
-        (OptionalNotEmptyString, "string"),
-        (OptionalZIMOutputFolder, "string"),
-        (OptionalZIMSecretStr, "string"),
-        (TaskStatus, "string-enum"),
-        (list[int], "list-of-integer"),
-        (list[str], "list-of-string"),
-        (list[bool], "list-of-boolean"),
-    ],
-)
-def test_get_field_type(field_type: Any, expected_type: str):
-    assert get_field_type(field_type) == expected_type
 
 
 @pytest.mark.parametrize(
@@ -124,7 +101,7 @@ def test_mw_offliner_schema_to_flags(mwoffliner_schema_cls: type[BaseModel]):
         elif key in ("speed",):
             assert flag.type == "float"
             assert flag.choices is None
-        elif key in ("mwUrl", "customZimFavicon"):
+        elif key in ("mwUrl", "customZimFavicon", "optimisationCacheUrl"):
             assert flag.type == "url"
             assert flag.choices is None
         else:

--- a/dev/frontend-ui-dev/config.json
+++ b/dev/frontend-ui-dev/config.json
@@ -1,4 +1,5 @@
 {
   "ZIMFARM_WEBAPI": "http://localhost:8000/v2",
-  "MONITORING_URL": "http://localhost:8004/v3"
+  "MONITORING_URL": "http://localhost:8004/v3",
+  "BLOB_MAX_SIZE": 1048576
 }

--- a/frontend-ui/public/config.json
+++ b/frontend-ui/public/config.json
@@ -5,5 +5,6 @@
   "MATOMO_HOST": "https://stats.kiwix.org",
   "MATOMO_SITE_ID": 8,
   "MATOMO_TRACKER_FILE_NAME": "matomo",
-  "MONITORING_URL": "https://monitoring.openzim.org/v3"
+  "MONITORING_URL": "https://monitoring.openzim.org",
+  "BLOB_MAX_SIZE": 1048576
 }

--- a/frontend-ui/src/components/BlobEditor.vue
+++ b/frontend-ui/src/components/BlobEditor.vue
@@ -1,0 +1,201 @@
+<template>
+  <div>
+    <div class="d-flex align-center">
+      <v-text-field
+        v-model="displayFileName"
+        :label="label"
+        density="compact"
+        variant="outlined"
+        readonly
+        :hint="description ?? undefined"
+        persistent-hint
+        :hide-details="hasError ? false : 'auto'"
+      >
+        <template #append-inner>
+          <v-btn
+            v-if="modelValue"
+            icon="mdi-close"
+            size="x-small"
+            variant="text"
+            color="error"
+            @click="handleRemove"
+          />
+          <v-btn icon="mdi-paperclip" size="small" variant="text" @click="triggerFileInput" />
+        </template>
+      </v-text-field>
+    </div>
+
+    <!-- Hidden file input -->
+    <input
+      ref="fileInputRef"
+      type="file"
+      :accept="acceptedTypes"
+      style="display: none"
+      @change="handleFileChange"
+    />
+
+    <!-- Error messages -->
+    <div v-if="errorMessage" class="text-error text-caption mt-2">
+      {{ errorMessage }}
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { formattedBytesSize } from '@/utils/format'
+import constants from '@/constants'
+import type { Config } from '@/config'
+import { computed, ref, watch, inject } from 'vue'
+
+const config = inject<Config>(constants.config)
+if (!config) {
+  throw new Error('Config is not defined')
+}
+
+interface Props {
+  modelValue: string | null | undefined
+  label?: string
+  kind?: 'image' | 'css'
+  required?: boolean
+  description?: string | null
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  label: 'File',
+  kind: 'image',
+  required: false,
+  description: null,
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string | null]
+}>()
+
+const fileInputRef = ref<HTMLInputElement | null>(null)
+const errorMessage = ref<string>('')
+const hasError = ref(false)
+const currentFileName = ref<string>('')
+
+const acceptedTypes = computed(() => {
+  if (props.kind === 'image') {
+    return 'image/*'
+  } else if (props.kind === 'css') {
+    return '.css,text/css'
+  }
+  return '*'
+})
+
+const displayFileName = computed(() => {
+  if (currentFileName.value) {
+    return currentFileName.value
+  }
+  if (props.modelValue) {
+    if (props.modelValue.startsWith('http://') || props.modelValue.startsWith('https://')) {
+      return props.modelValue
+    }
+    return 'Uploaded file (base64)'
+  }
+  return ''
+})
+
+const triggerFileInput = () => {
+  fileInputRef.value?.click()
+}
+
+const convertFileToBase64 = (file: File): Promise<string> => {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader()
+    reader.onload = () => {
+      if (typeof reader.result === 'string') {
+        resolve(reader.result)
+      } else {
+        reject(new Error('Failed to convert file to base64'))
+      }
+    }
+    reader.onerror = () => reject(reader.error)
+    reader.readAsDataURL(file)
+  })
+}
+
+const handleFileChange = async (event: Event) => {
+  errorMessage.value = ''
+  hasError.value = false
+
+  const target = event.target as HTMLInputElement
+  const files = target.files
+
+  if (!files || files.length === 0) {
+    return
+  }
+
+  const file = files[0]
+
+  // Validate file size
+  if (file.size > config.BLOB_MAX_SIZE) {
+    errorMessage.value = `File size must be less than ${formattedBytesSize(config.BLOB_MAX_SIZE)}`
+    hasError.value = true
+    if (fileInputRef.value) {
+      fileInputRef.value.value = ''
+    }
+    return
+  }
+
+  // Validate file type
+  if (props.kind === 'image' && !file.type.startsWith('image/')) {
+    errorMessage.value = 'File must be an image'
+    hasError.value = true
+    if (fileInputRef.value) {
+      fileInputRef.value.value = ''
+    }
+    return
+  }
+
+  if (props.kind === 'css' && file.type !== 'text/css' && !file.name.endsWith('.css')) {
+    errorMessage.value = 'File must be a CSS file'
+    hasError.value = true
+    if (fileInputRef.value) {
+      fileInputRef.value.value = ''
+    }
+    return
+  }
+
+  try {
+    // Store the filename
+    currentFileName.value = file.name
+
+    // Convert to base64
+    const base64 = await convertFileToBase64(file)
+    emit('update:modelValue', base64)
+  } catch (error) {
+    console.error('Failed to process file:', error)
+    errorMessage.value = 'Failed to process file. Please try again.'
+    hasError.value = true
+    currentFileName.value = ''
+    if (fileInputRef.value) {
+      fileInputRef.value.value = ''
+    }
+  }
+}
+
+const handleRemove = () => {
+  currentFileName.value = ''
+  if (fileInputRef.value) {
+    fileInputRef.value.value = ''
+  }
+  emit('update:modelValue', null)
+}
+
+// Watch for URL updates from backend (after submission)
+watch(
+  () => props.modelValue,
+  (newValue, oldValue) => {
+    // Update display when backend returns a URL
+    if (newValue && newValue !== oldValue) {
+      if (newValue.startsWith('http://') || newValue.startsWith('https://')) {
+        currentFileName.value = newValue
+      }
+    }
+  },
+  { immediate: true },
+)
+</script>

--- a/frontend-ui/src/config.ts
+++ b/frontend-ui/src/config.ts
@@ -11,6 +11,7 @@ export interface Config {
   MATOMO_SITE_ID: number
   MATOMO_TRACKER_FILE_NAME: string
   MONITORING_URL: string
+  BLOB_MAX_SIZE: number
 }
 
 export const ConfigService = {

--- a/frontend-ui/src/types/offliner.ts
+++ b/frontend-ui/src/types/offliner.ts
@@ -17,6 +17,7 @@ export interface OfflinerDefinition {
   min_length: number | null
   max_length: number | null
   pattern: string | null
+  kind?: 'image' | 'css'
 }
 
 export interface OfflinerDefinitionResponse {


### PR DESCRIPTION
## Changes
- remove logic to get_base_type from annotations since this is the same information coming from the schema. The function inspects the type of the class and for cases like `blob`, it would mean defining a custom type. Rather than do this, we just pass the information to the field class and retrieve it there.
- impose size limit on file uploads (default: 1MB)
- allow UI to upload files to the backend


This closes #1558 
