### PR TITLE
prevent duplicate blob uploads

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/offliners/models.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/models.py
@@ -22,11 +22,14 @@ class BaseFlagSchema(BaseModel):
     pattern: str | None = None
 
 
-class ProcessedBlob(BaseModel):
+class PreparedBlob(BaseModel):
+    """Blob data prepared for upload but not yet uploaded"""
+
     kind: str
-    url: AnyUrl
+    url: AnyUrl  # The URL to upload the file to. Includes generated filename
     flag_name: str
     checksum: str
+    data: bytes
 
 
 class FlagSchema(BaseFlagSchema):

--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -545,8 +545,8 @@ class UserSchemaWithSshKeys(UserSchema):
 
 
 class BlobSchema(BaseModel):
-    id: UUID = Field(exclude=True)
-    schedule_name: str
+    schedule_name: str | None
     flag_name: str
+    checksum: str
     created_at: datetime.datetime
     url: AnyUrl

--- a/backend/src/zimfarm_backend/db/blob.py
+++ b/backend/src/zimfarm_backend/db/blob.py
@@ -1,27 +1,69 @@
+from typing import cast
 from uuid import UUID
 
+from pydantic import AnyUrl
+from sqlalchemy import select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session as OrmSession
 
-from zimfarm_backend.common.schemas.offliners.models import ProcessedBlob
-from zimfarm_backend.db.models import Blob
+from zimfarm_backend.common.schemas.offliners.models import PreparedBlob
+from zimfarm_backend.common.schemas.orms import BlobSchema
+from zimfarm_backend.db.exceptions import RecordDoesNotExistError
+from zimfarm_backend.db.models import Blob, Schedule
+
+
+def get_blob_or_none(
+    session: OrmSession, *, schedule_id: UUID, flag_name: str, checksum: str
+) -> BlobSchema | None:
+    """Get a blob using the unique combination of schedule_id, flag_name and checksum"""
+    stmt = (
+        select(Blob, Schedule.name.label("schedule_name"))
+        .join(Schedule, Blob.schedule)
+        .where(
+            Blob.schedule_id == schedule_id,
+            Blob.flag_name == flag_name,
+            Blob.checksum == checksum,
+        )
+    )
+    if row := session.execute(stmt).one_or_none():
+        blob = cast(Blob, row.Blob)
+        return BlobSchema(
+            schedule_name=row.schedule_name,
+            checksum=blob.checksum,
+            url=AnyUrl(blob.url),
+            flag_name=blob.flag_name,
+            created_at=blob.created_at,
+        )
+    return None
+
+
+def get_blob(
+    session: OrmSession, *, schedule_id: UUID, flag_name: str, checksum: str
+) -> BlobSchema:
+    if blob := get_blob_or_none(
+        session, schedule_id=schedule_id, flag_name=flag_name, checksum=checksum
+    ):
+        return blob
+    raise RecordDoesNotExistError("Blob does not exist")
 
 
 def create_or_update_blob(
     session: OrmSession,
     *,
     schedule_id: UUID,
-    request: ProcessedBlob,
+    request: PreparedBlob,
 ):
     """Create or update a schedule blob"""
-    values = request.model_dump(exclude_unset=True, mode="json")
+    values = request.model_dump(exclude_unset=True, mode="json", exclude={"data"})
     values["schedule_id"] = schedule_id
     stmt = insert(Blob).values(**values)
     stmt = stmt.on_conflict_do_update(
         index_elements=[Blob.schedule_id, Blob.flag_name, Blob.checksum],
         set_={
             **request.model_dump(
-                exclude_unset=True, exclude={"flag_name", "checksum"}, mode="json"
+                exclude_unset=True,
+                exclude={"flag_name", "checksum", "data"},
+                mode="json",
             )
         },
     )

--- a/backend/tests/db/test_blob.py
+++ b/backend/tests/db/test_blob.py
@@ -1,8 +1,10 @@
+import pytest
 from pydantic import AnyUrl
 from sqlalchemy.orm import Session as OrmSession
 
-from zimfarm_backend.common.schemas.offliners.models import ProcessedBlob
-from zimfarm_backend.db.blob import create_or_update_blob
+from zimfarm_backend.common.schemas.offliners.models import PreparedBlob
+from zimfarm_backend.db.blob import create_or_update_blob, get_blob, get_blob_or_none
+from zimfarm_backend.db.exceptions import RecordDoesNotExistError
 from zimfarm_backend.db.models import Blob, Schedule
 
 
@@ -10,11 +12,12 @@ def test_create_schedule_blob(dbsession: OrmSession, schedule: Schedule):
     create_or_update_blob(
         dbsession,
         schedule_id=schedule.id,
-        request=ProcessedBlob(
+        request=PreparedBlob(
             kind="css",
             url=AnyUrl("https://www.example.com/style.css"),
             flag_name="custom-css",
             checksum="1",
+            data=b"hello",
         ),
     )
     dbsession.refresh(schedule)
@@ -36,13 +39,59 @@ def test_update_schedule_blob(dbsession: OrmSession, schedule: Schedule):
     create_or_update_blob(
         dbsession,
         schedule_id=schedule.id,
-        request=ProcessedBlob(
+        request=PreparedBlob(
             kind="css",
             url=AnyUrl("https://www.example.com/style2.css"),
             flag_name="custom-css",
             checksum="1",
+            data=b"hello",
         ),
     )
     dbsession.refresh(schedule)
     assert len(schedule.blobs) == 1
     assert schedule.blobs[0].url == "https://www.example.com/style2.css"
+
+
+def test_get_blob_or_none_found(dbsession: OrmSession, schedule: Schedule):
+    schedule.blobs.append(
+        Blob(
+            kind="css",
+            flag_name="custom-css",
+            url="https://www.example.com/style.css",
+            checksum="1",
+        )
+    )
+    dbsession.add(schedule)
+    dbsession.flush()
+
+    blob = get_blob_or_none(
+        dbsession,
+        schedule_id=schedule.id,
+        flag_name="custom-css",
+        checksum="1",
+    )
+    assert blob is not None
+    assert blob.flag_name == "custom-css"
+    assert blob.checksum == "1"
+    assert str(blob.url) == "https://www.example.com/style.css"
+    assert blob.schedule_name == schedule.name
+
+
+def test_get_blob_or_none_not_found(dbsession: OrmSession, schedule: Schedule):
+    blob = get_blob_or_none(
+        dbsession,
+        schedule_id=schedule.id,
+        flag_name="nonexistent",
+        checksum="999",
+    )
+    assert blob is None
+
+
+def test_get_blob_not_found(dbsession: OrmSession, schedule: Schedule):
+    with pytest.raises(RecordDoesNotExistError):
+        get_blob(
+            dbsession,
+            schedule_id=schedule.id,
+            flag_name="nonexistent",
+            checksum="999",
+        )

--- a/backend/tests/db/test_schedule.py
+++ b/backend/tests/db/test_schedule.py
@@ -1,23 +1,29 @@
 import datetime
 from collections.abc import Callable
 from contextlib import nullcontext as does_not_raise
+from unittest.mock import patch
 from uuid import uuid4
 
 import pytest
 from _pytest.python_api import RaisesContext
+from pydantic import AnyUrl
 from sqlalchemy import select
 from sqlalchemy.orm import Session as OrmSession
 
 from zimfarm_backend.common.enums import (
+    DockerImageName,
     ScheduleCategory,
     SchedulePeriodicity,
     TaskStatus,
 )
 from zimfarm_backend.common.schemas.models import ScheduleConfigSchema
+from zimfarm_backend.common.schemas.offliners.builder import build_offliner_model
+from zimfarm_backend.common.schemas.offliners.models import PreparedBlob
 from zimfarm_backend.common.schemas.orms import (
     LanguageSchema,
     OfflinerDefinitionSchema,
     OfflinerSchema,
+    OfflinerSpecSchema,
 )
 from zimfarm_backend.db import count_from_stmt
 from zimfarm_backend.db.exceptions import (
@@ -45,6 +51,7 @@ from zimfarm_backend.db.schedule import (
     get_schedule_history_entry_or_none,
     get_schedule_or_none,
     get_schedules,
+    process_schedule_blobs,
     restore_schedules,
     toggle_archive_status,
     update_schedule,
@@ -589,3 +596,58 @@ def test_restore_schedules(
 
     with expected:
         restore_schedules(dbsession, schedule_names=schedule_names, actor=user.username)
+
+
+def test_process_schedule_blobs(dbsession: OrmSession):
+    spec = OfflinerSpecSchema.model_validate(
+        {
+            "flags": {
+                "custom_css": {
+                    "type": "blob",
+                    "kind": "css",
+                    "label": "Custom CSS",
+                    "description": "Upload custom CSS file",
+                    "alias": "custom-css",
+                    "required": False,
+                },
+                "name": {
+                    "type": "string",
+                    "label": "Name",
+                    "description": "Project name",
+                    "required": True,
+                },
+            }
+        }
+    )
+    offliner = OfflinerSchema(
+        id="zimit",
+        base_model="CamelModel",
+        docker_image_name=DockerImageName.zimit,
+        command_name="zimit2zim",
+        ci_secret_hash=None,
+    )
+
+    offliner_model = build_offliner_model(offliner, spec)
+    instance = offliner_model.model_validate(
+        {"offliner_id": "zimit", "name": "test", "custom-css": "base64string"}
+    )
+
+    prepared_blob = PreparedBlob(
+        kind="css",
+        flag_name="custom_css",
+        url=AnyUrl("https://www.example.com/style.css"),
+        checksum="1",
+        data=b"hello",
+    )
+    with patch("zimfarm_backend.db.schedule.upload_blob") as mock_upload_blob:
+        process_schedule_blobs(
+            session=dbsession,
+            prepared_blobs=[prepared_blob],
+            schedule_id=uuid4(),
+            offliner=instance,
+        )
+        mock_upload_blob.assert_called_once()
+        assert (
+            instance.custom_css  # pyright: ignore[reportUnknownMemberType, reportAttributeAccessIssue]
+            == "https://www.example.com/style.css"
+        )


### PR DESCRIPTION
## Rationale
A blob is considered unique based on it's `checksum`, `flag_name` and `schedule_id` . Thus, if a user reuploads the same file for the same `flag_name` and `schedule_id`, we should not make another upload if we have already uploaded this file.

## Changes
- refactor transformer logic of processing uploads to just prepare the uploads with the all data computed
- process schedule blobs in the db calls to create/update a schedule using the prepared blobs. using the prepared blobs, we can check if a file has been uploaded before for the schedule and flag combination to prevent duplicate uploads
- add functions to retrieve blobs from db using the characteristics that make it unique
