### PR TITLE
add support for color types

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -19,6 +19,7 @@ classifiers = [
 dependencies = [
     "alembic == 1.15.2",
     "pydantic[email] == 2.11.4",
+    "pydantic-extra-types == 2.10.6",
     "SQLAlchemy == 2.0.41",
     "PyJWT == 2.10.1",
     "pymongo == 4.13.0",

--- a/backend/src/zimfarm_backend/common/schemas/fields.py
+++ b/backend/src/zimfarm_backend/common/schemas/fields.py
@@ -9,12 +9,14 @@ from pydantic import (
     AnyUrl,
     Field,
     SecretStr,
+    SerializerFunctionWrapHandler,
     ValidationInfo,
     ValidatorFunctionWrapHandler,
     WrapSerializer,
     WrapValidator,
 )
 from pydantic_core.core_schema import SerializationInfo
+from pydantic_extra_types.color import Color
 
 from zimfarm_backend.common.constants import SECRET_STRING_LENGTH
 from zimfarm_backend.common.enums import Platform, WarehousePath
@@ -258,6 +260,18 @@ ZIMOutputFolder = Annotated[
 
 SkipableBool = Annotated[bool, WrapValidator(skip_validation)]
 OptionalSkipableBool = SkipableBool | None
+
+
+def serialize_color_to_hex(value: Any, _: SerializerFunctionWrapHandler) -> str:
+    """Serialize a color to hexadecimal codes."""
+    if isinstance(value, Color):
+        value = value.as_hex(format="long").upper()
+    return value
+
+
+SkipableColor = Annotated[
+    Color, WrapValidator(skip_validation), WrapSerializer(serialize_color_to_hex)
+]
 
 OptionalZIMOutputFolder = ZIMOutputFolder | None
 

--- a/backend/src/zimfarm_backend/common/schemas/offliners/builder.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/builder.py
@@ -22,6 +22,7 @@ from zimfarm_backend.common.schemas.fields import (
     OptionalField,
     SecretUrl,
     SkipableBool,
+    SkipableColor,
     SkipableUrl,
     ZIMSecretStr,
     enum_member,
@@ -50,6 +51,7 @@ TYPE_MAP = {
     "list-of-integer": list[int],
     "list-of-float": list[float],
     "list-of-email": list[EmailStr],
+    "color": SkipableColor,
 }
 
 

--- a/backend/src/zimfarm_backend/common/schemas/offliners/models.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/models.py
@@ -49,6 +49,7 @@ class FlagSchema(BaseFlagSchema):
         "list-of-url",
         "list-of-email",
         "blob",
+        "color",
     ]
     kind: Literal["image", "css"] | None = None
     choices: list[str] | list[Choice] | None = None

--- a/frontend-ui/src/components/ScheduleEditor.vue
+++ b/frontend-ui/src/components/ScheduleEditor.vue
@@ -407,12 +407,15 @@
               :hint="field.description ?? undefined"
               persistent-hint
             />
-            <v-text-field
+            <v-color-input
               v-else-if="field.component === 'color'"
+              color-pip
+              pip-variant="flat"
               v-model.trim="editFlags[field.dataKey]"
-              type="color"
               density="compact"
               variant="outlined"
+              mode="hex"
+              :modes="['hex']"
               :placeholder="field.placeholder"
               :required="field.required"
               :rules="getFieldRules(field)"
@@ -919,7 +922,7 @@ const flagsFields = computed(() => {
     let options: Array<{ title: string; value: string | undefined }> | undefined = undefined
     let step = null
 
-    if (field.type === 'hex-color') {
+    if (field.type === 'color') {
       component = 'color'
     } else if (field.type === 'url') {
       component = 'url'

--- a/frontend-ui/src/main.ts
+++ b/frontend-ui/src/main.ts
@@ -11,6 +11,7 @@ import 'vuetify/styles'
 import { createPinia } from 'pinia'
 import VueMatomo from 'vue-matomo'
 import VueCookies from 'vue-cookies'
+import { VColorInput } from 'vuetify/labs/VColorInput'
 
 // config
 import getConfig, { configPlugin } from '@/config'
@@ -23,7 +24,10 @@ import constants from '@/constants'
 const app = createApp(App)
 
 const vuetify = createVuetify({
-  components,
+  components: {
+    ...components,
+    VColorInput,
+  },
   directives,
   theme: {
     defaultTheme: 'system',


### PR DESCRIPTION
## Rationale
This PR adds new type `color` and a color picker for flags representing a color in the UI

## Changes
- use pydantic color type for representing color objects
- show colorpicker for selecting color input

This closes #1573 

<img width="1120" height="611" alt="Screenshot_20251215_161645" src="https://github.com/user-attachments/assets/aca6a7a6-8198-42f8-899e-b3b1b5ea9a0d" />

