### PR TITLE
add script to migrate old schedule blobs to table entries

### DIFF
--- a/backend/maint-scripts/update_schedule_blobs.py
+++ b/backend/maint-scripts/update_schedule_blobs.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+
+import hashlib
+from typing import Literal
+
+import requests
+from pydantic import AnyUrl
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from zimfarm_backend import logger
+from zimfarm_backend.common.constants import (
+    BLOB_PRIVATE_STORAGE_URL,
+    BLOB_PUBLIC_STORAGE_URL,
+    BLOB_STORAGE_PASSWORD,
+    BLOB_STORAGE_USERNAME,
+    REQUESTS_TIMEOUT,
+)
+from zimfarm_backend.common.schemas import BaseModel
+from zimfarm_backend.common.schemas.models import ScheduleConfigSchema
+from zimfarm_backend.common.schemas.offliners.transformers import (
+    generate_blob_name_uuid,
+)
+from zimfarm_backend.common.schemas.orms import CreateBlobSchema
+from zimfarm_backend.db import Session
+from zimfarm_backend.db.blob import create_or_update_blob
+from zimfarm_backend.db.models import Schedule
+from zimfarm_backend.db.offliner import get_offliner
+from zimfarm_backend.db.offliner_definition import (
+    create_offliner_definition_schema,
+    create_offliner_instance,
+)
+
+
+class BlobFlag(BaseModel):
+    flag_name: str
+    kind: Literal["image", "css"]
+
+
+FLAG_MAPPINGS: dict[str, list[BlobFlag]] = {
+    "devdocs": [BlobFlag(flag_name="logo_format", kind="image")],
+    "freecodecamp": [BlobFlag(flag_name="illustration", kind="image")],
+    "ifixit": [BlobFlag(flag_name="icon", kind="image")],
+    "kolibri": [
+        BlobFlag(flag_name="favicon", kind="image"),
+        BlobFlag(flag_name="css", kind="css"),
+    ],
+    "mindtouch": [BlobFlag(flag_name="illustration_url", kind="image")],
+    "mwoffliner": [BlobFlag(flag_name="customZimFavicon", kind="image")],
+    "nautilus": [
+        BlobFlag(flag_name="main_logo", kind="image"),
+        BlobFlag(flag_name="secondary_logo", kind="image"),
+        BlobFlag(flag_name="favicon", kind="image"),
+    ],
+    "openedx": [BlobFlag(flag_name="favicon_url", kind="image")],
+    "sotoki": [BlobFlag(flag_name="favicon", kind="image")],
+    "youtube": [
+        BlobFlag(flag_name="profile", kind="image"),
+        BlobFlag(flag_name="banner", kind="image"),
+    ],
+    "zimit": [
+        BlobFlag(flag_name="favicon", kind="image"),
+        BlobFlag(flag_name="custom_css", kind="css"),
+    ],
+}
+
+
+def delete_blob(old_url: str) -> None:
+    """Delete a blob from storage."""
+    try:
+        response = requests.request(
+            "DELETE",
+            old_url,
+            timeout=REQUESTS_TIMEOUT,
+            auth=(BLOB_STORAGE_USERNAME, BLOB_STORAGE_PASSWORD),
+        )
+        response.raise_for_status()
+    except Exception as exc:
+        logger.warning(f"Failed to delete file at {old_url}, exc: {exc!s}")
+    logger.info(f"Deleted file at '{old_url}'")
+
+
+def copy_blob(old_url: str, flag_name: str, kind: str) -> CreateBlobSchema | None:
+    """Fetch blob from old_url, compute checksum, and copy to new location"""
+    try:
+        fetch_response = requests.get(
+            old_url,
+            timeout=REQUESTS_TIMEOUT,
+            auth=(BLOB_STORAGE_USERNAME, BLOB_STORAGE_PASSWORD),
+        )
+        fetch_response.raise_for_status()
+        blob_data = fetch_response.content
+    except Exception as exc:
+        logger.warning(f"Failed to fetch {old_url}, exc: {exc!s}")
+        return None
+
+    checksum = hashlib.sha256(blob_data).hexdigest()
+
+    filename = generate_blob_name_uuid(kind)
+    new_private_url = f"{BLOB_PRIVATE_STORAGE_URL}/{filename}"
+    new_public_url = f"{BLOB_PUBLIC_STORAGE_URL}/{filename}"
+
+    # Copy blob to new destination with overwrite set to F. This would raise an error
+    # if a file already exists at the location. While this shouldn't happen, it can
+    # be a safety net on the chance that it does happen. To overwrite, set to T.
+    headers = {"Destination": new_private_url, "Overwrite": "F"}
+
+    try:
+        copy_response = requests.request(
+            "COPY",
+            old_url,
+            headers=headers,
+            timeout=REQUESTS_TIMEOUT,
+            auth=(BLOB_STORAGE_USERNAME, BLOB_STORAGE_PASSWORD),
+        )
+        copy_response.raise_for_status()
+    except Exception as exc:
+        logger.warning(f"Failed to move {old_url} to {new_private_url}, exc: {exc!s}")
+        return None
+
+    return CreateBlobSchema(
+        flag_name=flag_name,
+        kind=kind,
+        url=AnyUrl(new_public_url),
+        checksum=checksum,
+    )
+
+
+def main():
+    # list of blob urls to delete after copying them to new locations
+    blobs_to_delete: set[str] = set()
+    with Session.begin() as session:
+        for offliner_id, flag_mappings in FLAG_MAPPINGS.items():
+            logger.info(f"Processing offliner: {offliner_id}")
+            offliner = get_offliner(session, offliner_id)
+
+            for schedule in session.execute(
+                select(Schedule)
+                .where(
+                    Schedule.config["offliner"]["offliner_id"].astext == offliner_id,
+                )
+                .options(selectinload(Schedule.offliner_definition))
+            ).scalars():
+                logger.info(f"Processing schedule {schedule.name} blobs...")
+                offliner_definition = create_offliner_definition_schema(
+                    schedule.offliner_definition
+                )
+                schedule_config = ScheduleConfigSchema.model_validate(
+                    {
+                        **schedule.config,
+                        "offliner": create_offliner_instance(
+                            offliner=offliner,
+                            offliner_definition=offliner_definition,
+                            data=schedule.config["offliner"],
+                            skip_validation=True,
+                        ),
+                    },
+                    context={"skip_validation": True},
+                )
+                for flag in flag_mappings:
+                    old_url = getattr(schedule_config.offliner, flag.flag_name)
+                    if not old_url:
+                        continue
+
+                    if not old_url.startswith("http"):
+                        logger.warning(
+                            f"Schedule '{schedule.name}' flag '{flag.flag_name}' is "
+                            "not a valid URL"
+                        )
+                        continue
+
+                    blob_schema = copy_blob(
+                        old_url,
+                        flag.flag_name,
+                        flag.kind,
+                    )
+                    if not blob_schema:
+                        continue
+
+                    create_or_update_blob(
+                        session, schedule_id=schedule.id, request=blob_schema
+                    )
+                    setattr(
+                        schedule_config.offliner, flag.flag_name, str(blob_schema.url)
+                    )
+                    schedule.config = schedule_config.model_dump(
+                        mode="json", context={"show_secrets": True}
+                    )
+                    logger.info(
+                        f"Updated schedule '{schedule.name}' flag '{flag.flag_name} "
+                        f"to '{blob_schema.url!s}'"
+                    )
+                    blobs_to_delete.add(old_url)
+
+    logger.info("Deleting old blobs...")
+    for blob_url in blobs_to_delete:
+        delete_blob(blob_url)
+
+    logger.info("FINISH!")
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -544,9 +544,13 @@ class UserSchemaWithSshKeys(UserSchema):
     ssh_keys: list[SshKeyRead]
 
 
-class BlobSchema(BaseModel):
-    schedule_name: str | None
+class CreateBlobSchema(BaseModel):
     flag_name: str
-    checksum: str
-    created_at: datetime.datetime
+    kind: str
     url: AnyUrl
+    checksum: str
+
+
+class BlobSchema(CreateBlobSchema):
+    schedule_name: str | None
+    created_at: datetime.datetime

--- a/backend/src/zimfarm_backend/db/schedule.py
+++ b/backend/src/zimfarm_backend/db/schedule.py
@@ -32,6 +32,7 @@ from zimfarm_backend.common.schemas.offliners.transformers import (
 )
 from zimfarm_backend.common.schemas.orms import (
     ConfigOfflinerOnlySchema,
+    CreateBlobSchema,
     LanguageSchema,
     MostRecentTaskSchema,
     OfflinerDefinitionSchema,
@@ -438,7 +439,16 @@ def create_schedule(
 
     # Create the blobs now that we have the schedule ID
     for blob in uploaded_blobs:
-        create_or_update_blob(session, schedule_id=schedule.id, request=blob)
+        create_or_update_blob(
+            session,
+            schedule_id=schedule.id,
+            request=CreateBlobSchema(
+                kind=blob.kind,
+                flag_name=blob.flag_name,
+                url=blob.public_url,
+                checksum=blob.checksum,
+            ),
+        )
 
     return schedule
 
@@ -632,7 +642,16 @@ def update_schedule(
             prepared_blobs=prepared_blobs,
         )
         for blob in uploaded_blobs:
-            create_or_update_blob(session, schedule_id=schedule.id, request=blob)
+            create_or_update_blob(
+                session,
+                schedule_id=schedule.id,
+                request=CreateBlobSchema(
+                    kind=blob.kind,
+                    flag_name=blob.flag_name,
+                    url=blob.public_url,
+                    checksum=blob.checksum,
+                ),
+            )
 
         schedule.config = new_schedule_config.model_dump(
             mode="json", context={"show_secrets": True}

--- a/backend/tests/db/test_blob.py
+++ b/backend/tests/db/test_blob.py
@@ -5,7 +5,7 @@ from pydantic import AnyUrl
 from sqlalchemy import select
 from sqlalchemy.orm import Session as OrmSession
 
-from zimfarm_backend.common.schemas.offliners.models import PreparedBlob
+from zimfarm_backend.common.schemas.orms import CreateBlobSchema
 from zimfarm_backend.db.blob import (
     create_or_update_blob,
     delete_blob,
@@ -20,13 +20,11 @@ def test_create_schedule_blob(dbsession: OrmSession, schedule: Schedule):
     create_or_update_blob(
         dbsession,
         schedule_id=schedule.id,
-        request=PreparedBlob(
+        request=CreateBlobSchema(
             kind="css",
-            private_url=AnyUrl("https://www.example.com/style.css"),
             url=AnyUrl("https://www.example.com/style.css"),
             flag_name="custom-css",
             checksum="1",
-            data=b"hello",
         ),
     )
     dbsession.refresh(schedule)
@@ -48,13 +46,11 @@ def test_update_schedule_blob(dbsession: OrmSession, schedule: Schedule):
     create_or_update_blob(
         dbsession,
         schedule_id=schedule.id,
-        request=PreparedBlob(
+        request=CreateBlobSchema(
             kind="css",
-            private_url=AnyUrl("https://www.example.com/style2.css"),
             url=AnyUrl("https://www.example.com/style2.css"),
             flag_name="custom-css",
             checksum="1",
-            data=b"hello",
         ),
     )
     dbsession.refresh(schedule)


### PR DESCRIPTION
## Rationale
With the introduction of blob tables, old schedules will need to have their files moved to the top-level on WebDAV and information concerning it's checksum and url will need to be added to blob table. This PR adds a migration script to perform the desired functionalities.

## Changes
- fetch schedule blobs from URL, compute it's checksum, move to new name and persist new url to DB
- create entry to track schedule blob

This closes #1575
