### PR TITLE
prevent registering changes if blobs flags are the same

### DIFF
--- a/backend/src/zimfarm_backend/api/entrypoint.py
+++ b/backend/src/zimfarm_backend/api/entrypoint.py
@@ -10,6 +10,7 @@ from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 
 from zimfarm_backend.api.routes.auth.logic import router as auth_router
+from zimfarm_backend.api.routes.blobs.logic import router as blobs_router
 from zimfarm_backend.api.routes.contexts.logic import router as contexts_router
 from zimfarm_backend.api.routes.healthcheck.logic import router as healthcheck_router
 from zimfarm_backend.api.routes.http_errors import BadRequestError
@@ -75,6 +76,7 @@ def create_app(*, debug: bool = True):
     main_router.include_router(router=languages_router)
     main_router.include_router(router=platforms_router)
     main_router.include_router(router=offliners_router)
+    main_router.include_router(router=blobs_router)
     main_router.include_router(router=users_router)
     main_router.include_router(router=requested_tasks_router)
     main_router.include_router(router=workers_router)

--- a/backend/src/zimfarm_backend/api/routes/blobs/__init__.py
+++ b/backend/src/zimfarm_backend/api/routes/blobs/__init__.py
@@ -1,0 +1,3 @@
+from zimfarm_backend.api.routes.blobs.logic import router
+
+__all__ = ["router"]

--- a/backend/src/zimfarm_backend/api/routes/blobs/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/blobs/logic.py
@@ -1,0 +1,36 @@
+from typing import Annotated
+
+from fastapi import APIRouter, Depends, Path, Query
+from sqlalchemy.orm import Session as OrmSession
+
+from zimfarm_backend.api.routes.dependencies import gen_dbsession
+from zimfarm_backend.api.routes.models import ListResponse
+from zimfarm_backend.common.schemas.fields import (
+    LimitFieldMax200,
+    NotEmptyString,
+    SkipField,
+)
+from zimfarm_backend.common.schemas.models import calculate_pagination_metadata
+from zimfarm_backend.db.blob import get_blobs as db_get_blobs
+
+router = APIRouter(prefix="/blobs", tags=["blobs"])
+
+
+@router.get("/{schedule_name}")
+async def get_blobs(
+    schedule_name: Annotated[NotEmptyString, Path()],
+    session: OrmSession = Depends(gen_dbsession),
+    skip: Annotated[SkipField, Query()] = 0,
+    limit: Annotated[LimitFieldMax200, Query()] = 20,
+):
+    """Get a list of all available blobs for schedule"""
+    result = db_get_blobs(session, skip=skip, limit=limit, schedule_name=schedule_name)
+    return ListResponse(
+        items=result.blobs,
+        meta=calculate_pagination_metadata(
+            nb_records=result.nb_records,
+            skip=skip,
+            limit=limit,
+            page_size=len(result.blobs),
+        ),
+    )

--- a/backend/src/zimfarm_backend/common/schemas/fields.py
+++ b/backend/src/zimfarm_backend/common/schemas/fields.py
@@ -28,10 +28,6 @@ class GraphemeStr(str):
         return len(regex.findall(r"\X", self))
 
 
-class BlobStr(str):
-    pass
-
-
 def to_grapheme_str(value: str):
     return GraphemeStr(value)
 

--- a/backend/src/zimfarm_backend/common/schemas/offliners/serializer.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/serializer.py
@@ -175,7 +175,7 @@ def schema_to_flags(schema_class: type[BaseModel]) -> list[Flag]:
         flag_obj = Flag(
             data_key=field_alias,
             description=description,
-            key=field_alias,
+            key=field_name,
             label=capitalize_words(title),
             required=required,
             type=json_schema_extra["type"],

--- a/backend/src/zimfarm_backend/db/language.py
+++ b/backend/src/zimfarm_backend/db/language.py
@@ -1,8 +1,8 @@
 import pycountry
-from pydantic import BaseModel
 from sqlalchemy import select
 from sqlalchemy.orm import Session as OrmSession
 
+from zimfarm_backend.common.schemas import BaseModel
 from zimfarm_backend.common.schemas.models import LanguageSchema
 from zimfarm_backend.db import count_from_stmt
 from zimfarm_backend.db.exceptions import RecordDoesNotExistError

--- a/backend/src/zimfarm_backend/db/schedule.py
+++ b/backend/src/zimfarm_backend/db/schedule.py
@@ -2,8 +2,9 @@ import uuid
 from typing import Any
 from uuid import UUID
 
+import pydantic
 from psycopg.errors import UniqueViolation
-from pydantic import BaseModel, SerializeAsAny
+from pydantic import SerializeAsAny
 from sqlalchemy import Integer, func, select
 from sqlalchemy import cast as sql_cast
 from sqlalchemy.dialects.postgresql import JSONPATH, insert
@@ -18,6 +19,7 @@ from zimfarm_backend.common.enums import (
     SchedulePeriodicity,
     TaskStatus,
 )
+from zimfarm_backend.common.schemas import BaseModel
 from zimfarm_backend.common.schemas.models import (
     ScheduleConfigSchema,
     ScheduleNotificationSchema,
@@ -582,7 +584,7 @@ def process_schedule_blobs(
     *,
     prepared_blobs: list[PreparedBlob],
     schedule_id: UUID,
-    offliner: SerializeAsAny[BaseModel],
+    offliner: SerializeAsAny[pydantic.BaseModel],
 ) -> list[PreparedBlob]:
     """Upload blobs for schedule and set flag in offliner config
 

--- a/backend/tests/routes/test_blob.py
+++ b/backend/tests/routes/test_blob.py
@@ -1,0 +1,58 @@
+from http import HTTPStatus
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session as OrmSession
+
+from zimfarm_backend.db.models import Blob, Schedule
+
+
+def test_get_blobs_empty(client: TestClient):
+    response = client.get("/v2/contexts?skip=0&limit=10")
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    assert "meta" in data
+    assert "items" in data
+    assert data["meta"]["skip"] == 0
+    assert data["meta"]["limit"] == 10
+    assert data["meta"]["page_size"] == 0
+    assert data["meta"]["count"] == 0
+    assert data["items"] == []
+
+
+@pytest.mark.parametrize(
+    "skip,limit,expected_results",
+    [
+        pytest.param(0, 3, 3, id="first-page"),
+        pytest.param(3, 3, 3, id="second-page"),
+        pytest.param(0, 1, 1, id="first-page-with-low-limit"),
+        pytest.param(0, 10, 6, id="first-page-with-high-limit"),
+        pytest.param(10, 10, 0, id="page-num-too-high-no-results"),
+    ],
+)
+def test_get_blobs_pagination(
+    dbsession: OrmSession,
+    client: TestClient,
+    schedule: Schedule,
+    skip: int,
+    limit: int,
+    expected_results: int,
+):
+    for i in range(6):
+        schedule.blobs.append(
+            Blob(
+                kind="css",
+                flag_name="custom-css",
+                url=f"https://www.example.com/style{i}.css",
+                checksum=f"{i}",
+            )
+        )
+    dbsession.add(schedule)
+    dbsession.flush()
+    response = client.get(f"/v2/blobs/{schedule.name}?skip={skip}&limit={limit}")
+    assert response.status_code == HTTPStatus.OK
+    data = response.json()
+    assert data["meta"]["skip"] == skip
+    assert data["meta"]["limit"] == limit
+    assert data["meta"]["page_size"] == expected_results
+    assert len(data["items"]) == expected_results

--- a/backend/tests/test_offliner_serializer.py
+++ b/backend/tests/test_offliner_serializer.py
@@ -59,7 +59,7 @@ def test_is_secret(field: Any, *, is_secret_field: bool):
 def test_mw_offliner_schema_to_flags(mwoffliner_schema_cls: type[BaseModel]):
     flags = schema_to_flags(mwoffliner_schema_cls)
     for flag in flags:
-        key = flag.key
+        key = flag.data_key
 
         # Check if the flag is required
         if key in (

--- a/backend/tests/test_validators.py
+++ b/backend/tests/test_validators.py
@@ -3,11 +3,13 @@
 from contextlib import nullcontext as does_not_raise
 from typing import Any
 
+import pydantic
 import pytest
 from _pytest.python_api import RaisesContext
 from pydantic import ValidationError
 
 from zimfarm_backend.common.constants import parse_bool
+from zimfarm_backend.common.schemas import BaseModel
 from zimfarm_backend.common.schemas.fields import (
     CommaSeparatedZIMLangCode,
     GraphemeStr,
@@ -19,7 +21,6 @@ from zimfarm_backend.common.schemas.fields import (
     ZIMName,
     ZIMTitle,
 )
-from zimfarm_backend.common.schemas.models import BaseModel
 
 
 class ZIMFileNameModel(BaseModel):
@@ -240,7 +241,7 @@ def test_language_code_validator_skips_validation_when_context_set():
     ],
 )
 def test_ted_flags_schema(
-    ted_flags_schema_cls: type[BaseModel],
+    ted_flags_schema_cls: type[pydantic.BaseModel],
     languages: str,
     expected: RaisesContext[Exception],
 ):
@@ -323,7 +324,7 @@ def test_ted_flags_schema_skips_validation_when_context_set(
     ],
 )
 def test_ted_flags_schema_fields_exclusivity(
-    ted_flags_schema_cls: type[BaseModel],
+    ted_flags_schema_cls: type[pydantic.BaseModel],
     links: str,
     topics: str,
     playlists: str,
@@ -365,7 +366,7 @@ def test_ted_flags_schema_fields_exclusivity(
     ],
 )
 def test_ted_flags_schema_links(
-    ted_flags_schema_cls: type[BaseModel],
+    ted_flags_schema_cls: type[pydantic.BaseModel],
     links: str,
     expected: RaisesContext[Exception],
 ):

--- a/frontend-ui/src/stores/blob.ts
+++ b/frontend-ui/src/stores/blob.ts
@@ -1,0 +1,46 @@
+import { useAuthStore } from '@/stores/auth'
+import type { ListResponse, Paginator } from '@/types/base'
+import { defineStore } from 'pinia'
+import { type Blob } from '@/types/blob'
+import { ref } from 'vue'
+import type { ErrorResponse } from '@/types/errors'
+import { translateErrors } from '@/utils/errors'
+
+export const useBlobStore = defineStore('blob', () => {
+  const blobs = ref<Blob[]>([])
+  const paginator = ref<Paginator>({
+    page: 1,
+    page_size: 20,
+    skip: 0,
+    limit: 20,
+    count: 0,
+  })
+  const errors = ref<string[]>([])
+  const authStore = useAuthStore()
+
+  const fetchBlobs = async (scheduleName: string, skip: number = 0, limit: number = 100) => {
+    try {
+      const service = await authStore.getApiService('blobs')
+      const response = await service.get<null, ListResponse<Blob>>(`/${scheduleName}`, {
+        params: { limit, skip },
+      })
+      blobs.value = response.items
+      paginator.value = response.meta
+      errors.value = []
+      return blobs.value
+    } catch (_error) {
+      console.error('Failed to fetch blobs', _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+      return null
+    }
+  }
+
+  return {
+    // State
+    blobs,
+    paginator,
+    errors,
+    // Actions
+    fetchBlobs,
+  }
+})

--- a/frontend-ui/src/types/blob.ts
+++ b/frontend-ui/src/types/blob.ts
@@ -1,0 +1,8 @@
+export interface Blob {
+  flag_name: string
+  kind: string
+  url: string
+  checksum: string
+  schedule_name?: string
+  created_at: string
+}

--- a/frontend-ui/src/utils/checksum.ts
+++ b/frontend-ui/src/utils/checksum.ts
@@ -1,0 +1,34 @@
+/**
+ * Computes the SHA-256 checksum of a base64-encoded data string
+ */
+export async function computeChecksumFromBase64(base64Data: string): Promise<string> {
+  const base64Content = base64Data.includes(',') ? base64Data.split(',')[1] : base64Data
+
+  const binaryString = atob(base64Content)
+
+  // Convert binary string to Uint8Array
+  const bytes = new Uint8Array(binaryString.length)
+  for (let i = 0; i < binaryString.length; i++) {
+    bytes[i] = binaryString.charCodeAt(i)
+  }
+
+  const hashBuffer = await crypto.subtle.digest('SHA-256', bytes)
+  const hashArray = Array.from(new Uint8Array(hashBuffer))
+  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+
+  return hashHex
+}
+
+/**
+ * Computes the SHA-256 checksum of a File object
+ */
+export async function computeChecksumFromFile(file: File): Promise<string> {
+  const arrayBuffer = await file.arrayBuffer()
+  const hashBuffer = await crypto.subtle.digest('SHA-256', arrayBuffer)
+
+  // Convert hash to hex string
+  const hashArray = Array.from(new Uint8Array(hashBuffer))
+  const hashHex = hashArray.map((b) => b.toString(16).padStart(2, '0')).join('')
+
+  return hashHex
+}


### PR DESCRIPTION
## Rationale

On the UI, when a blob is added, the flag is set to the base64 string of the blob. However, sometimes, the user might be re-uploading a blob they already added or a previous version and the we detect them as changes. To prevent this, the backend exposes an endpoint to retrieve a schedules' list of blobs. This allows the UI to compute the checksum of a blob and then check if we have that checksum in our blob list to better detect if this was indeed a new blob

## Changes
- add endpoint to return a schedules' list of blobs
- compute checksum of each blob after edit on the ui
- verify if blob checksum changed and enable/disable button to update changes
- use the diff object on all other flags aside from blobs as it would always find a difference between a base64 string and a URL (which the backend sets). To mitigate this, we explicitly check the checksum of blobs.
