### PR TITLE
add support for html blob types

### DIFF
--- a/backend/maint-scripts/update_offliner_definition_blobs.py
+++ b/backend/maint-scripts/update_offliner_definition_blobs.py
@@ -11,17 +11,18 @@ from zimfarm_backend.db import Session
 from zimfarm_backend.db.models import OfflinerDefinition
 from zimfarm_backend.db.offliner_definition import create_offliner_definition_schema
 
-FLAG_MAPPINGS: dict[str, list[dict[str, Literal["image", "css"]]]] = {
+FLAG_MAPPINGS: dict[str, list[dict[str, Literal["image", "css", "html"]]]] = {
     "devdocs": [{"logo_format": "image"}],
     "freecodecamp": [{"illustration": "image"}],
     "ifixit": [{"icon": "image"}],
-    "kolibri": [{"favicon": "image"}, {"css": "css"}],
+    "kolibri": [{"favicon": "image"}, {"css": "css"}, {"about": "html"}],
     "mindtouch": [{"illustration_url": "image"}],
     "mwoffliner": [{"customZimFavicon": "image"}],
     "nautilus": [
         {"main_logo": "image"},
         {"secondary_logo": "image"},
         {"favicon": "image"},
+        {"about": "html"},
     ],
     "openedx": [{"favicon_url": "image"}],
     "sotoki": [{"favicon": "image"}],
@@ -33,7 +34,7 @@ FLAG_MAPPINGS: dict[str, list[dict[str, Literal["image", "css"]]]] = {
 def update_offliner_definition_flags(
     offliner_id: str,
     spec: OfflinerSpecSchema,
-    flag_mappings: list[dict[str, Literal["image", "css"]]],
+    flag_mappings: list[dict[str, Literal["image", "css", "html"]]],
 ) -> bool:
     """
     Update flags in an offliner definition spec to use blob type with kind.

--- a/backend/maint-scripts/update_schedule_blobs.py
+++ b/backend/maint-scripts/update_schedule_blobs.py
@@ -34,7 +34,7 @@ from zimfarm_backend.db.offliner_definition import (
 
 class BlobFlag(BaseModel):
     flag_name: str
-    kind: Literal["image", "css"]
+    kind: Literal["image", "css", "html"]
 
 
 FLAG_MAPPINGS: dict[str, list[BlobFlag]] = {

--- a/backend/src/zimfarm_backend/common/schemas/offliners/models.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/models.py
@@ -51,7 +51,7 @@ class FlagSchema(BaseFlagSchema):
         "blob",
         "color",
     ]
-    kind: Literal["image", "css"] | None = None
+    kind: Literal["image", "css", "html"] | None = None
     choices: list[str] | list[Choice] | None = None
     alias: str | None = None
     relaxed_pattern: str | None = Field(validation_alias="relaxedPattern", default=None)

--- a/backend/src/zimfarm_backend/common/schemas/offliners/transformers.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/transformers.py
@@ -130,6 +130,8 @@ def get_extension_from_kind(kind: str) -> str:
         return ".css"
     elif kind == "image":
         return ".png"
+    elif kind == "html":
+        return ".html"
     return ".bin"
 
 

--- a/frontend-ui/src/components/TextEditorDialog.vue
+++ b/frontend-ui/src/components/TextEditorDialog.vue
@@ -2,8 +2,8 @@
   <v-dialog v-model="isOpen" max-width="600" persistent scrollable>
     <v-card>
       <v-card-title class="text-h6 bg-primary">
-        <v-icon class="mr-2">mdi-language-css3</v-icon>
-        Edit CSS File
+        <v-icon class="mr-2">{{ iconName }}</v-icon>
+        Edit {{ fileTypeLabel }} File
         <v-spacer />
         <v-btn icon="mdi-close" variant="text" @click="handleCancel" size="small" />
       </v-card-title>
@@ -14,7 +14,7 @@
           variant="outlined"
           auto-grow
           :rows="20"
-          placeholder="Enter your CSS code here..."
+          :placeholder="`Enter your ${fileTypeLabel} code here...`"
           hide-details
           spellcheck="false"
         />
@@ -37,16 +37,18 @@
 </template>
 
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { ref, watch, computed } from 'vue'
 
 interface Props {
   modelValue: boolean
-  cssContent: string
+  textContent: string
+  fileType?: 'css' | 'html'
   loading?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   loading: false,
+  fileType: 'css',
 })
 
 const emit = defineEmits<{
@@ -56,8 +58,30 @@ const emit = defineEmits<{
 }>()
 
 const isOpen = ref(props.modelValue)
-const editedContent = ref(props.cssContent)
+const editedContent = ref(props.textContent)
 const errorMessage = ref('')
+
+const iconName = computed(() => {
+  switch (props.fileType) {
+    case 'html':
+      return 'mdi-language-html5'
+    case 'css':
+      return 'mdi-language-css3'
+    default:
+      return 'mdi-file-document-outline'
+  }
+})
+
+const fileTypeLabel = computed(() => {
+  switch (props.fileType) {
+    case 'html':
+      return 'HTML'
+    case 'css':
+      return 'CSS'
+    default:
+      return 'Text'
+  }
+})
 
 // Watch for prop changes
 watch(
@@ -66,14 +90,14 @@ watch(
     isOpen.value = newValue
     if (newValue) {
       // Reset content when dialog opens
-      editedContent.value = props.cssContent
+      editedContent.value = props.textContent
       errorMessage.value = ''
     }
   },
 )
 
 watch(
-  () => props.cssContent,
+  () => props.textContent,
   (newValue) => {
     if (isOpen.value) {
       editedContent.value = newValue

--- a/frontend-ui/src/views/ScheduleDetailView.vue
+++ b/frontend-ui/src/views/ScheduleDetailView.vue
@@ -1085,6 +1085,13 @@ const updateSchedule = async (update: ScheduleUpdateSchema) => {
         }
       }
     }
+
+    // Refresh blobs after updating schedule
+    const scheduleName = update.name || props.scheduleName
+    const blobsResponse = await blobStore.fetchBlobs(scheduleName)
+    if (blobsResponse) {
+      blobs.value = blobsResponse
+    }
   } else {
     for (const error of scheduleStore.errors) {
       notificationStore.showError(error)


### PR DESCRIPTION
## Rationale
This PR adds support html for documents as a blob. It enhances the UI to upload html types from clipboard, drag/drop and upload.

## Changes
- add `html` as one of the accepted blob kinds
- update script to update existing blobs to modify html types for specific offliners
- rename csseditor to texteditor to allow for generic editing of text documents
- refresh schedule blob versions after updating schedule

This closes #1574 