### PR TITLE
add support for txt blobs

### DIFF
--- a/backend/maint-scripts/update_schedule_blobs.py
+++ b/backend/maint-scripts/update_schedule_blobs.py
@@ -34,7 +34,7 @@ from zimfarm_backend.db.offliner_definition import (
 
 class BlobFlag(BaseModel):
     flag_name: str
-    kind: Literal["image", "css", "html"]
+    kind: Literal["image", "css", "html", "txt"]
 
 
 FLAG_MAPPINGS: dict[str, list[BlobFlag]] = {
@@ -46,7 +46,11 @@ FLAG_MAPPINGS: dict[str, list[BlobFlag]] = {
         BlobFlag(flag_name="css", kind="css"),
     ],
     "mindtouch": [BlobFlag(flag_name="illustration_url", kind="image")],
-    "mwoffliner": [BlobFlag(flag_name="customZimFavicon", kind="image")],
+    "mwoffliner": [
+        BlobFlag(flag_name="customZimFavicon", kind="image"),
+        BlobFlag(flag_name="articleList", kind="txt"),
+        BlobFlag(flag_name="articleListToIgnore", kind="txt"),
+    ],
     "nautilus": [
         BlobFlag(flag_name="main_logo", kind="image"),
         BlobFlag(flag_name="secondary_logo", kind="image"),

--- a/backend/src/zimfarm_backend/common/schemas/offliners/models.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/models.py
@@ -51,7 +51,7 @@ class FlagSchema(BaseFlagSchema):
         "blob",
         "color",
     ]
-    kind: Literal["image", "css", "html"] | None = None
+    kind: Literal["image", "css", "html", "txt"] | None = None
     choices: list[str] | list[Choice] | None = None
     alias: str | None = None
     relaxed_pattern: str | None = Field(validation_alias="relaxedPattern", default=None)

--- a/backend/src/zimfarm_backend/common/schemas/offliners/transformers.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/transformers.py
@@ -132,6 +132,8 @@ def get_extension_from_kind(kind: str) -> str:
         return ".png"
     elif kind == "html":
         return ".html"
+    elif kind == "txt":
+        return ".txt"
     return ".bin"
 
 

--- a/backend/tests/test_transformers.py
+++ b/backend/tests/test_transformers.py
@@ -18,6 +18,7 @@ from zimfarm_backend.common.schemas.offliners.models import (
     TransformerSchema,
 )
 from zimfarm_backend.common.schemas.offliners.transformers import (
+    get_extension_from_kind,
     process_blob_fields,
     transform_data,
 )
@@ -297,3 +298,17 @@ def test_process_blob_field(monkeypatch: MonkeyPatch):
     processed_blobs = process_blob_fields(instance, spec)
     assert len(processed_blobs) == 1
     assert str(processed_blobs[0].public_url).startswith("http://blob-storage.com")
+
+
+@pytest.mark.parametrize(
+    "kind,expected_kind",
+    [
+        ("css", ".css"),
+        ("image", ".png"),
+        ("html", ".html"),
+        ("txt", ".txt"),
+        ("zip", ".bin"),
+    ],
+)
+def test_get_extension_from_kind(kind: str, expected_kind: str):
+    assert get_extension_from_kind(kind) == expected_kind

--- a/frontend-ui/src/components/ScheduleEditor.vue
+++ b/frontend-ui/src/components/ScheduleEditor.vue
@@ -1287,6 +1287,7 @@ const handleReset = () => {
   if (props.schedule) {
     editSchedule.value = JSON.parse(JSON.stringify(props.schedule))
     editFlags.value = JSON.parse(JSON.stringify(props.schedule.config.offliner))
+    blobChecksums.value = {}
     // reset the flags and fields
     handleOfflinerVersionChange(props.schedule.config.offliner.offliner_id, props.schedule.version)
   }

--- a/frontend-ui/src/components/TextEditorDialog.vue
+++ b/frontend-ui/src/components/TextEditorDialog.vue
@@ -42,7 +42,7 @@ import { ref, watch, computed } from 'vue'
 interface Props {
   modelValue: boolean
   textContent: string
-  fileType?: 'css' | 'html'
+  fileType?: 'css' | 'html' | 'txt'
   loading?: boolean
 }
 
@@ -67,6 +67,8 @@ const iconName = computed(() => {
       return 'mdi-language-html5'
     case 'css':
       return 'mdi-language-css3'
+    case 'txt':
+      return 'mdi-file-document-outline'
     default:
       return 'mdi-file-document-outline'
   }
@@ -78,6 +80,8 @@ const fileTypeLabel = computed(() => {
       return 'HTML'
     case 'css':
       return 'CSS'
+    case 'txt':
+      return 'Text'
     default:
       return 'Text'
   }


### PR DESCRIPTION
## Rationale
This PR adds the support for editing/uploading txt blobs from the schedule editor
## Changes
- add support for blobs of `txt` kind
- fix issue with reset button not clearing blob editor state

This closes #1598 