### PR TITLE
show selfish status of worker

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -360,6 +360,7 @@ class BaseWorkerSchema(BaseModel):
     admin_disabled: bool
     contexts: dict[str, IPv4Address | IPv6Address | None]
     last_ip: IPv4Address | None = Field(exclude=True)
+    selfish: bool
 
     @computed_field
     @property

--- a/backend/src/zimfarm_backend/db/worker.py
+++ b/backend/src/zimfarm_backend/db/worker.py
@@ -68,6 +68,7 @@ def create_worker_schema(
         show_secrets=show_secrets,
         last_ip=worker.last_ip,
         last_seen=worker.last_seen,
+        selfish=worker.selfish,
         name=worker.name,
         offliners=worker.offliners,
         resources=ConfigResourcesSchema(
@@ -167,6 +168,7 @@ def get_worker_metrics(
     return WorkerMetricsSchema(
         name=worker.name,
         last_ip=worker.last_ip,
+        selfish=worker.selfish,
         last_seen=worker.last_seen,
         username=worker.user.username,
         resources=ConfigResourcesSchema(

--- a/backend/tests/db/test_worker.py
+++ b/backend/tests/db/test_worker.py
@@ -273,5 +273,6 @@ def test_worker_ip_changed(
         admin_disabled=False,
         contexts=contexts,
         last_ip=last_ip,
+        selfish=False,
     )
     assert worker.ip_changed is ip_changed

--- a/frontend-ui/src/components/WorkersTable.vue
+++ b/frontend-ui/src/components/WorkersTable.vue
@@ -112,6 +112,17 @@
               >
                 Disabled by Zimfarm Administrator
               </v-chip>
+
+              <!-- Selfish worker status -->
+              <v-chip
+                v-if="item.selfish"
+                color="warning"
+                size="x-small"
+                variant="tonal"
+                prepend-icon="mdi-account-lock"
+              >
+                Selfish
+              </v-chip>
             </div>
           </template>
           <template v-else>

--- a/frontend-ui/src/types/workers.ts
+++ b/frontend-ui/src/types/workers.ts
@@ -11,6 +11,7 @@ interface BaseWorker {
   contexts: Record<string, string | null>
   last_ip?: string
   ip_changed: boolean
+  selfish: boolean
 }
 
 export interface Worker extends BaseWorker {

--- a/frontend-ui/src/views/WorkerDetailView.vue
+++ b/frontend-ui/src/views/WorkerDetailView.vue
@@ -35,6 +35,17 @@
           >
             Disabled by Zimfarm Administrator
           </v-chip>
+
+          <!-- Selfish worker status -->
+          <v-chip
+            v-if="worker?.selfish"
+            color="warning"
+            size="small"
+            variant="tonal"
+            prepend-icon="mdi-account-lock"
+          >
+            Selfish
+          </v-chip>
         </div>
       </v-col>
     </v-row>


### PR DESCRIPTION
## Rationale
This PR returns information regarding selfish status of worker and displays them on the UI

<img width="848" height="149" alt="Screenshot_20251221_165608" src="https://github.com/user-attachments/assets/66c9a0b4-0e3f-4c40-957f-b789f7170bde" />

<img width="617" height="166" alt="Screenshot_20251221_165542" src="https://github.com/user-attachments/assets/6d88284d-0d10-47fa-ad3f-df0c2f96c52b" />


## Changes

- return `selfish` status of worker from API
- display `selfish` status in UI

This closes #1603 