### PR TITLE
show illustrations in white background/foreground

### DIFF
--- a/dev/.gitignore
+++ b/dev/.gitignore
@@ -1,0 +1,2 @@
+# Local compose overrides
+docker-compose.override.yml

--- a/frontend-ui/src/components/ImageEditorDialog.vue
+++ b/frontend-ui/src/components/ImageEditorDialog.vue
@@ -94,6 +94,8 @@
             }"
             :default-size="defaultSize"
             image-restriction="fit-area"
+            backgroundClass="cropper-background"
+            foregroundClass="cropper-foreground"
             class="cropper"
             @change="handleCropperChange"
           />
@@ -352,7 +354,6 @@ const handleCancel = () => {
   width: 100%;
   height: 600px;
   max-height: 70vh;
-  background-color: #f5f5f5;
   border-radius: 4px;
   overflow: hidden;
 }
@@ -374,5 +375,13 @@ const handleCancel = () => {
 .cropper :deep(.vue-simple-handler) {
   background: rgb(var(--v-theme-primary));
   border-color: rgb(var(--v-theme-primary));
+}
+
+:deep(.cropper-background) {
+  background: white;
+}
+
+:deep(.cropper-foreground) {
+  background: white;
 }
 </style>


### PR DESCRIPTION
## Rationale
This PR shows the illustrations in white background and foreground allowing opposite colors to show properly. This seems to be an [issue on vue-advanced-cropper](https://github.com/advanced-cropper/vue-advanced-cropper/issues/56)

## Changes
- change background and foreground color of canvas to white
- add `.gitignore` file for devs to provide their own override files with different port mappings

<img width="1121" height="863" alt="Screenshot_20251223_111047" src="https://github.com/user-attachments/assets/089f9ef1-d99e-43be-8692-340de0b9dd6a" />



This fixes #1607 
