### PR TITLE
preview blob flags in ui

### DIFF
--- a/frontend-ui/src/components/BlobViewer.vue
+++ b/frontend-ui/src/components/BlobViewer.vue
@@ -1,0 +1,170 @@
+<template>
+  <v-btn
+    icon="mdi-eye"
+    size="x-small"
+    variant="text"
+    color="primary"
+    @click="handleView"
+    :title="`View ${kind === 'image' ? 'Image' : kind.toUpperCase()}`"
+    :loading="loadingBlobContent"
+  />
+
+  <!-- Image Viewer Dialog -->
+  <v-dialog v-if="kind === 'image'" v-model="showViewer" max-width="600">
+    <v-card>
+      <v-card-title class="d-flex justify-space-between align-center">
+        <span>View Image</span>
+        <v-btn icon="mdi-close" variant="text" @click="handleClose" />
+      </v-card-title>
+      <v-card-text>
+        <v-progress-circular v-if="loadingBlobContent" indeterminate />
+        <v-img
+          v-else-if="blobContent"
+          :src="blobContent"
+          max-height="70vh"
+          contain
+          alt="Blob image"
+        />
+        <div v-else class="text-error">Failed to load image</div>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn color="primary" variant="text" @click="handleClose">Close</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+
+  <!-- Text Viewer Dialog -->
+  <v-dialog v-if="isTextKind" v-model="showViewer" max-width="600px">
+    <v-card>
+      <v-card-title class="d-flex justify-space-between align-center">
+        <span>View {{ kind === 'txt' ? 'Text' : kind.toUpperCase() }}</span>
+        <v-btn icon="mdi-close" variant="text" @click="handleClose" />
+      </v-card-title>
+      <v-card-text>
+        <v-progress-circular v-if="loadingBlobContent" indeterminate />
+        <div v-else-if="blobContent">
+          <v-textarea
+            :model-value="blobContent"
+            readonly
+            variant="outlined"
+            auto-grow
+            rows="15"
+            :class="textFileClass"
+          />
+        </div>
+        <div v-else class="text-error">Failed to load content</div>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn color="primary" variant="text" @click="handleClose">Close</v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import { useNotificationStore } from '@/stores/notification'
+
+const TEXT_KINDS = ['css', 'html', 'txt'] as const
+
+const notificationStore = useNotificationStore()
+
+interface Props {
+  blobValue: string
+  kind?: 'image' | 'css' | 'html' | 'txt'
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  kind: 'txt',
+})
+
+const showViewer = ref(false)
+const blobContent = ref('')
+const loadingBlobContent = ref(false)
+
+const isTextKind = computed(() => TEXT_KINDS.includes(props.kind as (typeof TEXT_KINDS)[number]))
+
+const textFileClass = computed(() => {
+  if (props.kind === 'css') return 'language-css'
+  if (props.kind === 'html') return 'language-html'
+  return ''
+})
+
+const fetchBlobByUrl = async (url: string): Promise<Blob | null> => {
+  const response = await fetch(url)
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`)
+  }
+  return await response.blob()
+}
+
+const handleViewImage = async () => {
+  if (!props.blobValue) return
+
+  loadingBlobContent.value = true
+  blobContent.value = ''
+
+  try {
+    const blob = await fetchBlobByUrl(props.blobValue)
+    if (!blob) {
+      throw new Error('Failed to fetch blob content')
+    }
+    const reader = new FileReader()
+    blobContent.value = await new Promise((resolve, reject) => {
+      reader.onload = () => resolve(reader.result as string)
+      reader.onerror = reject
+      reader.readAsDataURL(blob)
+    })
+
+    showViewer.value = true
+  } catch (error) {
+    console.error('Failed to load image content:', error)
+    notificationStore.showError('There was a network error while loading image')
+  } finally {
+    loadingBlobContent.value = false
+  }
+}
+
+const handleViewText = async () => {
+  if (!props.blobValue) return
+
+  loadingBlobContent.value = true
+  blobContent.value = ''
+
+  try {
+    const blob = await fetchBlobByUrl(props.blobValue)
+    if (!blob) {
+      throw new Error('Failed to fetch blob content')
+    }
+    blobContent.value = await blob.text()
+
+    showViewer.value = true
+  } catch (error) {
+    console.error('Failed to load text content:', error)
+    notificationStore.showError('There was a network error while loading text content')
+  } finally {
+    loadingBlobContent.value = false
+  }
+}
+
+const handleView = () => {
+  if (props.kind === 'image') {
+    handleViewImage()
+  } else if (isTextKind.value) {
+    handleViewText()
+  }
+}
+
+const handleClose = () => {
+  showViewer.value = false
+}
+</script>
+
+<style scoped>
+.language-css,
+.language-html {
+  font-family: monospace;
+}
+</style>

--- a/frontend-ui/src/components/FlagsList.vue
+++ b/frontend-ui/src/components/FlagsList.vue
@@ -6,7 +6,14 @@
           <code class="text-pink-accent-2">{{ name }}</code>
         </td>
         <td>
-          <span>{{ value }}</span>
+          <div class="d-flex align-center ga-2">
+            <span>{{ value }}</span>
+            <BlobViewer
+              v-if="getBlobField(name)"
+              :blob-value="String(value)"
+              :kind="getBlobField(name)!.kind || 'image'"
+            />
+          </div>
         </td>
       </tr>
     </tbody>
@@ -15,17 +22,19 @@
 
 <script setup lang="ts">
 import type { OfflinerFlags } from '@/types/schedule'
+import type { OfflinerDefinition } from '@/types/offliner'
 import { computed } from 'vue'
+import BlobViewer from '@/components/BlobViewer.vue'
 
 interface Props {
   offliner: OfflinerFlags
   shrink?: boolean
-  secretFields?: string[]
+  flagsDefinition?: OfflinerDefinition[]
 }
 
 const props = withDefaults(defineProps<Props>(), {
   shrink: false,
-  secretFields: () => [],
+  flagsDefinition: () => [],
 })
 
 const filteredOffliner = computed(() => {
@@ -48,6 +57,14 @@ const filteredOffliner = computed(() => {
 
   return sortedResult
 })
+
+const getBlobField = (fieldName: string) => {
+  if (!props.flagsDefinition || props.flagsDefinition.length === 0) {
+    return null
+  }
+  const field = props.flagsDefinition.find((f) => f.data_key === fieldName)
+  return field?.type === 'blob' ? field : null
+}
 </script>
 
 <style scoped>

--- a/frontend-ui/src/components/ScheduleEditor.vue
+++ b/frontend-ui/src/components/ScheduleEditor.vue
@@ -595,7 +595,7 @@ interface FlagField {
   min_length: number | null
   max_length: number | null
   pattern: string | null
-  kind?: 'image' | 'css'
+  kind?: 'image' | 'css' | 'html' | 'txt'
 }
 
 export interface Props {

--- a/frontend-ui/src/types/offliner.ts
+++ b/frontend-ui/src/types/offliner.ts
@@ -17,7 +17,7 @@ export interface OfflinerDefinition {
   min_length: number | null
   max_length: number | null
   pattern: string | null
-  kind?: 'image' | 'css'
+  kind?: 'image' | 'css' | 'html' | 'txt'
 }
 
 export interface OfflinerDefinitionResponse {

--- a/frontend-ui/src/views/ScheduleDetailView.vue
+++ b/frontend-ui/src/views/ScheduleDetailView.vue
@@ -522,7 +522,7 @@
                   <tr>
                     <th class="text-left pa-4 align-top">Config</th>
                     <td>
-                      <FlagsList :offliner="config.offliner" :secret-fields="secretFields" />
+                      <FlagsList :offliner="config.offliner" :flags-definition="flagsDefinition" />
                     </td>
                   </tr>
                   <tr>
@@ -712,7 +712,6 @@ import {
   buildDockerCommand,
   buildScheduleDuration,
   buildTotalDurationDict,
-  getSecretFields,
   imageHuman as imageHumanFn,
   imageUrl as imageUrlFn,
 } from '@/utils/offliner'
@@ -798,7 +797,6 @@ const platform = computed(() => config.value?.platform || '')
 const warehousePath = computed(() => config.value?.warehouse_path || '')
 const imageHuman = computed(() => imageHumanFn(config.value))
 const imageUrl = computed(() => imageUrlFn(config.value))
-const secretFields = computed(() => getSecretFields(flagsDefinition.value))
 const command = computed(() => buildDockerCommand(schedule.value?.name || '', config.value))
 const offlinerCommand = computed(() => buildCommandWithout(config.value))
 const scheduleDurationDict = computed(() => {

--- a/frontend-ui/src/views/TaskDetailView.vue
+++ b/frontend-ui/src/views/TaskDetailView.vue
@@ -302,7 +302,7 @@
                     <td>
                       <FlagsList
                         :offliner="task.config.offliner"
-                        :secret-fields="secretFields"
+                        :flags-definition="flagsDefinition"
                         :shrink="false"
                       />
                     </td>
@@ -494,7 +494,6 @@ import {
 import {
   artifactsUrl,
   checkUrl,
-  getSecretFields,
   imageHuman as imageHumanFn,
   imageUrl as imageUrlFn,
   logsUrl,
@@ -556,8 +555,6 @@ const taskContainer = computed(() => {
 const taskProgress = computed(() => {
   return taskContainer.value?.progress || null
 })
-
-const secretFields = computed(() => getSecretFields(flagsDefinition.value))
 
 const taskDebug = computed(() => {
   return task.value?.debug || {}
@@ -741,7 +738,7 @@ const refreshData = async () => {
 
 // Lifecycle
 onMounted(async () => {
-  refreshData()
+  await refreshData()
   if (task.value) {
     const offlinerDefinition = await offlinerStore.fetchOfflinerDefinitionByVersion(
       task.value.offliner,


### PR DESCRIPTION
## Rationale
This PR adds support to preview flags which are blobs from the task detail and schedule config views.

## Changes
- add component `BlobViewer` which displays images/texts. Texts are shown in textarea while images are shown in image tags.
- update `FlagsList` component to use flags definition in order to determine which flags are blobs
- remove unused `secretFields` props from FlagsList as backend already hides secret fields if user doesn't have correct privileges
<img width="1037" height="855" alt="Screenshot_20260107_132856" src="https://github.com/user-attachments/assets/900dcb07-47b6-4cb0-93e7-3c79a16b95a9" />
<img width="1530" height="518" alt="Screenshot_20260107_132844" src="https://github.com/user-attachments/assets/0b4187e1-7945-4d5d-9605-17dc8bad8f66" />


This closes #1583 