### PR TITLE
Persist page number in route history

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/platforms/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/platforms/logic.py
@@ -2,7 +2,7 @@ from fastapi import APIRouter
 
 from zimfarm_backend.api.routes.models import ListResponse
 from zimfarm_backend.common.enums import Platform
-from zimfarm_backend.common.schemas.models import Paginator
+from zimfarm_backend.common.schemas.models import calculate_pagination_metadata
 
 router = APIRouter(prefix="/platforms", tags=["platforms"])
 
@@ -12,8 +12,8 @@ async def get_platforms():
     """Get a list of supported platforms."""
     platforms = Platform.all()
     return ListResponse[Platform](
-        meta=Paginator(
-            skip=0, limit=100, nb_records=len(platforms), page_size=len(platforms)
+        meta=calculate_pagination_metadata(
+            nb_records=len(platforms), skip=0, limit=100, page_size=len(platforms)
         ),
         items=platforms,
     )

--- a/backend/src/zimfarm_backend/common/schemas/models.py
+++ b/backend/src/zimfarm_backend/common/schemas/models.py
@@ -1,4 +1,5 @@
 import datetime
+import math
 import pathlib
 import re
 from typing import Any
@@ -94,6 +95,7 @@ class Paginator(BaseModel):
     skip: int
     limit: int
     page_size: int
+    page: int
 
 
 def calculate_pagination_metadata(
@@ -103,18 +105,21 @@ def calculate_pagination_metadata(
     limit: int,
     page_size: int,
 ) -> Paginator:
+    page = math.floor(skip / limit) + 1 if limit > 0 else 1
     if nb_records == 0:
         return Paginator(
             nb_records=0,
             skip=skip,
             limit=limit,
             page_size=0,
+            page=page,
         )
     return Paginator(
         nb_records=nb_records,
         skip=skip,
         limit=limit,
         page_size=min(page_size, nb_records),
+        page=page,
     )
 
 

--- a/frontend-ui/src/components/ScheduleEditor.vue
+++ b/frontend-ui/src/components/ScheduleEditor.vue
@@ -1229,7 +1229,6 @@ const handleSubmit = async () => {
 
   // Fetch similar recipes count before showing confirmation dialog
   await fetchSimilarRecipesCount()
-  console.log('similarRecipesCount', similarRecipesCount.value)
 
   // Show confirmation dialog instead of directly submitting
   showConfirmDialog.value = true

--- a/frontend-ui/src/components/SchedulesFilter.vue
+++ b/frontend-ui/src/components/SchedulesFilter.vue
@@ -113,7 +113,6 @@ watch(
       tags: [...newFilters.tags],
     }
   },
-  { deep: true },
 )
 
 // Computed properties for select options

--- a/frontend-ui/src/stores/requestedTasks.ts
+++ b/frontend-ui/src/stores/requestedTasks.ts
@@ -14,13 +14,13 @@ import type { VueCookies } from 'vue-cookies'
 
 export const useRequestedTasksStore = defineStore('requestedTasks', () => {
   const $cookies = inject<VueCookies>('$cookies')
-  const limit = Number($cookies?.get('requested-tasks-table-limit') || 20)
+  const defaultLimit = ref<number>(Number($cookies?.get('requested-tasks-table-limit') || 20))
   const requestedTasks = ref<RequestedTaskLight[]>([])
   const paginator = ref<Paginator>({
     page: 1,
-    page_size: limit,
+    page_size: defaultLimit.value,
     skip: 0,
-    limit: limit,
+    limit: defaultLimit.value,
     count: 0,
   })
 
@@ -137,6 +137,7 @@ export const useRequestedTasksStore = defineStore('requestedTasks', () => {
     requestedTasks,
     errors,
     paginator,
+    defaultLimit,
     // Actions
     fetchRequestedTasks,
     removeRequestedTask,

--- a/frontend-ui/src/stores/schedule.ts
+++ b/frontend-ui/src/stores/schedule.ts
@@ -13,12 +13,12 @@ export const useScheduleStore = defineStore('schedule', () => {
   const schedule = ref<Schedule | null>(null)
   const errors = ref<string[]>([])
   const schedules = ref<ScheduleLight[]>([])
-  const limit = Number($cookies?.get('schedules-table-limit') || 20)
+  const defaultLimit = ref<number>(Number($cookies?.get('schedules-table-limit') || 20))
   const paginator = ref<Paginator>({
     page: 1,
-    page_size: limit,
+    page_size: defaultLimit.value,
     skip: 0,
-    limit: limit,
+    limit: defaultLimit.value,
     count: 0,
   })
   const authStore = useAuthStore()
@@ -249,6 +249,7 @@ export const useScheduleStore = defineStore('schedule', () => {
 
   return {
     // State
+    defaultLimit,
     schedule,
     schedules,
     paginator,

--- a/frontend-ui/src/stores/tasks.ts
+++ b/frontend-ui/src/stores/tasks.ts
@@ -12,12 +12,12 @@ export const useTasksStore = defineStore('tasks', () => {
   const $cookies = inject<VueCookies>('$cookies')
   const task = ref<Task | null>(null)
   const tasks = ref<TaskLight[]>([])
-  const limit = Number($cookies?.get('tasks-table-limit') || 20)
+  const defaultLimit = ref<number>(Number($cookies?.get('tasks-table-limit') || 20))
   const paginator = ref<Paginator>({
     page: 1,
-    page_size: limit,
+    page_size: defaultLimit.value,
     skip: 0,
-    limit: limit,
+    limit: defaultLimit.value,
     count: 0,
   })
   const errors = ref<string[]>([])
@@ -94,7 +94,7 @@ export const useTasksStore = defineStore('tasks', () => {
     tasks,
     paginator,
     errors,
-
+    defaultLimit,
     // Actions
     fetchTasks,
     cancelTask,

--- a/frontend-ui/src/stores/user.ts
+++ b/frontend-ui/src/stores/user.ts
@@ -10,14 +10,14 @@ import type { VueCookies } from 'vue-cookies'
 
 export const useUserStore = defineStore('user', () => {
   const $cookies = inject<VueCookies>('$cookies')
-  const limit = Number($cookies?.get('users-table-limit') || 20)
+  const defaultLimit = ref<number>(Number($cookies?.get('users-table-limit') || 20))
   const errors = ref<string[]>([])
   const users = ref<User[]>([])
   const paginator = ref<Paginator>({
     page: 1,
-    page_size: limit,
+    page_size: defaultLimit.value,
     skip: 0,
-    limit: limit,
+    limit: defaultLimit.value,
     count: 0,
   })
 
@@ -168,6 +168,7 @@ export const useUserStore = defineStore('user', () => {
     // State
     errors,
     users,
+    defaultLimit,
     paginator,
 
     // Actions

--- a/frontend-ui/src/stores/workers.ts
+++ b/frontend-ui/src/stores/workers.ts
@@ -13,12 +13,12 @@ export const useWorkersStore = defineStore('workers', () => {
   const $cookies = inject<VueCookies>('$cookies')
   const workers = ref<Worker[]>([])
   const errors = ref<string[]>([])
-  const limit = Number($cookies?.get('workers-table-limit') || 20)
+  const defaultLimit = ref<number>(Number($cookies?.get('workers-table-limit') || 20))
   const paginator = ref<Paginator>({
     page: 1,
-    page_size: limit,
+    page_size: defaultLimit.value,
     skip: 0,
-    limit: limit,
+    limit: defaultLimit.value,
     count: 0,
   })
 
@@ -96,6 +96,7 @@ export const useWorkersStore = defineStore('workers', () => {
     // State
     workers,
     errors,
+    defaultLimit,
     paginator,
 
     // Actions


### PR DESCRIPTION
## Rationale
This PR persists the page number in history allowing the user to return to a previous page number

## Changes
- return current page number in pagination metadata (used by frontend `Paginator` model)
- decouple schedulesview paginator from the schedule store paginator
- modify vuetify's server-side tables to mutate query parameters instead of emitting event to load data
- adapt function to load filters from url to set correct paginator value
- adapt filter change events to reset paginator skip value to 0. This ensures that anytime we change a filter, we always get the entries starting from page 0
- load data in route watcher

This closes #1609 
