### PR TITLE
adapt offliner definition blobs from image to illustration

### DIFF
--- a/backend/maint-scripts/update_offliner_definition_blobs.py
+++ b/backend/maint-scripts/update_offliner_definition_blobs.py
@@ -15,21 +15,21 @@ FLAG_MAPPINGS: dict[
     str, list[dict[str, Literal["image", "css", "html", "illustration"]]]
 ] = {
     "devdocs": [{"logo_format": "image"}],
-    "freecodecamp": [{"illustration": "image"}],
-    "ifixit": [{"icon": "image"}],
-    "kolibri": [{"favicon": "image"}, {"css": "css"}, {"about": "html"}],
-    "mindtouch": [{"illustration_url": "image"}],
+    "freecodecamp": [{"illustration": "illustration"}],
+    "ifixit": [{"icon": "illustration"}],
+    "kolibri": [{"favicon": "illustration"}, {"css": "css"}, {"about": "html"}],
+    "mindtouch": [{"illustration_url": "illustration"}],
     "mwoffliner": [{"customZimFavicon": "illustration"}],
     "nautilus": [
         {"main_logo": "image"},
         {"secondary_logo": "image"},
-        {"favicon": "image"},
+        {"favicon": "illustration"},
         {"about": "html"},
     ],
-    "openedx": [{"favicon_url": "image"}],
-    "sotoki": [{"favicon": "image"}],
+    "openedx": [{"favicon_url": "illustration"}],
+    "sotoki": [{"favicon": "illustration"}],
     "youtube": [{"profile": "image"}, {"banner": "image"}],
-    "zimit": [{"favicon": "image"}, {"custom_css": "css"}],
+    "zimit": [{"favicon": "illustration"}, {"custom_css": "css"}],
 }
 
 


### PR DESCRIPTION
## Rationale
This PR updates the script responsible for changing the blob type of offliners from `image` to `illustration`. The following offliner definition flags are changed from image to illustration.
| offliner     | flag             |
|--------------|------------------|
| freecodecamp | illustration     |
| ifixit       | icon             |
| kolibri      | favicon          |
| mindtouch    | illustration_url |
| nautilus     | favicon          |
| openedx      | favicon_url      |
| sotoki       | favicon          |
| zimit        | favicon          |
