### PR TITLE
keep resource badges in flex box

### DIFF
--- a/frontend-ui/src/components/WorkersTable.vue
+++ b/frontend-ui/src/components/WorkersTable.vue
@@ -83,7 +83,6 @@
                 'py-1',
                 'flex-wrap',
                 'flex-row',
-                'flex-md-column',
                 { 'justify-end': smAndDown },
               ]"
             >

--- a/frontend-ui/src/views/ScheduleDetailView.vue
+++ b/frontend-ui/src/views/ScheduleDetailView.vue
@@ -583,24 +583,26 @@
                     <div class="text-subtitle-2">Resources</div>
                   </v-col>
                   <v-col cols="12" md="8">
-                    <ResourceBadge kind="cpu" :value="config.resources.cpu" />
-                    <ResourceBadge kind="memory" :value="config.resources.memory" />
-                    <ResourceBadge kind="disk" :value="config.resources.disk" />
-                    <ResourceBadge
-                      kind="shm"
-                      :value="config.resources.shm"
-                      v-if="config.resources.shm"
-                    />
-                    <v-chip
-                      v-if="config.monitor || false"
-                      size="small"
-                      color="warning"
-                      variant="tonal"
-                      class="ml-2"
-                    >
-                      <v-icon size="small" class="mr-1">mdi-bug</v-icon>
-                      monitored
-                    </v-chip>
+                    <div class="d-flex flex-row flex-wrap ga-1">
+                      <ResourceBadge kind="cpu" :value="config.resources.cpu" />
+                      <ResourceBadge kind="memory" :value="config.resources.memory" />
+                      <ResourceBadge kind="disk" :value="config.resources.disk" />
+                      <ResourceBadge
+                        kind="shm"
+                        :value="config.resources.shm"
+                        v-if="config.resources.shm"
+                      />
+                      <v-chip
+                        v-if="config.monitor || false"
+                        size="small"
+                        color="warning"
+                        variant="tonal"
+                        class="ml-2"
+                      >
+                        <v-icon size="small" class="mr-1">mdi-bug</v-icon>
+                        monitored
+                      </v-chip>
+                    </div>
                   </v-col>
                 </v-row>
                 <v-divider class="my-2"></v-divider>

--- a/frontend-ui/src/views/TaskDetailView.vue
+++ b/frontend-ui/src/views/TaskDetailView.vue
@@ -330,20 +330,22 @@
                     <div class="text-subtitle-2">Resources</div>
                   </v-col>
                   <v-col cols="12" md="9">
-                    <ResourceBadge kind="cpu" :value="task.config.resources.cpu" />
-                    <ResourceBadge kind="memory" :value="task.config.resources.memory" />
-                    <ResourceBadge kind="disk" :value="task.config.resources.disk" />
-                    <ResourceBadge
-                      kind="shm"
-                      :value="task.config.resources.shm"
-                      v-if="task.config.resources.shm"
-                    />
-                    <v-chip v-if="task.config.monitor" color="warning" size="small" class="ml-2">
-                      <a target="_blank" :href="monitoringUrl" class="text-decoration-none">
-                        <v-icon size="small" class="mr-1">mdi-bug</v-icon>
-                        monitored
-                      </a>
-                    </v-chip>
+                    <div class="d-flex flex-row flex-wrap ga-1">
+                      <ResourceBadge kind="cpu" :value="task.config.resources.cpu" />
+                      <ResourceBadge kind="memory" :value="task.config.resources.memory" />
+                      <ResourceBadge kind="disk" :value="task.config.resources.disk" />
+                      <ResourceBadge
+                        kind="shm"
+                        :value="task.config.resources.shm"
+                        v-if="task.config.resources.shm"
+                      />
+                      <v-chip v-if="task.config.monitor" color="warning" size="small" class="ml-2">
+                        <a target="_blank" :href="monitoringUrl" class="text-decoration-none">
+                          <v-icon size="small" class="mr-1">mdi-bug</v-icon>
+                          monitored
+                        </a>
+                      </v-chip>
+                    </div>
                   </v-col>
                 </v-row>
                 <v-divider v-if="task.config" class="my-2"></v-divider>


### PR DESCRIPTION
## Rationale
This PR keeps resource badges in flexbox containers so they can wrap around nicely even on small screens
Below are two screenshots of the badges without and with the flex additions respectively.

<img width="510" height="606" alt="Screenshot_20260119_132752" src="https://github.com/user-attachments/assets/14288e7f-23de-42df-890c-71ae079333d8" />
<img width="436" height="334" alt="Screenshot_20260119_133315" src="https://github.com/user-attachments/assets/1b40e3ac-77a7-4615-a879-ac5a90d62ab8" />

