### PR TITLE
prevent emitting save event when image is not edited

### DIFF
--- a/frontend-ui/src/components/BlobEditor.vue
+++ b/frontend-ui/src/components/BlobEditor.vue
@@ -174,7 +174,7 @@ const textFileType = computed(() => {
 })
 
 const acceptedTypes = computed(() => {
-  if (isImageKind) {
+  if (isImageKind.value) {
     return 'image/*'
   } else if (props.kind === 'css') {
     return '.css,text/css'
@@ -252,7 +252,7 @@ const processFile = async (file: File) => {
   }
 
   // Validate file type
-  if (isImageKind && !file.type.startsWith('image/')) {
+  if (isImageKind.value && !file.type.startsWith('image/')) {
     errorMessage.value = 'File must be an image/illustration'
     hasError.value = true
     return


### PR DESCRIPTION
## Rationale
When a user clicks the `Done` button, the image editor originally emitted the image data using `canvas.toDataURL` but it seems this causes different arrangements of the bytes leading to #1638. This PR maintains a computed property to keep track of when a user actually made edits to the image.

## Changes
- remove warning about saving image. see  #1635 
- avoid emitting save event when the user hasn't modified the image as the `canvas.toDataURL` is creating different bytes arrangement of the file fetched from URL. see https://stackoverflow.com/questions/9773154/canvas-todataurl-increases-file-size-of-image
- ask for confirmation before saving edits.

<img width="847" height="761" alt="Screenshot_20260122_135654" src="https://github.com/user-attachments/assets/15b7490e-4352-4b72-a4fe-9381b5868b59" />

This fixes #1638 
