### PR TITLE
remove unused binaries for zimscraperlib

### DIFF
--- a/backend/api.Dockerfile
+++ b/backend/api.Dockerfile
@@ -21,11 +21,16 @@ ENV MAILGUN_FROM="Zimfarm <info@farm.openzim.org>"
 # multiple notification for same event separated with pipe `|`
 # ENV suffixed with event: `GLOBAL_NOTIFICATION_started` or `GLOBAL_NOTIFICATION_ended`
 # ENV GLOBAL_NOTIFICATION_ended slack,#zimfarm-events,@rgaudin|mailgun,reg@kiwix.org
-# curl needed for healthcheck
-RUN apt-get update && apt-get install -y curl libmagic1 wget ffmpeg \
+
+# - curl needed for healthcheck
+# - zimscraperlib: We only install the binaries needed to make zimscraperlib image manipulation work, not
+# the whole list as recommended on the installation page. This is because the installing all
+# the prerequisites binaries blow up the image size by over 1Gb and we don't need all those
+# functionalities.
+RUN apt-get update && apt-get install -y curl libmagic1 wget \
     libtiff5-dev libjpeg62-turbo-dev libopenjp2-7-dev zlib1g-dev \
-    libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
-    libharfbuzz-dev libfribidi-dev libxcb1-dev gifsicle && \
+    libfreetype6-dev liblcms2-dev libwebp-dev libcairo2-dev \
+    libharfbuzz-dev libfribidi-dev libxcb1-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # install Python dependencies first (since they change more rarely than src code)

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -32,14 +32,14 @@ dependencies = [
     "Werkzeug == 3.1.5",
     "cryptography == 45.0.3",
     "pycountry == 24.6.1",
-    "regex == 2025.9.1",
-    "zimscraperlib == 5.2.0",
+    "regex == 2025.9.1"
 ]
 dynamic = ["version"]
 
 [project.optional-dependencies]
 api = [
     "fastapi[all] == 0.115.2",
+    "zimscraperlib == 5.2.0"
 ]
 scripts = [
     "invoke == 2.2.0",

--- a/backend/src/zimfarm_backend/api/routes/blobs/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/blobs/logic.py
@@ -6,10 +6,7 @@ from uuid import UUID
 from fastapi import APIRouter, Depends, Path, Query, Response
 from sqlalchemy.orm import Session as OrmSession
 
-from zimfarm_backend.api.image import (
-    convert_image_to_png,
-    create_zim_illustration,
-)
+from zimfarm_backend.api.image import convert_image_to_png, create_zim_illustration
 from zimfarm_backend.api.routes.blobs.models import (
     BlobsGetSchema,
     CreateBlobRequest,

--- a/dev/backend-tools-tests/Dockerfile
+++ b/dev/backend-tools-tests/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:3.13-slim-bookworm
 
-RUN apt-get update && apt-get install -y curl libmagic1 wget ffmpeg \
+RUN apt-get update && apt-get install -y curl libmagic1 wget \
     libtiff5-dev libjpeg62-turbo-dev libopenjp2-7-dev zlib1g-dev \
-    libfreetype6-dev liblcms2-dev libwebp-dev tcl8.6-dev tk8.6-dev python3-tk \
-    libharfbuzz-dev libfribidi-dev libxcb1-dev gifsicle && \
+    libfreetype6-dev liblcms2-dev libwebp-dev libcairo2-dev \
+    libharfbuzz-dev libfribidi-dev libxcb1-dev && \
     rm -rf /var/lib/apt/lists/*
 
 # install Python dependencies first (since they change more rarely than src code)


### PR DESCRIPTION
## Rationale
This PR replaces zimscraperlib library by copying over only the functionalities that have to deal with PNG image processing. As a consequence, api docker image has dropped to 601Mb from 1.53Gb. See #1627


## Changes
- use only functions from zimscraperlib that have to deal with image manipulation
- remove external binaries from dockerfile that aren't required to optimize/process images

This closes #1627 
