### PR TITLE
pass props directly to v-switch

### DIFF
--- a/frontend-ui/src/components/SwitchButton.vue
+++ b/frontend-ui/src/components/SwitchButton.vue
@@ -1,25 +1,15 @@
 <template>
-  <div class="d-flex flex-column">
-    <span v-if="label" class="text-body-2">{{ label }}</span>
-    <div class="d-flex align-center">
-      <v-switch
-        :model-value="modelValue"
-        :color="color"
-        :disabled="disabled"
-        :density="density"
-        :hide-details="hideDetails"
-        @update:model-value="handleUpdate"
-        :hint="hint"
-        :persistent-hint="persistentHint"
-      />
-      <span class="ml-2 text-body-2 text-medium-emphasis">
-        {{ modelValue ? 'Enabled' : 'Disabled' }}
-      </span>
-    </div>
-  </div>
-  <div v-if="details" class="mt-1 text-caption text-medium-emphasis">
-    {{ details }}
-  </div>
+  <v-switch
+    persistent-hint
+    :label="label"
+    :hint="details"
+    :model-value="modelValue"
+    :color="color"
+    :disabled="disabled"
+    :density="density"
+    :hide-details="'auto'"
+    @update:model-value="handleUpdate"
+  />
 </template>
 
 <script setup lang="ts">
@@ -30,9 +20,6 @@ interface Props {
   color?: string
   disabled?: boolean
   density?: 'default' | 'compact' | 'comfortable'
-  hideDetails?: boolean | 'auto'
-  hint?: string
-  persistentHint?: boolean
 }
 
 interface Emits {
@@ -43,7 +30,6 @@ withDefaults(defineProps<Props>(), {
   color: 'primary',
   disabled: false,
   density: 'default',
-  hideDetails: true,
 })
 
 const emit = defineEmits<Emits>()


### PR DESCRIPTION
## Rationale
 This PR reduces the vertical height of the SwitchButton component by passing all props to the underlying v-switch.
<img width="1089" height="606" alt="Screenshot_20260123_132119" src="https://github.com/user-attachments/assets/89366e09-73f6-41c2-9e85-94acee550f05" />

## Changes
- pass `label` to `label` props of the v-switch and remove `<span>` used for rendering it
- pass `details` to `hint` props of the v-switch and remove `<div>` used for rendering it

This closes #1386
