### PR TITLE
hide navigation items based on show attribute

### DIFF
--- a/frontend-ui/src/App.vue
+++ b/frontend-ui/src/App.vue
@@ -46,7 +46,7 @@ const canDeleteSchedules = computed(() => {
   return authStore.hasPermission('schedules', 'delete')
 })
 
-const navigationItems: NavigationItem[] = [
+const navigationItems = computed<NavigationItem[]>(() => [
   {
     name: 'pipeline',
     label: 'Pipeline',
@@ -87,7 +87,7 @@ const navigationItems: NavigationItem[] = [
     disabled: false,
     show: canReadUsers.value,
   },
-]
+])
 
 const handleSignOut = () => {
   authStore.logout()

--- a/frontend-ui/src/components/NavBar.vue
+++ b/frontend-ui/src/components/NavBar.vue
@@ -15,7 +15,7 @@
     <!-- Navigation Links -->
     <v-tabs class="d-none d-md-flex" color="white" slider-color="white">
       <v-tab
-        v-for="item in navigationItems"
+        v-for="item in visibleNavigationItems"
         :key="item.name"
         :disabled="item.disabled"
         :to="{ name: item.name }"
@@ -55,7 +55,7 @@
   <v-navigation-drawer v-model="drawer" temporary location="left" class="d-md-none">
     <v-list>
       <v-list-item
-        v-for="item in navigationItems"
+        v-for="item in visibleNavigationItems"
         :key="item.name"
         :disabled="item.disabled"
         :prepend-icon="item.icon"
@@ -79,7 +79,7 @@
 <script setup lang="ts">
 import Loading from '@/components/Loading.vue'
 import UserButton from '@/components/UserButton.vue'
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 
 // Props
 export interface NavigationItem {
@@ -91,7 +91,7 @@ export interface NavigationItem {
   show: boolean
 }
 
-defineProps<{
+const props = defineProps<{
   navigationItems: NavigationItem[]
   username: string | null
   isLoggedIn: boolean
@@ -106,6 +106,10 @@ defineEmits<{
 
 // Reactive data
 const drawer = ref(false)
+
+const visibleNavigationItems = computed(() => {
+  return props.navigationItems.filter((item) => item.show)
+})
 </script>
 
 <style scoped>


### PR DESCRIPTION
## Changes
- make navigation items a computed ref so it updates when authstore changes
- trim list of navigation items based on `show` attribute of prop elements
- 
<img width="1152" height="206" alt="Screenshot_20260123_153805" src="https://github.com/user-attachments/assets/daee926d-1f39-4360-93ef-8e923ccc69ac" />

<img width="1152" height="119" alt="Screenshot_20260123_153810" src="https://github.com/user-attachments/assets/cad7fb67-96d5-441d-b94c-112bd128e7b0" />



This fixes #1644

