### PR TITLE
reduce contrast of update offliner detail button

### DIFF
--- a/frontend-ui/src/components/ScheduleActionButton.vue
+++ b/frontend-ui/src/components/ScheduleActionButton.vue
@@ -39,7 +39,7 @@
     <!-- Request Button -->
     <v-btn
       v-show="canRequest"
-      color="info"
+      color="primary"
       variant="elevated"
       size="small"
       class="mr-2"

--- a/frontend-ui/src/components/ScheduleEditor.vue
+++ b/frontend-ui/src/components/ScheduleEditor.vue
@@ -1,21 +1,15 @@
 <template>
   <v-form @submit.prevent="handleSubmit" v-if="schedule">
-    <div class="d-flex flex-column flex-sm-row justify-end ga-2">
+    <div class="d-flex flex-column flex-sm-row justify-end ga-2 schedule-actions">
       <v-btn
         :disabled="!canSubmit"
+        :color="canSubmit ? 'primary' : undefined"
         type="submit"
-        :color="canSubmit ? 'primary' : 'secondary'"
         variant="elevated"
       >
         Update Offliner details
       </v-btn>
-      <v-btn
-        type="button"
-        :disabled="!hasChanges"
-        :color="hasChanges ? 'dark' : 'secondary'"
-        variant="outlined"
-        @click="handleReset"
-      >
+      <v-btn type="button" :disabled="!hasChanges" variant="outlined" @click="handleReset">
         Reset
       </v-btn>
     </div>
@@ -534,19 +528,13 @@
     <div class="d-flex flex-column flex-sm-row justify-end ga-2">
       <v-btn
         :disabled="!canSubmit"
+        :color="canSubmit ? 'primary' : undefined"
         type="submit"
-        :color="canSubmit ? 'primary' : 'secondary'"
         variant="elevated"
       >
         Update Offliner details
       </v-btn>
-      <v-btn
-        type="button"
-        :disabled="!hasChanges"
-        :color="hasChanges ? 'dark' : 'secondary'"
-        variant="outlined"
-        @click="handleReset"
-      >
+      <v-btn type="button" :disabled="!hasChanges" variant="outlined" @click="handleReset">
         Reset
       </v-btn>
     </div>


### PR DESCRIPTION

<img width="1084" height="453" alt="Screenshot_20260127_110020" src="https://github.com/user-attachments/assets/e5e65502-4af1-4d2e-b6e3-fbc0437da8bf" />
<img width="1084" height="453" alt="Screenshot_20260127_110014" src="https://github.com/user-attachments/assets/b7bbdcba-df8a-424d-b4af-06681b46d8d8" />
<img width="1212" height="480" alt="Screenshot_20260127_105951" src="https://github.com/user-attachments/assets/30f3471a-2594-4d18-8c1d-2c6f4ee69fe1" />
<img width="1123" height="459" alt="Screenshot_20260127_105941" src="https://github.com/user-attachments/assets/9c5e0996-f955-4ea6-ab9f-c42abc24fc52" />



The above screenshots represent the update button when the recipe has changes and when it doesn't in dark and light modesmode.

## Changes
- set color to undefined on no changes and to primary when there are changes

This fixes #1633 
