### PR TITLE
force luxon datetime locale to en

### DIFF
--- a/frontend-ui/src/utils/format.ts
+++ b/frontend-ui/src/utils/format.ts
@@ -1,5 +1,6 @@
 import { filesize } from 'filesize'
-import { DateTime, Duration, Interval, type DurationUnit } from 'luxon'
+import { DateTime, Duration, Interval, type DurationUnit, Settings } from 'luxon'
+Settings.defaultLocale = 'en'
 
 function getUnits(interval: Interval<true>) {
   const units: string[] = []


### PR DESCRIPTION
## Rationale
This PR forces default locale for luxon to be in English. As a consequence, datetime strings will always appear in English irrespective of user configured language at browser or OS-level

This fixes #1654
