### PR TITLE
summarize status text in workers table to prevent overflow

### DIFF
--- a/frontend-ui/src/components/WorkersTable.vue
+++ b/frontend-ui/src/components/WorkersTable.vue
@@ -111,7 +111,7 @@
                 variant="tonal"
                 prepend-icon="mdi-pause-circle"
               >
-                Cordoned by worker owner
+                Cordoned
               </v-chip>
 
               <!-- Admin scheduling status -->
@@ -122,7 +122,7 @@
                 variant="tonal"
                 prepend-icon="mdi-shield-alert"
               >
-                Disabled by Zimfarm Administrator
+                Disabled
               </v-chip>
 
               <!-- Selfish worker status -->


### PR DESCRIPTION
## Rationale
This PR summarizes the status text of a worker in the workers table to one word in order to keep the column at a fixed width and avoid horizontal scrolling.
## Changes
- Changed `Disabled by Zimfarm Administrator` to `Disabled`
- Changed `Cordoned by Worker owner` to `Cordoned`

Another alternative is to use tooltips completely for all the status text. Explored wrapping the text around but it doesn't look nice.


This closes #1652 