### PR TITLE
fix label overlap issues of confirmdialog in recipe archive/restore

### DIFF
--- a/frontend-ui/src/components/ArchiveItem.vue
+++ b/frontend-ui/src/components/ArchiveItem.vue
@@ -76,16 +76,9 @@
           <v-textarea
             v-model="comment"
             label="Comment (optional)"
-            :hint="
-              isArchived
-                ? 'Describe the reason for restoring this recipe'
-                : 'Describe the reason for archiving this recipe'
-            "
-            placeholder="e.g., Archived due to maintenance, Restored after review, etc."
             variant="outlined"
             auto-grow
             rows="3"
-            persistent-hint
           />
         </div>
       </template>

--- a/frontend-ui/src/components/ConfirmDialog.vue
+++ b/frontend-ui/src/components/ConfirmDialog.vue
@@ -47,8 +47,8 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   title: 'Please Confirm',
   message: '',
-  confirmText: 'YES',
-  cancelText: 'NO',
+  confirmText: 'Continue',
+  cancelText: 'Cancel',
   confirmColor: 'error',
   icon: 'mdi-alert-circle',
   iconColor: 'warning',

--- a/frontend-ui/src/components/SchedulesBaseView.vue
+++ b/frontend-ui/src/components/SchedulesBaseView.vue
@@ -45,6 +45,7 @@
       v-model="showRestoreCommentDialog"
       title="Restore Recipes"
       confirm-text="Restore"
+      cancel-text="Cancel"
       confirm-color="success"
       :max-width="600"
       icon="mdi-archive-arrow-up"
@@ -66,12 +67,9 @@
           <v-textarea
             v-model="restoreComment"
             label="Comment (optional)"
-            hint="Describe the reason for restoring these recipes"
-            placeholder="e.g., Restored after review, Maintenance completed, etc."
             variant="outlined"
             auto-grow
             rows="3"
-            persistent-hint
           />
         </div>
       </template>


### PR DESCRIPTION
<img width="1010" height="633" alt="Screenshot_20260127_081720" src="https://github.com/user-attachments/assets/8f55a9af-35a7-4827-bfbb-747549bcd430" />
<img width="1063" height="587" alt="Screenshot_20260127_081412" src="https://github.com/user-attachments/assets/d1bcf488-5eba-4a91-86b1-39a3da0045ad" />


## Changes
- fix label and placeholder overlap in confirm dialog to restore/archive recipe
- standardize confirm dialog component confirm and cancel texts

This fixes #1649 