### PR TITLE
sort workers by name only in ascending order

### DIFF
--- a/backend/src/zimfarm_backend/db/worker.py
+++ b/backend/src/zimfarm_backend/db/worker.py
@@ -3,7 +3,7 @@ from ipaddress import IPv4Address, IPv6Address
 from typing import Any
 from uuid import UUID
 
-from sqlalchemy import asc, desc, func, select
+from sqlalchemy import asc, func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session as OrmSession
 
@@ -133,7 +133,7 @@ def get_workers(
             )
             | (hide_offlines is False),
         )
-        .order_by(desc(Worker.last_seen), asc(Worker.name))
+        .order_by(asc(Worker.name))
         .offset(skip)
         .limit(limit)
     )


### PR DESCRIPTION
## Rationale

This PR sorts workers list by name only and in ascending order. Previous sort was done in combination with last_seen which changes frequently and isn't particularly useful.

This closes #1648 
