### PR TITLE
reposition button to clear filters for recipe listing

### DIFF
--- a/frontend-ui/src/components/SchedulesBaseView.vue
+++ b/frontend-ui/src/components/SchedulesBaseView.vue
@@ -7,6 +7,7 @@
       :languages="languages"
       :tags="tags"
       @filters-changed="handleFiltersChange"
+      @clear-filters="clearFilters"
     />
     <SchedulesTable
       v-if="ready"
@@ -19,10 +20,8 @@
       :filters="filters"
       :selected-schedules="selectedSchedules"
       :show-selection="true"
-      :show-filters="true"
       @limit-changed="handleLimitChange"
       @load-data="loadData"
-      @clear-filters="clearFilters"
       @selection-changed="handleSelectionChanged"
     >
       <template #actions>

--- a/frontend-ui/src/components/SchedulesFilter.vue
+++ b/frontend-ui/src/components/SchedulesFilter.vue
@@ -58,6 +58,16 @@
             @update:model-value="emitFilters"
           />
         </v-col>
+        <v-col
+          v-if="hasActiveFilters"
+          cols="12"
+          class="d-flex flex-sm-row flex-column align-sm-center"
+        >
+          <v-btn size="small" variant="outlined" @click="handleClearFilters">
+            <v-icon size="small" class="mr-1">mdi-close-circle</v-icon>
+            clear filters
+          </v-btn>
+        </v-col>
       </v-row>
     </v-card-text>
   </v-card>
@@ -92,6 +102,7 @@ const emit = defineEmits<{
       tags: string[]
     },
   ]
+  clearFilters: []
 }>()
 
 // Local filters state
@@ -137,6 +148,15 @@ const tagsOptions = computed(() => {
   }))
 })
 
+const hasActiveFilters = computed(() => {
+  return (
+    props.filters.name.length > 0 ||
+    props.filters.categories.length > 0 ||
+    props.filters.languages.length > 0 ||
+    props.filters.tags.length > 0
+  )
+})
+
 // Emit filters when they change
 function emitFilters() {
   emit('filtersChanged', {
@@ -145,5 +165,9 @@ function emitFilters() {
     languages: localFilters.value.languages,
     tags: localFilters.value.tags,
   })
+}
+
+function handleClearFilters() {
+  emit('clearFilters')
 }
 </script>

--- a/frontend-ui/src/components/SchedulesTable.vue
+++ b/frontend-ui/src/components/SchedulesTable.vue
@@ -2,7 +2,7 @@
   <div>
     <v-card v-if="!errors.length" :class="{ loading: loading }" flat>
       <v-card-title
-        v-if="showSelection || showFilters || $slots.actions"
+        v-if="showSelection || $slots.actions"
         class="d-flex flex-column-reverse flex-sm-row align-sm-center justify-sm-end ga-2"
       >
         <slot name="actions" />
@@ -16,16 +16,6 @@
         >
           <v-icon size="small" class="mr-1">mdi-checkbox-multiple-blank-outline</v-icon>
           clear selections
-        </v-btn>
-        <v-btn
-          v-if="showFilters"
-          size="small"
-          variant="outlined"
-          :disabled="!hasActiveFilters"
-          @click="handleClearFilters"
-        >
-          <v-icon size="small" class="mr-1">mdi-close-circle</v-icon>
-          clear filters
         </v-btn>
       </v-card-title>
 
@@ -142,14 +132,12 @@ interface Props {
   }
   selectedSchedules?: string[]
   showSelection?: boolean
-  showFilters?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   filters: () => ({ name: '', categories: [], languages: [], tags: [] }),
   selectedSchedules: () => [],
   showSelection: true,
-  showFilters: true,
 })
 
 const router = useRouter()
@@ -160,23 +148,12 @@ const { smAndDown } = useDisplay()
 const emit = defineEmits<{
   limitChanged: [limit: number]
   loadData: [limit: number, skip: number]
-  clearFilters: []
   selectionChanged: [selectedSchedules: string[]]
 }>()
 
 const limits = [10, 20, 50, 100]
 
 const selectedSchedules = computed(() => props.selectedSchedules)
-
-// Check if any filters are active
-const hasActiveFilters = computed(() => {
-  return (
-    props.filters.name.length > 0 ||
-    props.filters.categories.length > 0 ||
-    props.filters.languages.length > 0 ||
-    props.filters.tags.length > 0
-  )
-})
 
 function onUpdateOptions(options: { page: number; itemsPerPage: number }) {
   const query = { ...route.query }
@@ -201,10 +178,6 @@ function handleSelectionChange(selection: string[]) {
 
 function clearSelections() {
   emit('selectionChanged', [])
-}
-
-function handleClearFilters() {
-  emit('clearFilters')
 }
 
 function statusClass(status: string) {


### PR DESCRIPTION

<img width="510" height="527" alt="Screenshot_20260127_123016" src="https://github.com/user-attachments/assets/829fd807-d31a-4e34-81fb-3e9829f1f452" />
<img width="1109" height="427" alt="Screenshot_20260127_123000" src="https://github.com/user-attachments/assets/e28fe36b-94b2-45cf-9c12-f13627773486" />


This PR re-positions the button to clear filters for recipe listing based on #1650 recommendations

## Changes
- move button to clear filters in the same block as the filters.

This closes #1650 
