### PR TITLE
remove archive entry from navbar

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/schedules/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/schedules/logic.py
@@ -100,8 +100,15 @@ router = APIRouter(prefix="/schedules", tags=["schedules"])
 @router.get("")
 def get_schedules(
     params: Annotated[SchedulesGetSchema, Query()],
+    current_user: User | None = Depends(get_current_user_or_none),
     session: OrmSession = Depends(gen_dbsession),
 ) -> ListResponse[ScheduleLightSchema]:
+    if params.archived and not (
+        current_user
+        and check_user_permission(current_user, namespace="schedules", name="archive")
+    ):
+        raise UnauthorizedError("You are not allowed to view archived schedules.")
+
     results = db_get_schedules(
         session,
         skip=params.skip,

--- a/frontend-ui/src/App.vue
+++ b/frontend-ui/src/App.vue
@@ -42,9 +42,6 @@ onMounted(async () => {
 const canReadUsers = computed(() => {
   return authStore.hasPermission('users', 'read')
 })
-const canDeleteSchedules = computed(() => {
-  return authStore.hasPermission('schedules', 'delete')
-})
 
 const navigationItems = computed<NavigationItem[]>(() => [
   {
@@ -62,14 +59,6 @@ const navigationItems = computed<NavigationItem[]>(() => [
     icon: 'mdi-book-open-variant',
     disabled: false,
     show: true,
-  },
-  {
-    name: 'archived-schedules',
-    label: 'Archives',
-    route: 'archived-schedules',
-    icon: 'mdi-archive',
-    disabled: false,
-    show: canDeleteSchedules.value,
   },
   {
     name: 'workers',

--- a/frontend-ui/src/components/SchedulesBaseView.vue
+++ b/frontend-ui/src/components/SchedulesBaseView.vue
@@ -104,6 +104,13 @@ const props = withDefaults(defineProps<Props>(), {
   canRequestTasks: false,
 })
 
+// Emits
+const emit = defineEmits<{
+  'filters-updated': [
+    filters: { name: string; categories: string[]; languages: string[]; tags: string[] },
+  ]
+}>()
+
 // Define headers for the table
 const headers = [
   { title: 'Name', value: 'name', sortable: false },
@@ -388,6 +395,7 @@ watch(
     }
     const newSkip = (page - 1) * paginator.value.limit
     await loadData(paginator.value.limit, newSkip)
+    emit('filters-updated', filters.value)
   },
   { deep: true, immediate: true },
 )

--- a/frontend-ui/src/views/ArchivedSchedulesView.vue
+++ b/frontend-ui/src/views/ArchivedSchedulesView.vue
@@ -1,26 +1,49 @@
 <template>
-  <SchedulesBaseView :archived="true" :route-name="'archived-schedules'" :can-request-tasks="false">
-    <template #actions="{ selectedSchedules, restoringText, handleRestoreSchedules }">
-      <RestoreSelectionButton
-        v-if="canRestore"
-        :can-restore="canRestore"
-        :restoring-text="restoringText"
-        :count="selectedSchedules.length"
-        @restore-schedules="handleRestoreSchedules"
-      />
-    </template>
-  </SchedulesBaseView>
+  <div>
+    <!-- Error Message for permissions -->
+    <ErrorMessage :message="error" v-if="error" />
+
+    <!-- Content only shown if user has permission -->
+    <div v-show="canRestore">
+      <SchedulesBaseView
+        :archived="true"
+        :route-name="'archived-schedules'"
+        :can-request-tasks="false"
+      >
+        <template #actions="{ selectedSchedules, restoringText, handleRestoreSchedules }">
+          <RestoreSelectionButton
+            v-if="canRestore"
+            :can-restore="canRestore"
+            :restoring-text="restoringText"
+            :count="selectedSchedules.length"
+            @restore-schedules="handleRestoreSchedules"
+          />
+        </template>
+      </SchedulesBaseView>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
+import ErrorMessage from '@/components/ErrorMessage.vue'
 import RestoreSelectionButton from '@/components/RestoreSelectionButton.vue'
 import SchedulesBaseView from '@/components/SchedulesBaseView.vue'
 import { useAuthStore } from '@/stores/auth'
-import { computed } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 
 // Stores
 const authStore = useAuthStore()
 
+// Reactive data
+const error = ref<string | null>(null)
+
 // Computed properties
 const canRestore = computed(() => authStore.hasPermission('schedules', 'archive'))
+
+// Lifecycle
+onMounted(() => {
+  if (!canRestore.value) {
+    error.value = 'You do not have permission to view archived recipes.'
+  }
+})
 </script>

--- a/frontend-ui/src/views/SchedulesView.vue
+++ b/frontend-ui/src/views/SchedulesView.vue
@@ -1,32 +1,138 @@
 <!-- Filterable list of schedules with filtered-fire button -->
 
 <template>
-  <SchedulesBaseView
-    :archived="false"
-    :route-name="'schedules-list'"
-    :can-request-tasks="canRequestTasks"
-  >
-    <template #actions="{ selectedSchedules, requestingText, handleFetchSchedules }">
-      <RequestSelectionButton
-        v-if="canRequestTasks"
-        :can-request-tasks="canRequestTasks"
-        :requesting-text="requestingText"
-        :count="selectedSchedules.length"
-        @fetch-schedules="handleFetchSchedules"
-      />
-    </template>
-  </SchedulesBaseView>
+  <div>
+    <SchedulesBaseView
+      :archived="false"
+      :route-name="'schedules-list'"
+      :can-request-tasks="canRequestTasks"
+      @filters-updated="handleFiltersUpdated"
+    >
+      <template #actions="{ selectedSchedules, requestingText, handleFetchSchedules }">
+        <RequestSelectionButton
+          v-if="canRequestTasks"
+          :can-request-tasks="canRequestTasks"
+          :requesting-text="requestingText"
+          :count="selectedSchedules.length"
+          @fetch-schedules="handleFetchSchedules"
+        />
+      </template>
+    </SchedulesBaseView>
+
+    <div v-if="canAccessArchives" class="pa-0 mt-4">
+      <v-tooltip location="top">
+        <template #activator="{ props }">
+          <v-btn
+            v-bind="props"
+            variant="outlined"
+            size="small"
+            :loading="loadingArchivedCount"
+            @click="navigateToArchives"
+          >
+            <v-icon size="small" class="mr-2">mdi-archive</v-icon>
+            {{ archivedCountText }}
+          </v-btn>
+        </template>
+        <span>{{ archivedTooltipText }}</span>
+      </v-tooltip>
+    </div>
+  </div>
 </template>
 
 <script setup lang="ts">
 import RequestSelectionButton from '@/components/RequestSelectionButton.vue'
 import SchedulesBaseView from '@/components/SchedulesBaseView.vue'
 import { useAuthStore } from '@/stores/auth'
-import { computed } from 'vue'
+import { useScheduleStore } from '@/stores/schedule'
+import { computed, ref } from 'vue'
+import { useRouter } from 'vue-router'
 
 // Stores
 const authStore = useAuthStore()
+const scheduleStore = useScheduleStore()
+const router = useRouter()
+
+// State
+const currentFilters = ref({
+  name: '',
+  categories: [] as string[],
+  languages: [] as string[],
+  tags: [] as string[],
+})
+const archivedCount = ref(0)
+const loadingArchivedCount = ref(false)
 
 // Computed properties
 const canRequestTasks = computed(() => authStore.hasPermission('requested_tasks', 'create'))
+const canAccessArchives = computed(() => authStore.hasPermission('schedules', 'archive'))
+
+const archivedCountText = computed(() => {
+  if (loadingArchivedCount.value) {
+    return 'Loading...'
+  }
+  const count = archivedCount.value
+  return `ARCHIVES (${count})`
+})
+
+const archivedTooltipText = computed(() => {
+  const count = archivedCount.value
+  return count === 1 ? '1 matching archived recipe' : `${count} matching archived recipes`
+})
+
+// Methods
+async function fetchArchivedCount(filters: typeof currentFilters.value) {
+  if (!canAccessArchives.value) return
+
+  loadingArchivedCount.value = true
+  try {
+    await scheduleStore.fetchSchedules(
+      1, // limit - we only need the count
+      0, // skip
+      filters.categories.length > 0 ? filters.categories : undefined,
+      filters.languages.length > 0 ? filters.languages : undefined,
+      filters.tags.length > 0 ? filters.tags : undefined,
+      filters.name || undefined,
+      true, // archived
+    )
+    archivedCount.value = scheduleStore.paginator.count
+  } catch (error) {
+    console.error('Failed to fetch archived count', error)
+    archivedCount.value = 0
+  } finally {
+    loadingArchivedCount.value = false
+  }
+}
+
+function handleFiltersUpdated(filters: typeof currentFilters.value) {
+  currentFilters.value = filters
+  fetchArchivedCount(filters)
+}
+
+function navigateToArchives() {
+  const query: Record<string, string | string[]> = {}
+
+  if (currentFilters.value.name) {
+    query.name = currentFilters.value.name
+  }
+  if (currentFilters.value.categories.length === 1) {
+    query.category = currentFilters.value.categories[0]
+  } else if (currentFilters.value.categories.length > 1) {
+    query.category = currentFilters.value.categories
+  }
+  if (currentFilters.value.languages.length === 1) {
+    query.lang = currentFilters.value.languages[0]
+  } else if (currentFilters.value.languages.length > 1) {
+    query.lang = currentFilters.value.languages
+  }
+  if (currentFilters.value.tags.length === 1) {
+    query.tag = currentFilters.value.tags[0]
+  } else if (currentFilters.value.tags.length > 1) {
+    query.tag = currentFilters.value.tags
+  }
+
+  router.push({
+    name: 'archived-schedules',
+    query: Object.keys(query).length > 0 ? query : undefined,
+  })
+}
 </script>


### PR DESCRIPTION
## Rationale
This PR removes the archive entry from the navbar and replaces it with a button at the bottom left of the recipe listing table.

<img width="1128" height="180" alt="Screenshot_20260127_142352" src="https://github.com/user-attachments/assets/79cb7191-4543-4508-b440-63d7f47ecbe9" />

<img width="1104" height="171" alt="Screenshot_20260127_142334" src="https://github.com/user-attachments/assets/b85fbdd4-1dbb-4df1-a880-7bc0a78845a9" />


## Changes
- remove archive link from navbar
- load number of archived recipes from query filters
- prevent unauthorized users from viewing archived recipes at API level. Previously, users could view but couldn't restore.


This closes #1651 