### PR TITLE
upload logs and artifacts on cancellation

### DIFF
--- a/frontend-ui/src/components/ScheduleEditor.vue
+++ b/frontend-ui/src/components/ScheduleEditor.vue
@@ -639,8 +639,6 @@
         <v-textarea
           v-model.trim="pendingComment"
           label="Comment (optional)"
-          hint="Describe the changes you made to help track modifications"
-          placeholder="e.g., Updated memory allocation, changed offliner version, etc."
           variant="outlined"
           auto-grow
           rows="3"


### PR DESCRIPTION
## Rationale
This PR enhances the task worker to attempt to upload logs and artifacts when a SIGINT/SIGTERM is sent or when the worker manager stops it ( sends a SIGTERM)

## Changes
- create a dictionary to track the status of logs and artifacts uploads. This helps to keep the logs/artifacts uploads idempotent because the `exit_gracefully` function is used to register multiple signals. As per the [docker docs](https://docs.docker.com/reference/cli/docker/container/stop/#timeout), a `SIGKILL` is sent to forcefully kill the container. And we don't want to retry upload if one is already happening due to a `SIGTERM`
- enhance the existing checks for uploads to return booleans instead of just None. Also, they update the status of the upload to `DONE`, `SKIPPED`, `FAILED` based on events
- wait for upload containers in exit_gracefully function to handle exit signals
- fix unhandled overlap of confirmdialog label/placeholder that wasn't handled in #1663

This closes #965 
