### PR TITLE
send canceling event before uploading logs/artifacts on exit_gracefully

### DIFF
--- a/backend/src/zimfarm_backend/background_tasks/cancel_tasks.py
+++ b/backend/src/zimfarm_backend/background_tasks/cancel_tasks.py
@@ -182,6 +182,17 @@ def cancel_stale_tasks(session: OrmSession):
                 f"`{TaskStatus.cancel_requested}`"
             )
 
+    # `canceling` statuses
+    with session.begin_nested():
+        try:
+            cancel_stale_tasks_with_status(
+                session, TaskStatus.canceling, now, STALLED_CANCELREQ_TIMEOUT
+            )
+        except Exception:
+            logger.exception(
+                f"Failed to cancel stale tasks with status `{TaskStatus.canceling}`"
+            )
+
     # `scraper_completed` statuses: either success or failure
     with session.begin_nested():
         try:

--- a/backend/src/zimfarm_backend/common/enums.py
+++ b/backend/src/zimfarm_backend/common/enums.py
@@ -13,6 +13,7 @@ class TaskStatus(StrEnum):
     failed = "failed"
     cancel_requested = "cancel_requested"
     canceled = "canceled"
+    canceling = "canceling"
     succeeded = "succeeded"
 
     update = "update"
@@ -34,6 +35,7 @@ class TaskStatus(StrEnum):
             cls.scraper_running,
             cls.scraper_killed,
             cls.cancel_requested,
+            cls.canceling,
         ]
 
     @classmethod
@@ -60,6 +62,7 @@ class TaskStatus(StrEnum):
             cls.scraper_completed,
             cls.scraper_killed,
             cls.cancel_requested,
+            cls.canceling,
             cls.canceled,
             cls.succeeded,
             cls.failed,

--- a/backend/src/zimfarm_backend/common/utils.py
+++ b/backend/src/zimfarm_backend/common/utils.py
@@ -41,6 +41,7 @@ def task_event_handler(
         TaskStatus.failed: task_failed_event_handler,
         TaskStatus.cancel_requested: task_cancel_requested_event_handler,
         TaskStatus.canceled: task_canceled_event_handler,
+        TaskStatus.canceling: task_canceling_event_handler,
         TaskStatus.scraper_started: task_scraper_started_event_handler,
         TaskStatus.scraper_running: task_scraper_running_event_handler,
         TaskStatus.scraper_completed: task_scraper_completed_event_handler,
@@ -260,6 +261,19 @@ def task_failed_event_handler(
         exception=payload.get("exception"),
         traceback=payload.get("traceback"),
         task_log=payload.get("log"),
+    )
+
+
+def task_canceling_event_handler(
+    session: so.Session, task_id: UUID, payload: dict[str, Any]
+):
+    logger.info(f"Task Cancellation in progress: {task_id}")
+
+    save_event(
+        session,
+        task_id,
+        TaskStatus.canceling,
+        get_timestamp_from_event(payload),
     )
 
 

--- a/backend/tests/test_task_event_handlers.py
+++ b/backend/tests/test_task_event_handlers.py
@@ -1,0 +1,22 @@
+from collections.abc import Callable
+
+from sqlalchemy.orm import Session as OrmSession
+
+from zimfarm_backend.common import getnow
+from zimfarm_backend.common.enums import TaskStatus
+from zimfarm_backend.common.utils import task_canceling_event_handler
+from zimfarm_backend.db.models import Task
+
+
+def test_task_canceling_event_handler(
+    dbsession: OrmSession,
+    create_task: Callable[..., Task],
+):
+    task = create_task(status=TaskStatus.started)
+    task.timestamp = [(TaskStatus.started, getnow())]
+    dbsession.add(task)
+    dbsession.flush()
+
+    task_canceling_event_handler(dbsession, task.id, {})
+    dbsession.refresh(task)
+    assert task.status == TaskStatus.canceling

--- a/worker/src/zimfarm_worker/task/worker.py
+++ b/worker/src/zimfarm_worker/task/worker.py
@@ -609,6 +609,18 @@ class TaskWorker(BaseWorker):
                     if self.upload_status[ARTIFACTS_UPLOAD] == DOING:
                         containers_to_wait.append("artifacts_uploader")
 
+                    if containers_to_wait:
+                        logger.info(
+                            "Notifying API of cancellation with "
+                            "pending uploads of logs/artifacts"
+                        )
+                        self.patch_task(
+                            {
+                                "event": "canceling",
+                                "payload": {},
+                            }
+                        )
+
                     self.wait_for_upload_containers(containers_to_wait)
                 except NotFound:
                     logger.warning(


### PR DESCRIPTION
## Rationale
This PR adds a new status `canceling` to the list of TaskStatus. It will be sent by the task worker when it receives a cancellation signal and there are logs/artifacts to upload.

## Changes
-  add new task status `canceling` and event handlers for it to update the list of events
- notify API when work is to be done before cancellation occurs
- add function to cancel stale tasks with status of `canceling`

This closes #1672
