### PR TITLE
fix construction of help url for offliner flags

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/offliners/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/offliners/logic.py
@@ -143,7 +143,7 @@ async def get_offliner(
         content={
             "flags": [flag.model_dump(mode="json", by_alias=True) for flag in flags],
             "help": (  # dynamic + sourced from backend because it might be custom
-                f"https://github.com/openzim/{offliner}/wiki/Frequently-Asked-Questions"
+                f"https://github.com/openzim/{offliner_id}/wiki/Frequently-Asked-Questions"
             ),
         }
     )


### PR DESCRIPTION
## Changes
- use `offliner_id` variable in construction of url instead of `offliner` (pydantic model) 

This fixes #1683
