### PR TITLE
Clarify documentation of 'lang' param based on new crawler constraints

### DIFF
--- a/backend/src/zimfarm_backend/migrations/initial_offliner_definitions/zimit.json
+++ b/backend/src/zimfarm_backend/migrations/initial_offliner_definitions/zimit.json
@@ -19,7 +19,7 @@
       "type": "string",
       "required": false,
       "title": "Browser Language",
-      "description": "If set, sets the language used by the browser, should be ISO 639 language[-country] code, e.g. `en` or `en-GB`"
+      "description": "Set the language used by the browser, must be ISO-639-1 country language code, e.g. `en`"
     },
     "title": {
       "type": "string",


### PR DESCRIPTION
## Rationale

Corresponds to https://github.com/openzim/zimit/commit/26249fbb6db2b2ac422be4eaee2c7c980823598a

Issue: https://github.com/openzim/zimit/issues/543

## Changes

Update docs for 'lang' parameter to match zimit docs 
