### PR TITLE
compute task duration from started status in worker view

### DIFF
--- a/frontend-ui/src/components/WorkersTable.vue
+++ b/frontend-ui/src/components/WorkersTable.vue
@@ -155,7 +155,7 @@
             <TaskLink
               :id="item.task.id"
               :updatedAt="item.task.updated_at"
-              :status="item.task.status"
+              :status="'started'"
               :timestamp="item.task.timestamp"
             />
           </template>

--- a/frontend-ui/src/views/WorkerDetailView.vue
+++ b/frontend-ui/src/views/WorkerDetailView.vue
@@ -289,7 +289,7 @@
                       v-if="item.id && item.updated_at"
                       :id="item.id"
                       :updatedAt="item.updated_at"
-                      :status="item.status"
+                      :status="'started'"
                       :timestamp="item.timestamp"
                     />
                     <span v-else class="text-caption">-</span>
@@ -506,7 +506,7 @@ const canUpdateWorkers = computed(() => authStore.hasPermission('workers', 'upda
 const runningTasksHeaders = [
   { title: 'Schedule', value: 'schedule_name' },
   { title: 'Resources', value: 'resources' },
-  { title: 'Task', value: 'task' },
+  { title: 'Duration', value: 'task' },
 ]
 
 const hasChanges = computed(() => {


### PR DESCRIPTION
## Rationale
This PR sets the duration of the task to be computed from the `started` status of a task instead of the current status.

## Changes
- compute timestamp from `started` status instead of current status of task in worker detail and worker list views
- rename column from `Task` to `Duration` in worker detail view

This closes #1697 
