### PR TITLE
store illustrations sizes directly in metadata

### DIFF
--- a/backend/maint-scripts/update_file_illustration_metadata.py
+++ b/backend/maint-scripts/update_file_illustration_metadata.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+
+"""
+Script to update files in the database by renaming metadata keys that start with
+'Illustration_' to include '@1' suffix.
+"""
+
+import argparse
+
+from sqlalchemy import select
+from sqlalchemy.orm.attributes import flag_modified
+
+from zimfarm_backend import logger
+from zimfarm_backend.db import Session
+from zimfarm_backend.db.models import File
+
+
+def update_files_illustration_metadata() -> None:
+    """
+    Update files in the database to rename Illustration_ keys in metadata.
+    """
+    with Session.begin() as session:
+        for file in session.execute(select(File)).scalars():
+            if not file.info:
+                logger.warning(f"{file.name} does not have any zim info")
+                continue
+
+            metadata = file.info.get("metadata", {})
+            if not metadata:
+                logger.warning(f"{file.name} does not have any zim metadata")
+                continue
+
+            illustration_keys = [
+                key for key in metadata.keys() if key.startswith("Illustration_")
+            ]
+
+            if not illustration_keys:
+                logger.warning(f"{file.name} metadata does not have illustration keys.")
+                continue
+
+            for illustration_key in illustration_keys:
+                logger.info(
+                    f"Renaming {illustration_key} metadata for {file.name} "
+                    f"({file.id})..."
+                )
+                value = file.info["metadata"][illustration_key]
+                suffix = illustration_key[len("Illustration_") :]
+                new_key = f"Illustration_{suffix}@1"
+
+                del file.info["metadata"][illustration_key]
+                file.info["metadata"][new_key] = value
+                flag_modified(file, "info")
+                logger.info(f"Renamed '{illustration_key}' to '{new_key}'")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Update file metadata to rename illustration_ keys with @1 suffix",
+    )
+
+    args = parser.parse_args()
+
+    update_files_illustration_metadata()

--- a/frontend-ui/src/components/FileInfoTable.vue
+++ b/frontend-ui/src/components/FileInfoTable.vue
@@ -144,7 +144,7 @@ const handleImageError = () => {
 
 const parseIllustrationSize = (key: string): { width: number; height: number } | null => {
   const lower = key.toLowerCase()
-  const match = lower.match(/^illustration_(\d+)x(\d+)$/)
+  const match = lower.match(/^illustration_(\d+)x(\d+).*$/)
   if (!match) return null
   const width = parseInt(match[1], 10)
   const height = parseInt(match[2], 10)

--- a/worker/src/zimfarm_worker/task/zim.py
+++ b/worker/src/zimfarm_worker/task/zim.py
@@ -25,7 +25,7 @@ def get_zim_info(fpath: pathlib.Path) -> dict[str, Any]:
     for size in zim.get_illustration_sizes():
         payload["metadata"].update(
             {
-                f"Illustration_{size}x{size}": base64.standard_b64encode(
+                f"Illustration_{size}x{size}@1": base64.standard_b64encode(
                     zim.get_illustration_item(size).content
                 ).decode("ASCII")
             }


### PR DESCRIPTION
## Rationale
Currently, the task worker skips the illustration sizes in teh `zim.metadata_keys` of an `Archive` and computes a formatted one of the form `Illustration_{size}x{size}`. However, the cms expects key `Illustration_48x48@1` (which exists in the zim.metadata_key). This PR restores setting the keys as they are without any formatting of the key name.

## Changes
- detect the size of the illustration from the illustration key and extract the content for that size
- use the illustration key directly in the metadata
