### PR TITLE
avoid removing canceling task from list of known keys

### DIFF
--- a/worker/src/zimfarm_worker/task/worker.py
+++ b/worker/src/zimfarm_worker/task/worker.py
@@ -594,6 +594,8 @@ class TaskWorker(BaseWorker):
             if self.scraper:
                 try:
                     self.scraper.reload()
+                    # Stop the scraper before uploading it's logs and artificats
+                    self.scraper.stop()
 
                     containers_to_wait: list[str] = []
 
@@ -622,6 +624,7 @@ class TaskWorker(BaseWorker):
                         )
 
                     self.wait_for_upload_containers(containers_to_wait)
+                    self.scraper.remove()
                 except NotFound:
                     logger.warning(
                         "Scraper container not found, skipping log/artifact upload"


### PR DESCRIPTION
## Rationale

This PR improves the logic for exiting gracefully when cancellation is requested by stopping the scraper before uploading it's logs and artifacts. It also avoids marking a task that is in CANCEL_REQUESTED from having it's containers and directories removed by the logic to cleanup leftovers

## Changes
- rename function to cancel_and_remove_task to cancel_task with option for removal (default to True)
- stop scraper before uploading its logs and artifacts
