### PR TITLE
sort tasks by started column

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/blobs/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/blobs/logic.py
@@ -101,7 +101,7 @@ def create_blob(
     "/{schedule_name}",
     dependencies=[Depends(require_permission(namespace="schedules", name="read"))],
 )
-async def get_blobs(
+def get_blobs(
     schedule_name: Annotated[NotEmptyString, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
     params: Annotated[BlobsGetSchema, Query()],
@@ -128,7 +128,7 @@ async def get_blobs(
     "/{blob_id}",
     dependencies=[Depends(require_permission(namespace="schedules", name="create"))],
 )
-async def update_blob(
+def update_blob(
     blob_id: Annotated[UUID, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
     request: UpdateBlobRequest,
@@ -165,7 +165,7 @@ async def update_blob(
     "/{blob_id}",
     dependencies=[Depends(require_permission(namespace="schedules", name="create"))],
 )
-async def delete_blob(
+def delete_blob(
     blob_id: Annotated[UUID, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
 ):
@@ -180,7 +180,7 @@ async def delete_blob(
     "/{schedule_name}/{flag_name}/{checksum}",
     dependencies=[Depends(require_permission(namespace="schedules", name="read"))],
 )
-async def get_blob(
+def get_blob(
     schedule_name: Annotated[NotEmptyString, Path()],
     flag_name: Annotated[NotEmptyString, Path()],
     checksum: Annotated[NotEmptyString, Path()],

--- a/backend/src/zimfarm_backend/api/routes/contexts/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/contexts/logic.py
@@ -13,7 +13,7 @@ router = APIRouter(prefix="/contexts", tags=["contexts"])
 
 
 @router.get("")
-async def get_contexts(
+def get_contexts(
     session: OrmSession = Depends(gen_dbsession),
     skip: Annotated[SkipField, Query()] = 0,
     limit: Annotated[LimitFieldMax500, Query()] = 500,

--- a/backend/src/zimfarm_backend/api/routes/offliners/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/offliners/logic.py
@@ -42,7 +42,7 @@ router = APIRouter(prefix="/offliners", tags=["offliners"])
 
 
 @router.get("")
-async def get_offliners(
+def get_offliners(
     session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> ListResponse[str]:
     """Get a list of offliners"""
@@ -59,7 +59,7 @@ async def get_offliners(
 
 
 @router.post("")
-async def create_offliner(
+def create_offliner(
     request: OfflinerCreateSchema,
     session: Annotated[OrmSession, Depends(gen_dbsession)],
     current_user: User = Depends(get_current_user),
@@ -81,7 +81,7 @@ async def create_offliner(
 
 
 @router.get("/{offliner_id}/versions")
-async def get_offliner_versions(
+def get_offliner_versions(
     offliner_id: Annotated[str, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
     skip: Annotated[SkipField, Query()] = 0,
@@ -103,7 +103,7 @@ async def get_offliner_versions(
 
 
 @router.post("/{offliner_id}/versions")
-async def create_offliner_version(
+def create_offliner_version(
     offliner_id: Annotated[str, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
     request: Annotated[OfflinerDefinitionCreateSchema, Body()],
@@ -123,7 +123,7 @@ async def create_offliner_version(
 
 
 @router.get("/{offliner_id}/{version}")
-async def get_offliner(
+def get_offliner(
     offliner_id: Annotated[str, Path()],
     version: Annotated[str, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
@@ -150,7 +150,7 @@ async def get_offliner(
 
 
 @router.get("/{offliner_id}/{version}/spec")
-async def get_offliner_spec(
+def get_offliner_spec(
     offliner_id: Annotated[str, Path()],
     version: Annotated[str, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],

--- a/backend/src/zimfarm_backend/api/routes/platforms/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/platforms/logic.py
@@ -8,7 +8,7 @@ router = APIRouter(prefix="/platforms", tags=["platforms"])
 
 
 @router.get("")
-async def get_platforms():
+def get_platforms():
     """Get a list of supported platforms."""
     platforms = Platform.all()
     return ListResponse[Platform](

--- a/backend/src/zimfarm_backend/api/routes/status/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/status/logic.py
@@ -15,7 +15,7 @@ router = APIRouter(prefix="/status", tags=["status"])
 
 
 @router.get("/{monitor_name}")
-async def get_status(
+def get_status(
     monitor_name: Annotated[StatusMonitorName, Path(..., description="Monitor name")],
     threshold_secs: Annotated[int, Query(..., description="Threshold in seconds")],
     status: Annotated[TaskStatus, Query(..., description=" Task status")],

--- a/backend/src/zimfarm_backend/api/routes/tags/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/tags/logic.py
@@ -13,7 +13,7 @@ router = APIRouter(prefix="/tags", tags=["tags"])
 
 
 @router.get("")
-async def get_tags(
+def get_tags(
     session: OrmSession = Depends(gen_dbsession),
     skip: Annotated[SkipField, Query()] = 0,
     limit: Annotated[LimitFieldMax200, Query()] = 200,

--- a/backend/src/zimfarm_backend/api/routes/tasks/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/tasks/logic.py
@@ -52,7 +52,7 @@ router = APIRouter(prefix="/tasks", tags=["tasks"])
 
 
 @router.get("")
-async def get_tasks(
+def get_tasks(
     db_session: Annotated[Session, Depends(gen_dbsession)],
     skip: Annotated[SkipField, Query()] = 0,
     limit: Annotated[LimitFieldMax200, Query()] = 20,
@@ -75,7 +75,7 @@ async def get_tasks(
 
 
 @router.get("/{task_id}")
-async def get_task(
+def get_task(
     task_id: Annotated[UUID, Path()],
     db_session: Annotated[Session, Depends(gen_dbsession)],
     current_user: Annotated[User | None, Depends(get_current_user_or_none)],
@@ -114,7 +114,7 @@ async def get_task(
 
 
 @router.post("/{requested_task_id}")
-async def create_task(
+def create_task(
     requested_task_id: Annotated[UUID, Path()],
     task_create_schema: TaskCreateSchema,
     db_session: Annotated[Session, Depends(gen_dbsession)],
@@ -154,7 +154,7 @@ async def create_task(
 
 
 @router.patch("/{task_id}")
-async def update_task(
+def update_task(
     task_id: Annotated[UUID, Path()],
     task_update_schema: TaskUpdateSchema,
     db_session: Annotated[Session, Depends(gen_dbsession)],
@@ -174,7 +174,7 @@ async def update_task(
 
 
 @router.post("/{task_id}/cancel")
-async def cancel_task(
+def cancel_task(
     task_id: Annotated[UUID, Path()],
     db_session: Annotated[Session, Depends(gen_dbsession)],
     current_user: Annotated[User, Depends(get_current_user)],

--- a/backend/src/zimfarm_backend/api/routes/workers/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/workers/logic.py
@@ -39,7 +39,7 @@ router = APIRouter(prefix="/workers", tags=["workers"])
 
 
 @router.get("")
-async def get_workers(
+def get_workers(
     session: Annotated[OrmSession, Depends(gen_dbsession)],
     current_user: Annotated[User | None, Depends(get_current_user_or_none)],
     skip: Annotated[SkipField, Query()] = 0,
@@ -68,7 +68,7 @@ async def get_workers(
 
 
 @router.put("/{name}")
-async def update_worker(
+def update_worker(
     name: Annotated[str, Path()],
     request: WorkerUpdateSchema,
     session: Annotated[OrmSession, Depends(gen_dbsession)],
@@ -97,7 +97,7 @@ async def update_worker(
 
 
 @router.get("/{name}")
-async def get_worker(
+def get_worker(
     name: Annotated[str, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
     current_user: Annotated[User | None, Depends(get_current_user_or_none)],
@@ -112,7 +112,7 @@ async def get_worker(
 
 
 @router.put("/{name}/check-in")
-async def check_in_worker(
+def check_in_worker(
     name: Annotated[str, Path()],
     worker_checkin: WorkerCheckInSchema,
     session: Annotated[OrmSession, Depends(gen_dbsession)],

--- a/backend/src/zimfarm_backend/db/tasks.py
+++ b/backend/src/zimfarm_backend/db/tasks.py
@@ -44,7 +44,10 @@ from zimfarm_backend.db.offliner import get_offliner
 from zimfarm_backend.db.offliner_definition import create_offliner_instance
 from zimfarm_backend.db.schedule import get_schedule_duration
 from zimfarm_backend.db.user import get_user_by_username
-from zimfarm_backend.utils.timestamp import get_timestamp_for_status
+from zimfarm_backend.utils.timestamp import (
+    get_status_timestamp_expr,
+    get_timestamp_for_status,
+)
 
 
 class TaskListResult(BaseModel):
@@ -195,7 +198,11 @@ def get_tasks(
             (Schedule.name == schedule_name) | (schedule_name is None),
             (Task.status.in_(status)),
         )
-        .order_by(Task.updated_at.desc())
+        .order_by(
+            get_status_timestamp_expr(Task.timestamp, TaskStatus.started).desc(),
+            get_status_timestamp_expr(Task.timestamp, TaskStatus.reserved).desc(),
+            Task.updated_at.desc(),
+        )
         .offset(skip)
         .limit(limit)
     )

--- a/frontend-ui/src/components/PipelineTable.vue
+++ b/frontend-ui/src/components/PipelineTable.vue
@@ -78,11 +78,27 @@
             <template #activator="{ props }">
               <span v-bind="props" class="text-no-wrap">
                 <router-link :to="{ name: 'task-detail', params: { id: item.id } }">
-                  {{ fromNow(getTimestampStringForStatus(item.timestamp, 'reserved')) }}
+                  {{
+                    fromNow(
+                      getTimestampStringForStatus(
+                        item.timestamp,
+                        'started',
+                        getTimestampStringForStatus(item.timestamp, 'reserved'),
+                      ),
+                    )
+                  }}
                 </router-link>
               </span>
             </template>
-            <span>{{ formatDt(getTimestampStringForStatus(item.timestamp, 'reserved')) }}</span>
+            <span>{{
+              formatDt(
+                getTimestampStringForStatus(
+                  item.timestamp,
+                  'started',
+                  getTimestampStringForStatus(item.timestamp, 'reserved'),
+                ),
+              )
+            }}</span>
           </v-tooltip>
         </template>
 


### PR DESCRIPTION
## Rationale
This PR sorts the list of tasks returned by the db using three ties:
- the time the tasks started (in ascending order)
- the time the task was reserved (in ascending order)
- the time the task was last updated (in descending order)
A task is considered 'doing' once it's reserved, hence the decision to include the 'reserved' status in the sort.
This has the general effect that most recent tasks will be returned first.

## Changes
- remove `async` keyword in front of route definitions (purely cosmetic as FastAPI doesn't care but it's clearer the code isn't async in any way)
- sort tasks by combination of started timestamp, reserved timestamp and updated_at.

This closes #1700
