### PR TITLE
generate and use access token before advertising book to cms

### DIFF
--- a/backend/src/zimfarm_backend/background_tasks/constants.py
+++ b/backend/src/zimfarm_backend/background_tasks/constants.py
@@ -8,7 +8,7 @@ from zimfarm_backend.common.constants import getenv, parse_bool
 HISTORY_TASK_PER_SCHEDULE = int(getenv("HISTORY_TASK_PER_SCHEDULE", default=10))
 
 # Stalled task timeouts
-STALLED_GONE_TIMEOUT = parse_timespan(getenv("STALLED_GONE_TIMEOUT", default="1h"))
+STALLED_GONE_TIMEOUT = parse_timespan(getenv("STALLED_GONE_IMEOUT", default="1h"))
 # when launching worker, it sets status to `started` then start scraper and
 # change status to `scraper_started` so it's a minutes max duration
 STALLED_STARTED_TIMEOUT = parse_timespan(
@@ -71,4 +71,13 @@ CMS_MAXIMUM_RETRY_INTERVAL = parse_timespan(
 )
 DELETE_ORPHANED_BLOBS_INTERVAL = datetime.timedelta(
     seconds=parse_timespan(getenv("DELETE_ORPHANED_BLOBS_INTERVAL", default="24h"))
+)
+
+CMS_OAUTH_ISSUER = getenv("CMS_OAUTH_ISSUER", default="https://login.kiwix.org")
+CMS_OAUTH_CLIENT_ID = getenv("CMS_OAUTH_CLIENT_ID", default="")
+CMS_OAUTH_CLIENT_SECRET = getenv("CMS_OAUTH_CLIENT_SECRET", default="")
+CMS_OAUTH_AUDIENCE_ID = getenv("CMS_OAUTH_AUDIENCE_ID", default="")
+# Number of seconds before the access token expires at which it should be renewed
+CMS_TOKEN_RENEWAL_WINDOW = datetime.timedelta(
+    seconds=parse_timespan(getenv("CMS_TOKEN_RENEWAL_WINDOW", default="5m"))
 )

--- a/backend/src/zimfarm_backend/common/constants.py
+++ b/backend/src/zimfarm_backend/common/constants.py
@@ -141,11 +141,7 @@ WASABI_MAX_WHITELIST_VERSIONS = int(
 # openZIM CMS can be called upon receival of each ZIM
 INFORM_CMS = parse_bool(getenv("INFORM_CMS", default="false"))
 CMS_ENDPOINT = getenv(
-    "CMS_ENDPOINT", default="https://api.cms.openzim.org/v1/books/add"
-)
-# URL to tell the CMS where to download ZIM from
-CMS_ZIM_DOWNLOAD_URL = getenv(
-    "CMS_ZIM_DOWNLOAD_URL", default="https://download.kiwix.org/zim"
+    "CMS_ENDPOINT", default="https://api.cms.openzim.org/v1/zimfarm-notifications"
 )
 
 # [DEBUG] prevent scraper containers from running wit extended capabilities


### PR DESCRIPTION
## Rationale
This PR enhances the logic that advertises book to cms to generate and use access tokens as authentication mechanism.
It also removes unwanted fields sent as part of the payload to the CMS endpoint

## Changes
- add env vars for oauth2 client token generation
- add functionality to generate access token and cache expires_time
- move logic for advertising book to cms to background task where it's used.
- remove unnecessary params in payload. previous code added `period` (retrieved from `metadata["Date"]`) and download_url. These fields are now computed/retrieved by the CMS 

This closes #1677
