### PR TITLE
return false if unable to fetch user info from handlecallback

### DIFF
--- a/frontend-ui/src/stores/auth.ts
+++ b/frontend-ui/src/stores/auth.ts
@@ -307,6 +307,7 @@ export const useAuthStore = defineStore('auth', () => {
 
       // Fetch user info from backend using the Kiwix token
       await fetchUserInfo(newToken.access_token)
+      if (!user.value) return false
 
       errors.value = []
       provider.saveToken(newToken)


### PR DESCRIPTION
## Rationale
in the logic to handle an auth mechanism's callback, we should return false if we were unable to fetch a user. this success status is used by the callback view to display errors. This should display token requirement errors to the frontend after authentication.
<img width="1199" height="616" alt="Screenshot_20260220_150914" src="https://github.com/user-attachments/assets/fc59e365-e1cc-4a5f-a414-fa62ed687d18" />


This closes #1688