### PR TITLE
translate oauth2 callback error messages

### DIFF
--- a/frontend-ui/src/types/errors.ts
+++ b/frontend-ui/src/types/errors.ts
@@ -4,8 +4,17 @@ export interface ErrorResponse {
   errors?: Record<string, string>
 }
 
+export interface OAuth2ErrorRecord {
+  id: string
+  code: number
+  status: string
+  reason: string
+  details: Record<string, string>
+  message: string
+}
+
 export interface OAuth2ErrorResponse {
   code?: number
-  error: string
+  error: string | OAuth2ErrorRecord
   error_description?: string
 }

--- a/frontend-ui/src/utils/errors.ts
+++ b/frontend-ui/src/utils/errors.ts
@@ -1,9 +1,39 @@
-import { type ErrorResponse } from '@/types/errors'
+import { type ErrorResponse, type OAuth2ErrorResponse } from '@/types/errors'
 
-export function translateErrors(error: ErrorResponse) {
-  // build up a list of the errors
-  const errors = []
-  if (error.errors) {
+export function translateErrors(error: ErrorResponse | OAuth2ErrorResponse) {
+  // Handle OAuth2ErrorResponse
+  if ('error' in error) {
+    const errors = []
+
+    if (typeof error.error === 'object') {
+      if (error.error.message) {
+        errors.push(error.error.message)
+      }
+      if (error.error.reason) {
+        errors.push(error.error.reason)
+      }
+      if (errors.length > 0) {
+        return errors
+      }
+    }
+
+    if (typeof error.error === 'string') {
+      errors.push(error.error)
+    }
+
+    // Add error_description if present
+    if (error.error_description) {
+      errors.push(error.error_description)
+    }
+
+    if (errors.length > 0) {
+      return errors
+    }
+  }
+
+  // Handle ErrorResponse
+  if ('errors' in error && error.errors) {
+    const errors = []
     if (error.message) {
       errors.push(error.message)
     }
@@ -13,7 +43,7 @@ export function translateErrors(error: ErrorResponse) {
     return errors
   }
 
-  if (error.message) {
+  if ('message' in error && error.message) {
     return [error.message]
   }
 


### PR DESCRIPTION
## Rationale
This PR attempts to unify the error message sent by both the zimfarm and Ory APIs to a list of strings that can be shown on the UI. This way, messages can be used by the views that require them (e,g Callback view)  knowing they are a list of strings and not really caring where they are coming from

## Changes
- enhance logic for translating errors to include oauth2 error responses too

This closes #1712
