### PR TITLE
limit the size of scraper logs submitted on the fly

### DIFF
--- a/worker/src/zimfarm_worker/common/requests.py
+++ b/worker/src/zimfarm_worker/common/requests.py
@@ -78,7 +78,7 @@ def query_api(
         return Response(
             status_code=resp.status_code,
             success=resp.ok,
-            json=resp.json() if resp.text else {},
+            json=resp.json() if resp.text and resp.text.strip() else {},
         )
     except (JSONDecodeError, Exception) as exc:
         logger.exception(

--- a/worker/src/zimfarm_worker/task/worker.py
+++ b/worker/src/zimfarm_worker/task/worker.py
@@ -42,6 +42,8 @@ from zimfarm_worker.task.zim import get_zim_info
 SLEEP_INTERVAL = 60  # nb of seconds to sleep before watching
 CPU_EWMA_ALPHA = 0.01  # EWMA smoothing factor for CPU percentage samples (0..1)
 
+MAX_LOG_SIZE = 1000 * 1000  # Number of log characters to store on API
+
 
 PENDING = "pending"
 DOING = "doing"
@@ -302,8 +304,15 @@ class TaskWorker(BaseWorker):
             logger.error("No scraper to update")
             return
         self.scraper.reload()
-        stdout = self.scraper.logs(stdout=True, stderr=False, tail=5000).decode("utf-8")
-        stderr = self.scraper.logs(stdout=False, stderr=True, tail=5000).decode("utf-8")
+        # Cap the scraper logs at MAX_LOG_SIZE to avoid exceeding the API payload
+        # limit. The full scraper logs will inadvertently be uploaded whether the
+        # scraper is stopped or succeeded (unless killed manually by user)
+        stdout = (
+            self.scraper.logs(stdout=True, stderr=False, tail=5000)[-MAX_LOG_SIZE:]
+        ).decode("utf-8", errors="replace")
+        stderr = (
+            self.scraper.logs(stdout=False, stderr=True, tail=5000)[-MAX_LOG_SIZE:]
+        ).decode("utf-8", errors="replace")
         scraper_stats = self.scraper.stats(  # pyright: ignore[reportUnknownVariableType, reportUnknownMemberType]
             stream=False
         )
@@ -1294,8 +1303,12 @@ class TaskWorker(BaseWorker):
             return
         self.scraper.reload()
         exit_code = self.scraper.attrs["State"]["ExitCode"]
-        stdout = self.scraper.logs(stdout=True, stderr=False, tail=100).decode("utf-8")
-        stderr = self.scraper.logs(stdout=False, stderr=True, tail=100).decode("utf-8")
+        stdout = (
+            self.scraper.logs(stdout=True, stderr=False, tail=100)[-MAX_LOG_SIZE:]
+        ).decode("utf-8", errors="replace")
+        stderr = (
+            self.scraper.logs(stdout=False, stderr=True, tail=100)[-MAX_LOG_SIZE:]
+        ).decode("utf-8", errors="replace")
         self.mark_scraper_completed(exit_code, stdout, stderr)
         self.scraper_succeeded = exit_code == 0
         self.upload_scraper_log()


### PR DESCRIPTION
## Rationale
This PR aims to restrict the size of scraper logs generated and submitted to the API as the requests appear to be rejected by load balancer and don't reach the API, thereby making it seem like the task is stale and inadvertently getting canceled by the periodic task (see #1704). For now, the size is capped at 1million charactrs both for the scraper stderr and scraper stdout output. Since these logs are eventually uploaded, the log attribute of the task will be more of a mirror of the most recent logs instead of the full logs (which can exceed the API limit)

## Changes
- cap scraper stdout and stderr output sent to the API at 1 milion characteres
