### PR TITLE
dump notifications object as json

### DIFF
--- a/backend/src/zimfarm_backend/db/schedule.py
+++ b/backend/src/zimfarm_backend/db/schedule.py
@@ -599,7 +599,7 @@ def update_schedule(
     )
     schedule.is_valid = is_valid if is_valid is not None else schedule.is_valid
     schedule.notification = (
-        notification.model_dump() if notification else schedule.notification
+        notification.model_dump(mode="json") if notification else schedule.notification
     )
 
     schedule.context = context if context is not None else schedule.context

--- a/backend/src/zimfarm_backend/db/tasks.py
+++ b/backend/src/zimfarm_backend/db/tasks.py
@@ -402,10 +402,14 @@ def create_or_update_task_file(
     request: FileCreateUpdateSchema,
 ):
     """Create or update a task file using insert with on conflict update."""
-    values = request.model_dump(exclude_unset=True)
+    values = request.model_dump(exclude_unset=True, mode="json")
     stmt = insert(File).values(**values)
     stmt = stmt.on_conflict_do_update(
         index_elements=[File.task_id, File.name],
-        set_={**request.model_dump(exclude_unset=True, exclude={"task_id", "name"})},
+        set_={
+            **request.model_dump(
+                exclude_unset=True, exclude={"task_id", "name"}, mode="json"
+            )
+        },
     )
     session.execute(stmt)

--- a/backend/src/zimfarm_backend/db/user.py
+++ b/backend/src/zimfarm_backend/db/user.py
@@ -178,7 +178,7 @@ def update_user(
     if request.role is not None and request.scope is not None:
         raise ValueError("Only one of role/scope must be set.")
 
-    values = request.model_dump(exclude_unset=True)
+    values = request.model_dump(exclude_unset=True, mode="json")
 
     if "display_name" in values and not values["display_name"]:
         raise ValueError("User must have a display name.")


### PR DESCRIPTION
## Rationale
In kiwix/operations#643, it appears notifications objects aren't saved because they cannot be properly serialzied with just plain `model_dump`. This PR forces to be dumped with `mode='json'` so it can be properly saved to the database.

