### PR TITLE
add warehouse and filename to cms notification

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/requested_tasks/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/requested_tasks/logic.py
@@ -262,6 +262,7 @@ def get_requested_tasks_for_worker(
                     ),
                     timestamp=task.timestamp,
                     requested_by=task.requested_by,
+                    requester_id=task.requester_id,
                     priority=task.priority,
                     original_schedule_name=task.original_schedule_name,
                     worker_name=task.worker_name,

--- a/backend/src/zimfarm_backend/api/routes/tasks/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/tasks/logic.py
@@ -200,7 +200,7 @@ def cancel_task(
         db_session,
         task.id,
         TaskStatus.cancel_requested,
-        {"canceled_by": current_user.username},
+        {"canceled_by": str(current_user.id)},
     )
 
     return Response(status_code=HTTPStatus.NO_CONTENT)

--- a/backend/src/zimfarm_backend/background_tasks/send_cms_notifications.py
+++ b/backend/src/zimfarm_backend/background_tasks/send_cms_notifications.py
@@ -32,7 +32,7 @@ from zimfarm_backend.common.schemas.orms import (
     TaskFileSchema,
     TaskFullSchema,
 )
-from zimfarm_backend.common.upload import upload_url
+from zimfarm_backend.common.upload import generate_http_upload_url
 from zimfarm_backend.db.models import File, Task
 from zimfarm_backend.db.tasks import create_or_update_task_file, get_task_by_id
 
@@ -137,8 +137,11 @@ def advertise_book_to_cms(session: OrmSession, task: TaskFullSchema, file_name: 
         resp = requests.post(
             url,
             json=get_openzimcms_payload(
-                file_data,
-                task.upload.check.upload_uri if task.upload.check else None,
+                file=file_data,
+                warehouse_path=task.config.warehouse_path,
+                zimcheck_base_url=(
+                    task.upload.check.upload_uri if task.upload.check else None
+                ),
             ),
             timeout=REQ_TIMEOUT_CMS,
             headers={"Authorization": f"Bearer {access_token}"},
@@ -168,17 +171,19 @@ def advertise_book_to_cms(session: OrmSession, task: TaskFullSchema, file_name: 
 
 
 def get_openzimcms_payload(
-    file: TaskFileSchema, zimcheck_base_url: str | None
+    *, file: TaskFileSchema, zimcheck_base_url: str | None, warehouse_path: str
 ) -> dict[str, Any]:
     payload = {
         "id": file.info["id"],
         "counter": file.info.get("counter"),
         "article_count": file.info.get("article_count"),
+        "folder_name": warehouse_path,
+        "filename": file.name,
         "media_count": file.info.get("media_count"),
         "size": file.info.get("size"),
         "metadata": file.info.get("metadata"),
         "zimcheck_url": (
-            upload_url(zimcheck_base_url, file.check_filename)
+            generate_http_upload_url(zimcheck_base_url, file.check_filename)
             if zimcheck_base_url and file.check_filename
             else None
         ),

--- a/backend/src/zimfarm_backend/common/constants.py
+++ b/backend/src/zimfarm_backend/common/constants.py
@@ -67,10 +67,7 @@ ARTIFACTS_UPLOAD_URI = getenv("ARTIFACTS_UPLOAD_URI", default=None)
 # on the bucket and the bucket retention is smaller than value below
 ARTIFACTS_EXPIRATION = int(getenv("ARTIFACTS_EXPIRATION", default="30"))
 
-ZIMCHECK_RESULTS_UPLOAD_URI = getenv(
-    "ZIMCHECK_RESULTS_UPLOAD_URI",
-    default="sftp://uploader@warehouse.farm.openzim.org:1522/zimchecks",
-)
+ZIMCHECK_RESULTS_UPLOAD_URI = getenv("ZIMCHECK_RESULTS_UPLOAD_URI", default="")
 # zimcheck files expiration, 0 to disable expiration
 # only working in Wasabi S3 for now, works only if retention compliance is activated
 # on the bucket and the bucket retention is smaller than value below

--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -189,6 +189,7 @@ class BaseRequestedTaskSchema(BaseModel):
     status: str
     timestamp: list[tuple[str, datetime.datetime]]
     requested_by: str
+    requester_id: UUID = Field(exclude=True)
     priority: int
     schedule_name: str | None
     original_schedule_name: str

--- a/backend/src/zimfarm_backend/common/upload.py
+++ b/backend/src/zimfarm_backend/common/upload.py
@@ -87,8 +87,11 @@ def build_task_upload_uris(
     return task
 
 
-def upload_url(uri: str, filename: str) -> str:
-    """Generate a display URL for an upload based on the URI scheme."""
+def generate_http_upload_url(uri: str, filename: str) -> str:
+    """Generate a HTTP(S) URL for HTTP/S3 upload URLs.
+
+    Raises ValueError if upload uri scheme is not HTTP(S) or S3.
+    """
     url = urllib.parse.urlparse(uri)
     scheme = url.scheme
 
@@ -122,4 +125,4 @@ def upload_url(uri: str, filename: str) -> str:
 
         return f"{url.scheme}://{url.netloc}{path}{filename}"
 
-    return filename
+    raise ValueError(f"Unsupported scheme '{scheme}' in URI.")

--- a/backend/src/zimfarm_backend/common/utils.py
+++ b/backend/src/zimfarm_backend/common/utils.py
@@ -18,7 +18,7 @@ from zimfarm_backend.db.exceptions import RecordDoesNotExistError
 from zimfarm_backend.db.models import Task
 from zimfarm_backend.db.schedule import update_schedule_duration
 from zimfarm_backend.db.tasks import create_or_update_task_file
-from zimfarm_backend.db.user import get_user_by_username
+from zimfarm_backend.db.user import get_user_by_identifier
 from zimfarm_backend.db.worker import get_worker
 
 logger = logging.getLogger(__name__)
@@ -158,7 +158,9 @@ def save_event(
         task.worker = worker
 
     if "canceled_by" in kwargs:
-        task.canceled_by = get_user_by_username(session, username=kwargs["canceled_by"])
+        task.canceled_by = get_user_by_identifier(
+            session, user_identifier=kwargs["canceled_by"]
+        )
 
     add_to_container_if_present(
         task=task, kwargs_key="command", container_key="command"

--- a/backend/src/zimfarm_backend/db/requested_task.py
+++ b/backend/src/zimfarm_backend/db/requested_task.py
@@ -329,7 +329,8 @@ def get_requested_tasks(
             RequestedTask.status,
             RequestedTask.config,
             RequestedTask.timestamp,
-            User.username.label("requested_by"),
+            User.display_name.label("requested_by"),
+            User.id.label("requester_id"),
             RequestedTask.priority,
             RequestedTask.original_schedule_name,
             RequestedTask.updated_at,
@@ -384,6 +385,7 @@ def get_requested_tasks(
         config,
         timestamp,
         requested_by,
+        requester_id,
         _priority,
         original_schedule_name,
         updated_at,
@@ -408,6 +410,7 @@ def get_requested_tasks(
                 ),
                 timestamp=timestamp,
                 requested_by=requested_by,
+                requester_id=requester_id,
                 priority=_priority,
                 original_schedule_name=original_schedule_name,
                 updated_at=updated_at,
@@ -426,6 +429,7 @@ class RequestedTaskWithDuration(BaseModel):
     config: ExpandedScheduleConfigSchema
     timestamp: list[tuple[str, datetime.datetime]]
     requested_by: str
+    requester_id: UUID = Field(exclude=True)
     priority: int
     schedule_name: str | None
     original_schedule_name: str
@@ -518,6 +522,7 @@ def get_tasks_doable_by_worker(
                 ),
                 timestamp=task.timestamp,
                 requested_by=task.requested_by.display_name,
+                requester_id=task.requested_by.id,
                 priority=task.priority,
                 worker_name=task.worker.name if task.worker else worker.name,
                 context=task.context,
@@ -740,6 +745,7 @@ def create_requested_task_full_schema(
         ),
         timestamp=requested_task.timestamp,
         requested_by=requested_task.requested_by.display_name,
+        requester_id=requested_task.requested_by.id,
         priority=requested_task.priority,
         schedule_name=(
             requested_task.schedule.name if requested_task.schedule else None

--- a/backend/src/zimfarm_backend/db/tasks.py
+++ b/backend/src/zimfarm_backend/db/tasks.py
@@ -43,7 +43,6 @@ from zimfarm_backend.db.models import (
 from zimfarm_backend.db.offliner import get_offliner
 from zimfarm_backend.db.offliner_definition import create_offliner_instance
 from zimfarm_backend.db.schedule import get_schedule_duration
-from zimfarm_backend.db.user import get_user_by_username
 from zimfarm_backend.utils.timestamp import (
     get_status_timestamp_expr,
     get_timestamp_for_status,
@@ -288,9 +287,7 @@ def create_task(
         context=requested_task.context,
     )
     task.id = requested_task.id
-    task.requested_by_id = get_user_by_username(
-        session, username=requested_task.requested_by
-    ).id
+    task.requested_by_id = requested_task.requester_id
     task.schedule_id = requested_task.schedule_id
     task.worker_id = worker_id
     task.offliner_definition_id = requested_task.offliner_definition_id

--- a/backend/tests/db/test_requested_task.py
+++ b/backend/tests/db/test_requested_task.py
@@ -914,6 +914,7 @@ def test_does_platform_allow_worker_to_run(
         config=expanded_config(schedule_config, mwoffliner, mwoffliner_definition),
         timestamp=[("requested", getnow()), ("reserved", getnow())],
         requested_by=worker.user.display_name,
+        requester_id=worker.user.id,
         priority=0,
         schedule_name="test_schedule",
         original_schedule_name="test_schedule",

--- a/backend/tests/test_upload.py
+++ b/backend/tests/test_upload.py
@@ -7,9 +7,9 @@ import pytest
 from zimfarm_backend.common.constants import SECRET_STRING_LENGTH
 from zimfarm_backend.common.upload import (
     build_task_upload_uris,
+    generate_http_upload_url,
     rebuild_uri,
     safe_upload_uri,
-    upload_url,
 )
 
 
@@ -334,10 +334,10 @@ def test_build_task_upload_uris_no_secrets_in_uri():
 )
 def test_upload_url(uri: str, filename: str, expected: str):
     """Test upload_url function with various URI schemes and filenames."""
-    result = upload_url(uri, filename)
+    result = generate_http_upload_url(uri, filename)
     assert result == expected
 
 
 def test_upload_url_with_invalid_uri():
-    result = upload_url("not a valid uri at all", "file.zim")
-    assert result == "file.zim"
+    with pytest.raises(ValueError):
+        generate_http_upload_url("not a valid uri at all", "file.zim")


### PR DESCRIPTION
## Rationale
This PR adds the warehouse and zim filename to the payload to the CMS. Furthermore, it removes usage of `get_user_by_username` and uses user_id in task cancellation events. 

## Changes
- add `filename` and `folder_name` to cms payload
- cancel events by user_id instead of username as those could be nullable (see #1722)
- give function to generate HTTP upload URLs better name

This closes #1727
