### PR TITLE
return display name instead of username while fetching tasks

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/requested_tasks/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/requested_tasks/logic.py
@@ -188,7 +188,7 @@ def get_requested_tasks_for_worker(
 
     fallback_ip = request.client.host if request.client else None
     x_forwarded_for = request.headers.get("X-Forwarded-For", fallback_ip)
-    if worker.user.username == current_user.username:
+    if worker.user.id == current_user.id:
         ip_changed = str(worker.last_ip) != x_forwarded_for
 
         if ip_changed:

--- a/backend/src/zimfarm_backend/db/tasks.py
+++ b/backend/src/zimfarm_backend/db/tasks.py
@@ -135,7 +135,7 @@ def get_task_by_id_or_none(session: OrmSession, task_id: UUID) -> TaskFullSchema
             events=task.events,
             debug=task.debug,
             requested_by=task.requested_by.display_name,
-            canceled_by=task.canceled_by.username if task.canceled_by else None,
+            canceled_by=task.canceled_by.display_name if task.canceled_by else None,
             container=TaskContainerSchema.model_validate(task.container),
             priority=task.priority,
             notification=(
@@ -202,7 +202,7 @@ def get_tasks(
                 Task.config["resources"].label("resources"),
             ),
             Task.updated_at,
-            User.username.label("requested_by"),
+            User.display_name.label("requested_by"),
             Schedule.name.label("schedule_name"),
             Worker.name.label("worker_name"),
         )


### PR DESCRIPTION
## Changes
- return display_name instead of username while fetching tasks
- compare worker user_id to current_user id instead of username while getting tasks for worker
- get rid of last dealings with username in app/db logic. only used in logic for updating ssh keys/password as they are required in those places.

This closes #1729
