### PR TITLE
suppress pydantic serialization warnings

### DIFF
--- a/backend/src/zimfarm_backend/__init__.py
+++ b/backend/src/zimfarm_backend/__init__.py
@@ -1,6 +1,19 @@
 import logging
+import warnings
 
 from zimfarm_backend.common.constants import DEBUG
+
+# The offliner configuration is dynamic and it has types built at runtime.
+# However, because the database could contain data which does not meet these type
+# constraints, reads from the database are often done with skip_validation set to True
+# and this bypasses all validation. As a consequence, when dumping results to clients,
+# Pydantic complains about types mismatch. This is often noisy and needs to be
+# suppressed.
+warnings.filterwarnings(
+    "ignore",
+    message=".*Pydantic serializer warnings.*",
+    category=UserWarning,
+)
 
 logger = logging.getLogger("zimfarm_backend")
 

--- a/backend/tests/routes/test_schedules.py
+++ b/backend/tests/routes/test_schedules.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from http import HTTPStatus
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -720,11 +721,15 @@ def test_delete_schedule(
     assert response.status_code == expected_status_code
 
 
+@patch("zimfarm_backend.api.routes.schedules.logic.get_schedule_image_tags")
 def test_get_schedule_image_names(
+    mock_get_tags: MagicMock,
     client: TestClient,
     dbsession: OrmSession,
     create_schedule: Callable[..., Schedule],
 ):
+    mock_get_tags.return_value = ["latest", "1.0.0", "1.0.1"]
+
     schedule = create_schedule(name="test_schedule")
     dbsession.add(schedule)
     dbsession.flush()
@@ -737,6 +742,8 @@ def test_get_schedule_image_names(
     assert "items" in data
     for item in data["items"]:
         assert isinstance(item, str)
+
+    mock_get_tags.assert_called_once_with("openzim/mwoffliner")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Changes
- suppress pydantic serialization warnings
- patch call to get schedule image tags in tests

This fixes #1541