### PR TITLE
retrieve zim donwload/view urls from cms

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/tasks/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/tasks/logic.py
@@ -17,7 +17,7 @@ from zimfarm_backend.api.routes.http_errors import (
 )
 from zimfarm_backend.api.routes.models import ListResponse
 from zimfarm_backend.api.routes.tasks.models import TaskCreateSchema, TaskUpdateSchema
-from zimfarm_backend.common.constants import ENABLED_SCHEDULER
+from zimfarm_backend.common.constants import ENABLED_SCHEDULER, INFORM_CMS
 from zimfarm_backend.common.enums import TaskStatus
 from zimfarm_backend.common.schemas.fields import (
     LimitFieldMax200,
@@ -27,8 +27,8 @@ from zimfarm_backend.common.schemas.models import (
     ScheduleConfigSchema,
     calculate_pagination_metadata,
 )
-from zimfarm_backend.common.schemas.orms import TaskLightSchema
-from zimfarm_backend.common.upload import build_task_upload_uris
+from zimfarm_backend.common.schemas.orms import TaskFullSchema, TaskLightSchema
+from zimfarm_backend.common.upload import build_task_upload_uris, populate_zim_urls
 from zimfarm_backend.common.utils import task_event_handler
 from zimfarm_backend.db.models import User
 from zimfarm_backend.db.offliner import get_offliner as db_get_offliner
@@ -116,6 +116,8 @@ def get_task(
     task = build_task_upload_uris(
         task, keys=["secretAccessKey", "keyId"], show_secrets=show_secrets
     )
+    if INFORM_CMS:
+        populate_zim_urls(cast(TaskFullSchema, task))
     return JSONResponse(
         content=task.model_dump(mode="json", context={"show_secrets": show_secrets})
     )

--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -1,7 +1,7 @@
 import datetime
 from collections import defaultdict
 from ipaddress import IPv4Address, IPv6Address
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 import pytz
@@ -82,6 +82,14 @@ class TaskLightSchema(BaseTaskSchema):
     config: ConfigWithOnlyResourcesSchema
 
 
+class ZimUrlSchema(BaseModel):
+    """Schema for a single zim URL"""
+
+    kind: Literal["view", "download"]
+    url: AnyUrl
+    collection: str
+
+
 class TaskFileSchema(BaseModel):
     """
     Schema for reading the files associated with a task
@@ -102,6 +110,9 @@ class TaskFileSchema(BaseModel):
     check_filename: str | None = None
     check_upload_timestamp: datetime.datetime | None = None
     info: dict[str, Any] = Field(default_factory=dict)
+    zim_urls: list[ZimUrlSchema] = Field(  # pyright: ignore[reportUnknownVariableType]
+        default_factory=list
+    )
 
 
 class TaskContainerProgressSchema(BaseModel):

--- a/backend/src/zimfarm_backend/common/upload.py
+++ b/backend/src/zimfarm_backend/common/upload.py
@@ -1,9 +1,20 @@
 import pathlib
 import urllib.parse
 
+import requests
+
 from zimfarm_backend import logger
-from zimfarm_backend.common.constants import SECRET_STRING_LENGTH
-from zimfarm_backend.common.schemas.orms import RequestedTaskFullSchema, TaskFullSchema
+from zimfarm_backend.common.constants import (
+    CMS_BASE_URL,
+    REQ_TIMEOUT_CMS,
+    SECRET_STRING_LENGTH,
+)
+from zimfarm_backend.common.schemas.orms import (
+    RequestedTaskFullSchema,
+    TaskFileSchema,
+    TaskFullSchema,
+    ZimUrlSchema,
+)
 
 
 def rebuild_uri(
@@ -126,3 +137,31 @@ def generate_http_upload_url(uri: str, filename: str) -> str:
         return f"{url.scheme}://{url.netloc}{path}{filename}"
 
     raise ValueError(f"Unsupported scheme '{scheme}' in URI.")
+
+
+def populate_zim_urls(task: TaskFullSchema) -> None:
+    """Populate the zim_urls for task ZIM files."""
+    zim_ids: dict[str, TaskFileSchema] = {}  # mapping of zim_id to the file
+
+    for _, file in task.files.items():
+        if file.info and file.info.get("id"):
+            zim_ids[file.info["id"]] = file
+
+    if zim_ids:
+        try:
+            response = requests.get(
+                f"{CMS_BASE_URL}/books/zims",
+                timeout=REQ_TIMEOUT_CMS,
+                params={"zim_ids": list(zim_ids.keys())},
+            )
+            response.raise_for_status()
+        except Exception:
+            logger.exception(
+                "An unexpected error occurred while fetching ZIM URLs from CMS"
+            )
+        else:
+            data = response.json()["urls"]
+            for zim_id, entries in data.items():
+                zim_ids[zim_id].zim_urls = [
+                    ZimUrlSchema.model_validate(entry) for entry in entries
+                ]

--- a/backend/tests/routes/test_task.py
+++ b/backend/tests/routes/test_task.py
@@ -1,18 +1,23 @@
 from collections.abc import Callable
 from http import HTTPStatus
 from typing import Literal
+from unittest.mock import Mock, patch
 from uuid import uuid4
 
 import pytest
+import requests
 from fastapi.testclient import TestClient
 from sqlalchemy.orm import Session as OrmSession
 from sqlalchemy.orm.attributes import flag_modified
 
+from zimfarm_backend.api.routes.tasks import logic as tasks_module
 from zimfarm_backend.api.token import generate_access_token
 from zimfarm_backend.common import getnow
 from zimfarm_backend.common.enums import TaskStatus
 from zimfarm_backend.common.roles import RoleEnum
+from zimfarm_backend.common.schemas.models import FileCreateUpdateSchema
 from zimfarm_backend.db.models import RequestedTask, Task, User, Worker
+from zimfarm_backend.db.tasks import create_or_update_task_file
 
 
 def test_get_tasks(
@@ -39,12 +44,19 @@ def test_get_tasks(
 
 
 @pytest.mark.parametrize("hide_secrets", ["true", "false"])
+@patch("zimfarm_backend.common.upload.requests.get")
 def test_get_task_no_auth(
+    mock_requests_get: Mock,
     client: TestClient,
     task: Task,
     hide_secrets: str,
 ):
     """Test successful retrieval of a single task"""
+    mock_response = Mock()
+    mock_response.json.return_value = {"urls": {}}
+    mock_response.raise_for_status = Mock()
+    mock_requests_get.return_value = mock_response
+
     response = client.get(
         f"/v2/tasks/{task.id}?hide_secrets={hide_secrets}",
     )
@@ -61,13 +73,20 @@ def test_get_task_no_auth(
 
 
 @pytest.mark.parametrize("hide_secrets", ["true", "false"])
+@patch("zimfarm_backend.common.upload.requests.get")
 def test_get_task_with_auth(
+    mock_requests_get: Mock,
     client: TestClient,
     task: Task,
     access_token: str,
     hide_secrets: Literal["true", "false"],
 ):
     """Test successful retrieval of a single task"""
+    mock_response = Mock()
+    mock_response.json.return_value = {"urls": {}}
+    mock_response.raise_for_status = Mock()
+    mock_requests_get.return_value = mock_response
+
     response = client.get(
         f"/v2/tasks/{task.id}?hide_secrets={hide_secrets}",
         headers={"Authorization": f"Bearer {access_token}"},
@@ -87,12 +106,19 @@ def test_get_task_with_auth(
         assert config["offliner"]["mwPassword"] == "test-password"
 
 
+@patch("zimfarm_backend.common.upload.requests.get")
 def test_get_obsolete_task(
+    mock_requests_get: Mock,
     client: TestClient,
     dbsession: OrmSession,
     create_user: Callable[..., User],
     create_task: Callable[..., Task],
 ):
+    mock_response = Mock()
+    mock_response.json.return_value = {"urls": {}}
+    mock_response.raise_for_status = Mock()
+    mock_requests_get.return_value = mock_response
+
     user = create_user(permission=RoleEnum.ADMIN)
     access_token = generate_access_token(
         issue_time=getnow(),
@@ -309,3 +335,192 @@ def test_cancel_task_success(
         headers={"Authorization": f"Bearer {access_token}"},
     )
     assert response.status_code == HTTPStatus.NO_CONTENT
+
+
+@patch("zimfarm_backend.common.upload.requests.get")
+def test_get_task_populate_zim_urls_disabled(
+    mock_requests_get: Mock,
+    client: TestClient,
+    dbsession: OrmSession,
+    task: Task,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test that populate_zim_urls is not called when INFORM_CMS is disabled"""
+    monkeypatch.setattr(tasks_module, "INFORM_CMS", False)
+
+    create_or_update_task_file(
+        dbsession,
+        FileCreateUpdateSchema(
+            task_id=task.id,
+            name="test.zim",
+            status="uploaded",
+            info={"id": "test-zim-id-123"},
+        ),
+    )
+    dbsession.flush()
+
+    response = client.get(f"/v2/tasks/{task.id}")
+    assert response.status_code == HTTPStatus.OK
+
+    mock_requests_get.assert_not_called()
+
+    data = response.json()
+    assert "files" in data
+    assert "test.zim" in data["files"]
+    assert data["files"]["test.zim"]["zim_urls"] == []
+
+
+@patch("zimfarm_backend.common.upload.requests.get")
+def test_get_task_populate_zim_urls_enabled_no_files(
+    mock_requests_get: Mock,
+    client: TestClient,
+    task: Task,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test populate_zim_urls when INFORM_CMS is enabled but task has no files"""
+    monkeypatch.setattr(tasks_module, "INFORM_CMS", True)
+
+    mock_response = Mock()
+    mock_response.json.return_value = {"urls": {}}
+    mock_response.raise_for_status = Mock()
+    mock_requests_get.return_value = mock_response
+
+    response = client.get(f"/v2/tasks/{task.id}")
+    assert response.status_code == HTTPStatus.OK
+
+    mock_requests_get.assert_not_called()
+
+    data = response.json()
+    assert "files" in data
+    assert len(data["files"]) == 0
+
+
+@patch("zimfarm_backend.common.upload.requests.get")
+def test_get_task_populate_zim_urls_enabled(
+    mock_requests_get: Mock,
+    client: TestClient,
+    dbsession: OrmSession,
+    task: Task,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test populate_zim_urls successfully populates URLs for multiple files"""
+    monkeypatch.setattr(tasks_module, "INFORM_CMS", True)
+
+    zim_id_1 = str(uuid4())
+    zim_id_2 = str(uuid4())
+
+    create_or_update_task_file(
+        dbsession,
+        FileCreateUpdateSchema(
+            task_id=task.id,
+            name="file1.zim",
+            status="uploaded",
+            info={"id": zim_id_1},
+        ),
+    )
+    create_or_update_task_file(
+        dbsession,
+        FileCreateUpdateSchema(
+            task_id=task.id,
+            name="file2.zim",
+            status="uploaded",
+            info={"id": zim_id_2},
+        ),
+    )
+    # File without zim_id
+    create_or_update_task_file(
+        dbsession,
+        FileCreateUpdateSchema(
+            task_id=task.id,
+            name="file3.zim",
+            status="uploaded",
+            info={},
+        ),
+    )
+    dbsession.flush()
+
+    mock_response = Mock()
+    mock_response.json.return_value = {
+        "urls": {
+            zim_id_1: [
+                {
+                    "kind": "view",
+                    "url": "https://library.kiwix.org/viewer#file1.zim",
+                    "collection": "main",
+                }
+            ],
+            zim_id_2: [
+                {
+                    "kind": "download",
+                    "url": "https://download.kiwix.org/zim/file2.zim",
+                    "collection": "archive",
+                }
+            ],
+        }
+    }
+    mock_response.raise_for_status = Mock()
+    mock_requests_get.return_value = mock_response
+
+    response = client.get(f"/v2/tasks/{task.id}")
+    assert response.status_code == HTTPStatus.OK
+
+    mock_requests_get.assert_called_once()
+    call_args = mock_requests_get.call_args
+    zim_ids = call_args[1]["params"]["zim_ids"]
+    assert sorted(zim_ids) == sorted([zim_id_1, zim_id_2])
+
+    data = response.json()
+    assert "files" in data
+
+    # File 1 should have URLs
+    assert "file1.zim" in data["files"]
+    assert len(data["files"]["file1.zim"]["zim_urls"]) == 1
+    assert data["files"]["file1.zim"]["zim_urls"][0]["kind"] == "view"
+
+    # File 2 should have URLs
+    assert "file2.zim" in data["files"]
+    assert len(data["files"]["file2.zim"]["zim_urls"]) == 1
+    assert data["files"]["file2.zim"]["zim_urls"][0]["kind"] == "download"
+
+    # File 3 should not have URLs (no zim_id)
+    assert "file3.zim" in data["files"]
+    assert data["files"]["file3.zim"]["zim_urls"] == []
+
+
+@patch("zimfarm_backend.common.upload.requests.get")
+def test_get_task_populate_zim_urls_cms_api_error(
+    mock_requests_get: Mock,
+    client: TestClient,
+    dbsession: OrmSession,
+    task: Task,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test populate_zim_urls handles CMS API errors gracefully"""
+    monkeypatch.setattr(tasks_module, "INFORM_CMS", True)
+
+    zim_id = str(uuid4())
+    create_or_update_task_file(
+        dbsession,
+        FileCreateUpdateSchema(
+            task_id=task.id,
+            name="test.zim",
+            status="uploaded",
+            info={"id": zim_id},
+        ),
+    )
+    dbsession.flush()
+
+    mock_requests_get.side_effect = requests.exceptions.RequestException(
+        "CMS API unavailable"
+    )
+
+    response = client.get(f"/v2/tasks/{task.id}")
+    assert response.status_code == HTTPStatus.OK
+
+    mock_requests_get.assert_called_once()
+
+    data = response.json()
+    assert "files" in data
+    assert "test.zim" in data["files"]
+    # When there's an error, zim_urls should remain empty
+    assert data["files"]["test.zim"]["zim_urls"] == []

--- a/frontend-ui/src/components/ZimUrlButtons.vue
+++ b/frontend-ui/src/components/ZimUrlButtons.vue
@@ -1,0 +1,52 @@
+<template>
+  <div v-if="loading" class="d-flex align-center">
+    <v-progress-circular indeterminate size="20" width="2" />
+    <span v-if="!compact && !iconOnly" class="ml-2 text-grey">Loading URLs...</span>
+  </div>
+  <div v-else-if="urls && urls.length > 0" :class="iconOnly ? 'd-inline-flex align-center' : ''">
+    <v-tooltip v-for="url in urls" :key="`${url.kind}-${url.collection}`" location="bottom">
+      <template #activator="{ props: tooltipProps }">
+        <v-btn
+          v-bind="tooltipProps"
+          :href="url.url"
+          target="_blank"
+          :icon="iconOnly || compact"
+          :prepend-icon="
+            iconOnly || compact ? undefined : url.kind === 'download' ? 'mdi-download' : 'mdi-eye'
+          "
+          :variant="iconOnly ? 'text' : compact ? 'text' : 'outlined'"
+          :size="iconOnly ? 'x-small' : compact ? 'x-small' : 'small'"
+          :class="iconOnly ? 'ml-1' : compact ? '' : 'mr-2'"
+        >
+          <v-icon v-if="iconOnly || compact" :size="iconOnly ? 'small' : undefined">
+            {{ url.kind === 'download' ? 'mdi-download' : 'mdi-eye' }}
+          </v-icon>
+          <span v-else>{{ url.kind === 'download' ? 'Download' : 'View' }}</span>
+        </v-btn>
+      </template>
+      <span>{{ url.kind === 'download' ? 'Download' : 'View' }} ({{ url.collection }})</span>
+    </v-tooltip>
+  </div>
+  <span v-else-if="!iconOnly" class="text-grey">{{ emptyText }}</span>
+</template>
+
+<script setup lang="ts">
+import type { ZimUrl } from '@/types/tasks'
+
+withDefaults(
+  defineProps<{
+    urls?: ZimUrl[]
+    loading?: boolean
+    compact?: boolean
+    iconOnly?: boolean
+    emptyText?: string
+  }>(),
+  {
+    urls: undefined,
+    loading: false,
+    compact: false,
+    iconOnly: false,
+    emptyText: 'No URLs available',
+  },
+)
+</script>

--- a/frontend-ui/src/types/tasks.ts
+++ b/frontend-ui/src/types/tasks.ts
@@ -10,6 +10,12 @@ export interface TaskEvent {
   timestamp: string
 }
 
+export interface ZimUrl {
+  kind: 'view' | 'download'
+  url: string
+  collection: string
+}
+
 export interface TaskFileInfo {
   id: string
   counter: Record<string, number>
@@ -30,6 +36,7 @@ export interface TaskFile {
   check_filename?: string
   check_upload_timestamp?: string
   info?: TaskFileInfo
+  zim_urls: ZimUrl[]
 }
 
 export interface TaskResourceUsage {

--- a/frontend-ui/src/views/TaskDetailView.vue
+++ b/frontend-ui/src/views/TaskDetailView.vue
@@ -210,12 +210,7 @@
                       :class="smAndDown ? '' : 'files-table'"
                     >
                       <template #[`item.name`]="{ item }">
-                        <a
-                          target="_blank"
-                          :href="kiwixDownloadUrl + task.config.warehouse_path + '/' + item.name"
-                        >
-                          {{ item.name }}
-                        </a>
+                        {{ item.name }}
                       </template>
 
                       <template #[`item.size`]="{ item }">
@@ -286,6 +281,33 @@
                             <FileInfoTable :file-info="item.info" />
                           </v-menu>
                           <span v-else>-</span>
+                        </div>
+                      </template>
+
+                      <template #[`item.urls`]="{ item }">
+                        <div :class="['d-flex', 'align-center', { 'justify-end': smAndDown }]">
+                          <ZimUrlButtons
+                            v-if="item.zim_urls && item.zim_urls.length > 0"
+                            :urls="item.zim_urls"
+                            :icon-only="!smAndDown"
+                          />
+                          <v-tooltip v-else location="bottom">
+                            <template #activator="{ props: tooltipProps }">
+                              <v-btn
+                                v-bind="tooltipProps"
+                                :href="
+                                  kiwixDownloadUrl + task.config.warehouse_path + '/' + item.name
+                                "
+                                target="_blank"
+                                variant="text"
+                                icon
+                                size="small"
+                              >
+                                <v-icon size="small">mdi-download</v-icon>
+                              </v-btn>
+                            </template>
+                            <span>Download</span>
+                          </v-tooltip>
                         </div>
                       </template>
                     </v-data-table>
@@ -597,6 +619,7 @@ import ErrorMessage from '@/components/ErrorMessage.vue'
 import FileInfoTable from '@/components/FileInfoTable.vue'
 import FlagsList from '@/components/FlagsList.vue'
 import ResourceBadge from '@/components/ResourceBadge.vue'
+import ZimUrlButtons from '@/components/ZimUrlButtons.vue'
 import type { Config } from '@/config'
 import constants from '@/constants'
 import { useAuthStore } from '@/stores/auth'
@@ -669,6 +692,7 @@ const filesHeaders = [
   { title: 'Upload Duration', value: 'upload_duration' },
   { title: 'Quality', value: 'quality' },
   { title: 'Info', value: 'info' },
+  { title: 'URLs', value: 'urls' },
 ]
 
 // Computed properties


### PR DESCRIPTION
## Rationale
This PR enhances the API to retrieve download/view links from the CMS while retrieving a task.
<img width="1449" height="238" alt="Screenshot_20260312_121013" src="https://github.com/user-attachments/assets/92c582a8-0b8a-441e-b7a4-12f15c8ded55" />

## Changes
- retrieve cms download/view links if `INFORM_CMS` is enabled while fetching a task
- update UI to show download/view links for zim files. fallback to show the original download url if no urls found

This closes #1439 
