### PR TITLE
set default  ZIMFARM_API_URL for monitor parent

### DIFF
--- a/monitor/parent/Dockerfile
+++ b/monitor/parent/Dockerfile
@@ -8,6 +8,7 @@ ENV DO_NOT_TRACK=1
 ENV STREAM_WHITELIST=""
 ENV NETDATA_HOSTNAME=monitoring.openzim.org
 ENV STREAM_KEY=7DC0DDB8-8EAA-4391-AF5D-BE017EECF0EE
+ENV ZIMFARM_API_URL=https://api.farm.openzim.org/v2
 
 COPY netdata.conf /etc/netdata/netdata.conf
 COPY update-stream-whitelist.sh /usr/local/bin/update-stream-whitelist.sh

--- a/monitor/parent/regen-stream-conf.py
+++ b/monitor/parent/regen-stream-conf.py
@@ -11,7 +11,10 @@ import urllib.request
 from http import HTTPStatus
 from typing import Any, Tuple, Union
 
-API_URL = os.getenv("ZIMFARM_API_URL", "https://api.farm.openzim.org/v2")
+API_URL = os.getenv("ZIMFARM_API_URL")
+if not API_URL:
+    raise OSError("Please set the ZIMFARM_API_URL environment variable")
+
 TEMPLATE = """[__KEY__]
  enabled = yes
  retention = 30d


### PR DESCRIPTION
## Rationale
This PR sets a default value for the `ZIMFARM_API_URL` in the monitor/parent Dockerfile. Without a default, cron job is set up with its value as empty string leading to failure in updating the stream configuration. This is problematic when new workers are registered as their keys will not be updated with the monitor parent.

## Changes
- set default value of `ZIMFARM_API_URL` in monitor/parent Dockerfile

This fixes #1732 
