### PR TITLE
log worker authentication failure

### DIFF
--- a/worker/src/zimfarm_worker/common/requests.py
+++ b/worker/src/zimfarm_worker/common/requests.py
@@ -6,7 +6,6 @@ from typing import Any
 import requests
 
 from zimfarm_worker.common import logger
-from zimfarm_worker.common.cryptography import AuthMessage
 
 
 @dataclass
@@ -28,29 +27,6 @@ class Response:
     json: dict[str, Any]
 
 
-def get_token(
-    webapi_uri: str,
-    auth_message: AuthMessage,
-) -> Token:
-    """Get a token from the webapi"""
-    request = requests.post(
-        f"{webapi_uri}/auth/ssh-authorize",
-        headers={
-            "X-SSHAuth-Message": auth_message.body,
-            "X-SSHAuth-Signature": auth_message.signature,
-        },
-        timeout=30,
-    )
-    request.raise_for_status()
-    data = request.json()
-    return Token(
-        access_token=data["access_token"],
-        expires_time=datetime.datetime.fromisoformat(data["expires_time"]),
-        refresh_token=data["refresh_token"],
-        token_type=data["token_type"],
-    )
-
-
 def query_api(
     url: str,
     method: str = "get",
@@ -58,6 +34,7 @@ def query_api(
     headers: dict[str, Any] | None = None,
     payload: dict[str, Any] | None = None,
     params: dict[str, Any] | None = None,
+    timeout: int | None = None,
 ) -> Response:
     req_headers: dict[str, Any] = {}
 
@@ -74,7 +51,9 @@ def query_api(
 
     resp = None
     try:
-        resp = func(url, headers=req_headers, json=payload, params=params)
+        resp = func(
+            url, headers=req_headers, json=payload, params=params, timeout=timeout
+        )
         return Response(
             status_code=resp.status_code,
             success=resp.ok,

--- a/worker/src/zimfarm_worker/common/worker.py
+++ b/worker/src/zimfarm_worker/common/worker.py
@@ -24,7 +24,7 @@ from zimfarm_worker.common.cryptography import (
     load_private_key_from_path,
 )
 from zimfarm_worker.common.docker import list_containers
-from zimfarm_worker.common.requests import Response, get_token, query_api
+from zimfarm_worker.common.requests import Response, Token, query_api
 
 
 @dataclass(kw_only=True)
@@ -159,7 +159,32 @@ class BaseWorker:
             try:
                 private_key = load_private_key_from_path(PRIVATE_KEY)
                 auth_message = generate_auth_message(self.username, private_key)
-                token = get_token(uri, auth_message)
+                token_response = query_api(
+                    f"{uri}/auth/ssh-authorize",
+                    method="POST",
+                    headers={
+                        "X-SSHAuth-Message": auth_message.body,
+                        "X-SSHAuth-Signature": auth_message.signature,
+                    },
+                    timeout=30,
+                )
+                if not token_response.success:
+                    logger.error(
+                        "failed to authenticate with API: "
+                        f"status_code={token_response.status_code} "
+                        f"mesage={token_response.json.get('message')}"
+                    )
+                    return False
+
+                token = Token(
+                    access_token=token_response.json["access_token"],
+                    expires_time=datetime.datetime.fromisoformat(
+                        token_response.json["expires_time"]
+                    ),
+                    refresh_token=token_response.json["refresh_token"],
+                    token_type=token_response.json["token_type"],
+                )
+
                 self.connections[uri].access_token = token.access_token
                 self.connections[uri].refresh_token = token.refresh_token
                 jwt_payload = jwt.decode(


### PR DESCRIPTION
## Changes
- re-use `query_api` function in worker manager to authenticate with API as this function converts API responses into a concrete type
- log status code and message from API when authentication fails

This fixes #931 
