### PR TITLE
use requests with timeouts

### DIFF
--- a/receiver/apps/get_zimfarm_key.py
+++ b/receiver/apps/get_zimfarm_key.py
@@ -19,6 +19,8 @@ import sys
 
 import requests
 
+REQUESTS_TIMEOUT = 30
+
 default_environ = {
     "ZIMFARM_WEBAPI": "https://api.farm.openzim.org/v2",
     "ZIMFARM_USERNAME": "uploader",
@@ -57,6 +59,7 @@ def fetch_public_keys_for(username, fingerprint):
     req = requests.get(
         url=f"{environ['ZIMFARM_WEBAPI']}/users/-/keys/{fingerprint}",
         params={"with_permission": ["zim.upload"]},
+        timeout=REQUESTS_TIMEOUT,
     )
     try:
         response = req.json()

--- a/watcher/watcher.py
+++ b/watcher/watcher.py
@@ -84,7 +84,7 @@ SUMMARY_FILENAME = "summary.json"
 
 def get_last_modified_for(url):
     """the Last-Modified header for an URL"""
-    with requests.head(url, allow_redirects=True) as resp:
+    with requests.head(url, allow_redirects=True, timeout=HTTP_REQUEST_TIMEOUT) as resp:
         if resp.status_code == 404:
             raise FileNotFoundError(url)
         return resp.headers.get("last-modified")
@@ -101,6 +101,7 @@ def get_token(api_url, username, password):
             "username": username,
             "password": password,
         },
+        timeout=HTTP_REQUEST_TIMEOUT,
     )
     req.raise_for_status()
     return req.json().get("access_token"), req.json().get("refresh_token")

--- a/worker/src/zimfarm_worker/common/constants.py
+++ b/worker/src/zimfarm_worker/common/constants.py
@@ -196,3 +196,7 @@ DOCKER_API_RETRIES = int(getenv("DOCKER_API_RETRIES", default=5))
 DOCKER_API_RETRY_SECONDS = humanfriendly.parse_timespan(
     getenv("DOCKER_API_RETRY_DURATION", default="5s")
 )
+
+REQUESTS_TIMEOUT = int(
+    humanfriendly.parse_timespan(getenv("REQUESTS_TIMEOUT", default="30s"))
+)

--- a/worker/src/zimfarm_worker/common/requests.py
+++ b/worker/src/zimfarm_worker/common/requests.py
@@ -6,6 +6,7 @@ from typing import Any
 import requests
 
 from zimfarm_worker.common import logger
+from zimfarm_worker.common.constants import REQUESTS_TIMEOUT
 
 
 @dataclass
@@ -34,7 +35,7 @@ def query_api(
     headers: dict[str, Any] | None = None,
     payload: dict[str, Any] | None = None,
     params: dict[str, Any] | None = None,
-    timeout: int | None = None,
+    timeout: int = REQUESTS_TIMEOUT,
 ) -> Response:
     req_headers: dict[str, Any] = {}
 


### PR DESCRIPTION
## Rationale
This PR ensures that requests are made with timeouts across the codebase. 


This fixes #1757

