### PR TITLE
revert schedule to previous history

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/schedules/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/schedules/logic.py
@@ -14,6 +14,7 @@ from zimfarm_backend.api.routes.dependencies import (
     gen_dbsession,
     get_current_user,
     get_current_user_or_none,
+    require_permission,
 )
 from zimfarm_backend.api.routes.http_errors import (
     BadRequestError,
@@ -25,6 +26,7 @@ from zimfarm_backend.api.routes.models import ListResponse
 from zimfarm_backend.api.routes.schedules.models import (
     CloneSchema,
     RestoreSchedulesSchema,
+    RevertScheduleSchema,
     ScheduleCreateResponseSchema,
     ScheduleCreateSchema,
     SchedulesGetSchema,
@@ -82,6 +84,7 @@ from zimfarm_backend.db.schedule import get_schedules as db_get_schedules
 from zimfarm_backend.db.schedule import (
     restore_schedules as db_restore_schedules,
 )
+from zimfarm_backend.db.schedule import revert_schedule as db_revert_schedule
 from zimfarm_backend.db.schedule import (
     toggle_archive_status as db_toggle_archive_status,
 )
@@ -823,3 +826,28 @@ def get_schedule_history_entry(
         session, schedule_name=schedule_name, history_id=history_id
     )
     return create_schedule_history_schema(history_entry)
+
+
+@router.patch(
+    "/{schedule_name}/revert/{history_id}",
+    dependencies=[Depends(require_permission(namespace="schedules", name="update"))],
+)
+def revert_schedule(
+    schedule_name: Annotated[NotEmptyString, Path()],
+    history_id: Annotated[UUID, Path()],
+    request: RevertScheduleSchema,
+    session: OrmSession = Depends(gen_dbsession),
+    current_user: User = Depends(get_current_user),
+) -> JSONResponse:
+    """Revert a schedule to a previous history."""
+    db_revert_schedule(
+        session,
+        schedule_name=schedule_name,
+        history_id=history_id,
+        author_id=current_user.id,
+        comment=request.comment,
+    )
+    return JSONResponse(
+        content={"message": f"Schedule '{schedule_name}' has been restored"},
+        status_code=HTTPStatus.OK,
+    )

--- a/backend/src/zimfarm_backend/api/routes/schedules/models.py
+++ b/backend/src/zimfarm_backend/api/routes/schedules/models.py
@@ -86,3 +86,7 @@ class RestoreSchedulesSchema(BaseModel):
 
 class ToggleArchiveStatusSchema(BaseModel):
     comment: str | None = None
+
+
+class RevertScheduleSchema(BaseModel):
+    comment: str | None = None

--- a/backend/src/zimfarm_backend/db/schedule.py
+++ b/backend/src/zimfarm_backend/db/schedule.py
@@ -49,7 +49,10 @@ from zimfarm_backend.db.models import (
     Worker,
 )
 from zimfarm_backend.db.offliner import get_offliner
-from zimfarm_backend.db.offliner_definition import create_offliner_instance
+from zimfarm_backend.db.offliner_definition import (
+    create_offliner_instance,
+    get_offliner_definition,
+)
 from zimfarm_backend.utils.timestamp import (
     get_status_timestamp_expr,
     get_timestamp_for_status,
@@ -554,6 +557,37 @@ def toggle_archive_status(
     return schedule
 
 
+def create_schedule_history_entry(
+    session: OrmSession,
+    *,
+    schedule: Schedule,
+    offliner_definition: OfflinerDefinitionSchema,
+    comment: str | None,
+    author_id: UUID,
+) -> ScheduleHistory:
+    """Create a schedule history entry from a schedule."""
+    history_entry = ScheduleHistory(
+        created_at=getnow(),
+        comment=comment,
+        config=schedule.config,
+        name=schedule.name,
+        category=schedule.category,
+        enabled=schedule.enabled,
+        language_code=schedule.language_code,
+        tags=schedule.tags,
+        periodicity=schedule.periodicity,
+        context=schedule.context,
+        archived=schedule.archived,
+        offliner_definition_version=offliner_definition.version,
+        notification=schedule.notification,
+    )
+    history_entry.author_id = author_id
+    schedule.history_entries.append(history_entry)
+    session.add(history_entry)
+
+    return history_entry
+
+
 def update_schedule(
     session: OrmSession,
     *,
@@ -606,26 +640,14 @@ def update_schedule(
     )
 
     schedule.context = context if context is not None else schedule.context
-
-    history_entry = ScheduleHistory(
-        created_at=getnow(),
-        comment=comment,
-        config=schedule.config,
-        name=schedule.name,
-        category=schedule.category,
-        enabled=schedule.enabled,
-        language_code=schedule.language_code,
-        tags=schedule.tags,
-        periodicity=schedule.periodicity,
-        context=schedule.context,
-        archived=schedule.archived,
-        offliner_definition_version=offliner_definition.version,
-        notification=schedule.notification,
-    )
-    history_entry.author_id = author_id
-    schedule.history_entries.append(history_entry)
-
     session.add(schedule)
+    create_schedule_history_entry(
+        session,
+        schedule=schedule,
+        offliner_definition=offliner_definition,
+        comment=comment,
+        author_id=author_id,
+    )
     try:
         session.flush()
     except IntegrityError as exc:
@@ -732,3 +754,88 @@ def restore_schedules(
             archived=False,
             comment=comment,
         )
+
+
+def revert_schedule(
+    session: OrmSession,
+    *,
+    schedule_name: str,
+    history_id: UUID,
+    author_id: UUID,
+    comment: str | None = None,
+) -> Schedule:
+    """Revert the schedule configuration and settings to those defined in history_id"""
+    schedule = get_schedule(session, schedule_name=schedule_name)
+    if schedule.archived:
+        raise RecordDoesNotExistError(f"Schedule with name {schedule_name} is archived")
+
+    history_entry = get_schedule_history_entry(
+        session, schedule_name=schedule_name, history_id=history_id
+    )
+    if history_entry.offliner_definition_version is None:
+        raise ValueError(
+            "Cannot revert to history with no offliner definition version."
+        )
+
+    offliner = get_offliner(
+        session, offliner_id=history_entry.config["offliner"]["offliner_id"]
+    )
+    offliner_definition = get_offliner_definition(
+        session,
+        offliner_id=offliner.id,
+        version=history_entry.offliner_definition_version,
+    )
+    old_schedule_config = ScheduleConfigSchema.model_validate(
+        {
+            **history_entry.config,
+            "offliner": create_offliner_instance(
+                offliner=offliner,
+                offliner_definition=offliner_definition,
+                data={**history_entry.config["offliner"]},
+            ),
+        }
+    )
+    # Copy over the attributes from the history entry to the schedule as both db
+    # models are the same.
+    schedule.config = old_schedule_config.model_dump(
+        mode="json", context={"show_secrets": True}
+    )
+    schedule.similarity_data = generate_similarity_data(
+        old_schedule_config.model_dump(mode="json", exclude={"offliner_id"}),
+        offliner,
+        offliner_definition.schema_,
+    )
+    schedule.language_code = history_entry.language_code
+    schedule.offliner_definition_id = offliner_definition.id
+    schedule.name = history_entry.name
+    schedule.category = history_entry.category
+    schedule.tags = history_entry.tags
+    schedule.enabled = history_entry.enabled
+    schedule.periodicity = history_entry.periodicity
+    schedule.notification = history_entry.notification
+    schedule.context = history_entry.context
+    session.add(schedule)
+
+    create_schedule_history_entry(
+        session,
+        schedule=schedule,
+        offliner_definition=offliner_definition,
+        author_id=author_id,
+        comment=comment,
+    )
+
+    # Ensure that the schedule is valid
+    create_schedule_full_schema(schedule, offliner, skip_validation=False)
+
+    try:
+        session.flush()
+    except IntegrityError as exc:
+        if isinstance(exc.orig, UniqueViolation):
+            raise RecordAlreadyExistsError(
+                f"Schedule with name {schedule.name} already exists"
+            ) from exc
+        logger.exception("Unknown exception encountered while updating schedule")
+        raise
+    session.refresh(schedule)
+
+    return schedule

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -922,6 +922,7 @@ def create_schedule(
         context: str | None = None,
         schedule_config: ScheduleConfigSchema | None = None,
         raw_schedule_config: dict[str, Any] | None = None,
+        enabled: bool = True,
         worker: Worker | None = None,
         user: User | None = None,
         archived: bool = False,
@@ -942,7 +943,7 @@ def create_schedule(
                     mode="json", context={"show_secrets": True}
                 )
             ),
-            enabled=True,
+            enabled=enabled,
             language_code=language.code,
             periodicity=periodicity,
             notification=notification,
@@ -970,6 +971,7 @@ def create_schedule(
             tags=schedule.tags,
             periodicity=schedule.periodicity,
             context=schedule.context,
+            notification=notification,
             offliner_definition_version=offliner_definition.version,
         )
         history_entry.author_id = user.id if user else _user.id

--- a/backend/tests/db/test_schedule.py
+++ b/backend/tests/db/test_schedule.py
@@ -1,10 +1,12 @@
 import datetime
 from collections.abc import Callable
 from contextlib import nullcontext as does_not_raise
+from copy import deepcopy
 from uuid import uuid4
 
 import pytest
 from _pytest.python_api import RaisesContext
+from faker import Faker
 from sqlalchemy import select
 from sqlalchemy.orm import Session as OrmSession
 
@@ -12,8 +14,13 @@ from zimfarm_backend.common.enums import (
     ScheduleCategory,
     SchedulePeriodicity,
     TaskStatus,
+    WarehousePath,
 )
-from zimfarm_backend.common.schemas.models import ScheduleConfigSchema
+from zimfarm_backend.common.schemas.models import (
+    EventNotificationSchema,
+    ScheduleConfigSchema,
+    ScheduleNotificationSchema,
+)
 from zimfarm_backend.common.schemas.orms import (
     LanguageSchema,
     OfflinerDefinitionSchema,
@@ -32,6 +39,7 @@ from zimfarm_backend.db.models import (
     User,
     Worker,
 )
+from zimfarm_backend.db.offliner_definition import create_offliner_instance
 from zimfarm_backend.db.schedule import (
     DEFAULT_SCHEDULE_DURATION,
     count_enabled_schedules,
@@ -46,6 +54,7 @@ from zimfarm_backend.db.schedule import (
     get_schedule_or_none,
     get_schedules,
     restore_schedules,
+    revert_schedule,
     toggle_archive_status,
     update_schedule,
     update_schedule_duration,
@@ -593,3 +602,149 @@ def test_restore_schedules(
 
     with expected:
         restore_schedules(dbsession, schedule_names=schedule_names, actor_id=user.id)
+
+
+def test_revert_schedule_archived_schedule(
+    dbsession: OrmSession,
+    create_schedule: Callable[..., Schedule],
+    user: User,
+):
+    """Test that reverting an archived schedule raises an error"""
+    schedule = create_schedule(name="archived_schedule", archived=True)
+    history_id = schedule.history_entries[0].id
+
+    with pytest.raises(
+        RecordDoesNotExistError,
+    ):
+        revert_schedule(
+            dbsession,
+            schedule_name="archived_schedule",
+            history_id=history_id,
+            author_id=user.id,
+        )
+
+
+def test_revert_schedule_no_offliner_definition_version(
+    dbsession: OrmSession,
+    create_schedule: Callable[..., Schedule],
+    user: User,
+):
+    """Test that reverting to history with no offliner definition version
+    raises error"""
+    schedule = create_schedule(name="test_schedule")
+    history_entry = schedule.history_entries[0]
+
+    history_entry.offliner_definition_version = None
+    dbsession.add(history_entry)
+
+    with pytest.raises(
+        ValueError,
+    ):
+        revert_schedule(
+            dbsession,
+            schedule_name="test_schedule",
+            history_id=history_entry.id,
+            author_id=user.id,
+        )
+
+
+def test_revert_schedule_all_fields(
+    dbsession: OrmSession,
+    create_schedule: Callable[..., Schedule],
+    schedule_config: ScheduleConfigSchema,
+    mwoffliner_definition: OfflinerDefinitionSchema,
+    mwoffliner: OfflinerSchema,
+    user: User,
+    data_gen: Faker,
+):
+    """Test that all schedule fields are properly reverted"""
+    initial_notification: dict[str, dict[str, list[str]]] = {
+        "requested": {"mailgun": ["test@example.com"]},
+        "started": {"mailgun": []},
+        "ended": {"mailgun": []},
+    }
+    schedule = create_schedule(
+        name="test_schedule",
+        enabled=True,
+        tags=["tag1", "tag2"],
+        category="wikipedia",
+        periodicity="monthly",
+        context="initial context",
+        schedule_config=schedule_config,
+        notification=initial_notification,
+    )
+    initial_history_id = schedule.history_entries[0].id
+    initial_config = deepcopy(schedule.config)
+    initial_tags = deepcopy(schedule.tags)
+    initial_category = schedule.category
+    initial_periodicity = schedule.periodicity
+    initial_context = schedule.context
+    initial_enabled = schedule.enabled
+
+    new_schedule_config = ScheduleConfigSchema.model_validate(
+        {
+            **schedule_config.model_dump(
+                mode="json",
+                exclude={"offliner"},
+                context={"show_secrets": True},
+            ),
+            "image": {
+                "name": mwoffliner.docker_image_name,
+                "tag": "1.17",
+            },
+            "warehouse_path": WarehousePath.libretexts,
+            "offliner": create_offliner_instance(
+                offliner=mwoffliner,
+                offliner_definition=mwoffliner_definition,
+                data={
+                    "offliner_id": mwoffliner_definition.offliner,
+                    "mwUrl": data_gen.uri(),
+                    "adminEmail": data_gen.email(),
+                    "mwPassword": "new-password",
+                },
+            ),
+        }
+    )
+    update_schedule(
+        dbsession,
+        author_id=user.id,
+        schedule_name="test_schedule",
+        new_schedule_config=new_schedule_config,
+        offliner_definition=mwoffliner_definition,
+        tags=["tag3", "tag4"],
+        category=ScheduleCategory.other,
+        periodicity=SchedulePeriodicity.quarterly,
+        context="updated context",
+        enabled=False,
+        comment="Update all fields",
+        notification=ScheduleNotificationSchema(
+            requested=EventNotificationSchema(
+                mailgun=["updated@example.com", "another@example.com"]
+            )
+        ),
+    )
+
+    updated_schedule = get_schedule(dbsession, schedule_name="test_schedule")
+
+    assert updated_schedule.config != initial_config
+    assert updated_schedule.tags != initial_tags
+    assert updated_schedule.category != initial_category
+    assert updated_schedule.periodicity != initial_periodicity
+    assert updated_schedule.context != initial_context
+    assert updated_schedule.enabled != initial_enabled
+    assert updated_schedule.notification != initial_notification
+
+    reverted_schedule = revert_schedule(
+        dbsession,
+        schedule_name="test_schedule",
+        history_id=initial_history_id,
+        author_id=user.id,
+    )
+
+    assert reverted_schedule.config == initial_config
+    assert reverted_schedule.tags == initial_tags
+    assert reverted_schedule.category == initial_category
+    assert reverted_schedule.periodicity == initial_periodicity
+    assert reverted_schedule.context == initial_context
+    assert reverted_schedule.enabled == initial_enabled
+    assert reverted_schedule.notification == initial_notification

--- a/backend/tests/routes/test_schedules.py
+++ b/backend/tests/routes/test_schedules.py
@@ -1,6 +1,7 @@
 from collections.abc import Callable
 from http import HTTPStatus
 from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -10,7 +11,11 @@ from zimfarm_backend.api.token import generate_access_token
 from zimfarm_backend.common import getnow
 from zimfarm_backend.common.enums import ScheduleCategory, SchedulePeriodicity
 from zimfarm_backend.common.roles import RoleEnum
-from zimfarm_backend.common.schemas.models import ScheduleConfigSchema
+from zimfarm_backend.common.schemas.models import (
+    EventNotificationSchema,
+    ScheduleConfigSchema,
+    ScheduleNotificationSchema,
+)
 from zimfarm_backend.common.schemas.orms import (
     LanguageSchema,
     OfflinerDefinitionSchema,
@@ -720,11 +725,14 @@ def test_delete_schedule(
     assert response.status_code == expected_status_code
 
 
+@patch("zimfarm_backend.api.routes.schedules.logic.get_schedule_image_tags")
 def test_get_schedule_image_names(
+    mock_get_tags: MagicMock,
     client: TestClient,
     dbsession: OrmSession,
     create_schedule: Callable[..., Schedule],
 ):
+    mock_get_tags.return_value = ["latest", "1.0.0", "1.0.1"]
     schedule = create_schedule(name="test_schedule")
     dbsession.add(schedule)
     dbsession.flush()
@@ -732,11 +740,12 @@ def test_get_schedule_image_names(
     response = client.get(
         f"/v2/schedules/{schedule.name}/image-names?hub_name=openzim/mwoffliner",
     )
+    mock_get_tags.assert_called_once_with("openzim/mwoffliner")
+
     assert response.status_code == HTTPStatus.OK
     data = response.json()
     assert "items" in data
-    for item in data["items"]:
-        assert isinstance(item, str)
+    assert data["items"] == ["latest", "1.0.0", "1.0.1"]
 
 
 @pytest.mark.parametrize(
@@ -1284,6 +1293,66 @@ def test_restore_schedule(
 
     response = client.patch(
         f"/v2/schedules/{schedule.name}/restore",
+        headers={"Authorization": f"Bearer {access_token}"},
+        json={},
+    )
+    assert response.status_code == expected_status_code
+
+
+@pytest.mark.parametrize(
+    "permission,expected_status_code",
+    [
+        pytest.param(RoleEnum.ADMIN, HTTPStatus.OK, id="admin"),
+        pytest.param(RoleEnum.PROCESSOR, HTTPStatus.UNAUTHORIZED, id="processor"),
+    ],
+)
+def test_revert_schedule_history(
+    client: TestClient,
+    dbsession: OrmSession,
+    create_user: Callable[..., User],
+    create_schedule: Callable[..., Schedule],
+    schedule_config: ScheduleConfigSchema,
+    mwoffliner_definition: OfflinerDefinitionSchema,
+    permission: RoleEnum,
+    expected_status_code: HTTPStatus,
+):
+    user = create_user(permission=permission)
+    access_token = generate_access_token(
+        issue_time=getnow(),
+        user_id=str(user.id),
+    )
+
+    schedule = create_schedule(
+        name="test_schedule",
+        enabled=True,
+        tags=["tag1", "tag2"],
+        category="wikipedia",
+        periodicity="monthly",
+        context="initial context",
+        schedule_config=schedule_config,
+    )
+    initial_history_id = schedule.history_entries[0].id
+
+    update_schedule(
+        dbsession,
+        author_id=user.id,
+        schedule_name="test_schedule",
+        offliner_definition=mwoffliner_definition,
+        tags=["tag3", "tag4"],
+        category=ScheduleCategory.other,
+        periodicity=SchedulePeriodicity.quarterly,
+        context="updated context",
+        enabled=False,
+        comment="Update all fields",
+        notification=ScheduleNotificationSchema(
+            requested=EventNotificationSchema(
+                mailgun=["updated@example.com", "another@example.com"]
+            )
+        ),
+    )
+
+    response = client.patch(
+        f"/v2/schedules/{schedule.name}/revert/{initial_history_id}",
         headers={"Authorization": f"Bearer {access_token}"},
         json={},
     )

--- a/frontend-ui/src/components/ScheduleHistory.vue
+++ b/frontend-ui/src/components/ScheduleHistory.vue
@@ -52,6 +52,20 @@
                   </div>
                 </v-list-item-subtitle>
               </v-list-item-content>
+
+              <template v-slot:append>
+                <v-btn
+                  icon="mdi-restore"
+                  variant="text"
+                  size="small"
+                  color="primary"
+                  @click.stop="confirmRevert(item, index)"
+                  :disabled="index === 0"
+                  :title="index === 0 ? 'This is the current version' : 'Revert to this version'"
+                >
+                  <v-icon>mdi-restore</v-icon>
+                </v-btn>
+              </template>
             </v-list-item>
             <v-divider />
           </template>
@@ -101,11 +115,55 @@
         </v-col>
       </v-row>
     </template>
+
+    <!-- Revert Confirmation Dialog -->
+    <ConfirmDialog
+      v-model="showRevertDialog"
+      title="Revert to Previous Version"
+      confirm-text="Revert"
+      cancel-text="Cancel"
+      confirm-color="info"
+      icon="mdi-restore"
+      icon-color="info"
+      :max-width="600"
+      :loading="isReverting"
+      @confirm="handleRevertConfirm"
+      @cancel="handleCancelRevert"
+    >
+      <template #content>
+        <div v-if="selectedHistoryItem">
+          <v-alert type="info" variant="tonal" density="compact" class="mb-4">
+            You are about to revert recipe <strong>{{ scheduleName }}</strong> to a previous
+            version. Review the changes below:
+          </v-alert>
+
+          <div v-if="loadingOfflinerDef" class="d-flex justify-center align-center pa-8">
+            <v-progress-circular indeterminate color="primary" />
+            <span class="ml-4">Loading differences...</span>
+          </div>
+
+          <DiffViewer v-else :differences="enhancedDifferences" />
+
+          <!-- Comment Input -->
+          <div class="mt-4">
+            <v-textarea
+              v-model="revertComment"
+              label="Comment (optional)"
+              variant="outlined"
+              auto-grow
+              rows="3"
+              placeholder="Add a note about why you're reverting to this version..."
+            />
+          </div>
+        </div>
+      </template>
+    </ConfirmDialog>
   </v-container>
 </template>
 
 <script setup lang="ts">
 import DiffViewer from '@/components/DiffViewer.vue'
+import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import { useNotificationStore } from '@/stores/notification'
 import { useScheduleHistoryStore } from '@/stores/scheduleHistory'
 import { useOfflinerStore } from '@/stores/offliner'
@@ -129,6 +187,7 @@ const props = defineProps<{
 
 const emit = defineEmits<{
   load: [{ limit: number; skip: number }]
+  revert: []
 }>()
 
 const route = useRoute()
@@ -143,12 +202,24 @@ const showDiffViewer = ref(false)
 const oldFlagsDefinition = ref<OfflinerDefinition[]>([])
 const newFlagsDefinition = ref<OfflinerDefinition[]>([])
 const loadingOfflinerDef = ref(false)
+const showRevertDialog = ref(false)
+const selectedHistoryItem = ref<ScheduleHistorySchema | null>(null)
+const isReverting = ref(false)
+const isRevertMode = ref(false)
+const revertComment = ref('')
 
 const selectedItemsArray = computed(() => {
-  return Array.from(selectedItems.value)
+  const items = Array.from(selectedItems.value)
     .map((index) => props.history[index])
     .filter(Boolean)
-    .sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
+
+  // In revert mode, sort current->previous (descending)
+  // In normal compare mode, sort previous->current (ascending)
+  if (isRevertMode.value) {
+    return items.sort((a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime())
+  }
+
+  return items.sort((a, b) => new Date(a.created_at).getTime() - new Date(b.created_at).getTime())
 })
 
 const scheduleDifferences = computed(
@@ -408,6 +479,68 @@ const backToHistoryList = () => {
   showDiffViewer.value = false
   selectedItems.value.clear()
   updateUrlQueryParams()
+}
+
+const confirmRevert = async (item: ScheduleHistorySchema, index: number) => {
+  selectedHistoryItem.value = item
+  isRevertMode.value = true
+
+  // Select current (0) and target (index) to trigger diff computation
+  selectedItems.value = new Set([0, index])
+
+  // Fetch offliner definitions for both versions
+  await fetchOfflinerDefinitions()
+
+  // Check if there are any differences
+  if (!scheduleDifferences.value || scheduleDifferences.value.length === 0) {
+    selectedHistoryItem.value = null
+    isRevertMode.value = false
+    selectedItems.value.clear()
+    notificationStore.showInfo(
+      'No differences found between current and selected version. Nothing to revert.',
+    )
+    return
+  }
+
+  showRevertDialog.value = true
+}
+
+const handleCancelRevert = () => {
+  showRevertDialog.value = false
+  isRevertMode.value = false
+  revertComment.value = ''
+  selectedItems.value.clear()
+}
+
+const handleRevertConfirm = async () => {
+  if (!selectedHistoryItem.value) {
+    return
+  }
+
+  isReverting.value = true
+  const comment = revertComment.value.trim() || undefined
+  const success = await scheduleHistoryStore.revertToHistory(
+    props.scheduleName,
+    selectedHistoryItem.value.id,
+    comment,
+  )
+
+  if (success) {
+    notificationStore.showSuccess(
+      `Successfully reverted to version ${selectedHistoryItem.value.id.substring(0, 8)}`,
+    )
+    showRevertDialog.value = false
+    selectedHistoryItem.value = null
+    isRevertMode.value = false
+    revertComment.value = ''
+    selectedItems.value.clear()
+    emit('revert')
+  } else {
+    for (const error of scheduleHistoryStore.errors) {
+      notificationStore.showError(error)
+    }
+  }
+  isReverting.value = false
 }
 
 // Load more history items

--- a/frontend-ui/src/stores/scheduleHistory.ts
+++ b/frontend-ui/src/stores/scheduleHistory.ts
@@ -64,6 +64,23 @@ export const useScheduleHistoryStore = defineStore('scheduleHistory', () => {
     }
   }
 
+  const revertToHistory = async (scheduleName: string, historyId: string, comment?: string) => {
+    const service = await authStore.getApiService('schedules')
+    try {
+      const data = { comment: comment ? comment : null }
+      await service.patch<{ comment?: string } | null, { message: string }>(
+        `/${scheduleName}/revert/${historyId}`,
+        data,
+      )
+      errors.value = []
+      return true
+    } catch (_error) {
+      console.error(`Failed to revert to schedule history entry ${historyId}`, _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+      return false
+    }
+  }
+
   const clearHistory = () => {
     history.value = []
     errors.value = []
@@ -85,5 +102,6 @@ export const useScheduleHistoryStore = defineStore('scheduleHistory', () => {
     fetchHistory,
     fetchHistoryEntry,
     clearHistory,
+    revertToHistory,
   }
 })

--- a/frontend-ui/src/views/ScheduleDetailView.vue
+++ b/frontend-ui/src/views/ScheduleDetailView.vue
@@ -516,6 +516,7 @@
             :paginator="scheduleHistoryStore.paginator"
             :schedule-name="scheduleName"
             @load="loadHistory"
+            @revert="handleRevert"
           />
         </v-window-item>
 
@@ -1261,6 +1262,11 @@ const restoreSchedule = async (comment?: string) => {
       notificationStore.showError(error)
     }
   }
+}
+
+const handleRevert = async () => {
+  // Reload schedule data after revert
+  await refreshData(true, true)
 }
 
 const refreshData = async (forceReload: boolean = false, fetchHistory: boolean = false) => {


### PR DESCRIPTION
## Rationale
This PR enhances the API and UI to allow for reverting a schedule to a previous history
<img width="927" height="606" alt="Screenshot_20260318_151201" src="https://github.com/user-attachments/assets/ce278dc5-e108-462b-8596-f517e6a78805" />


## Changes
- add endpoint to revert schedule to a previous history
- copy over all the attributes from the history entry to the current schedule given both models share the same fields
- enhance the way diffs are computed by sorting either in descending or ascending order. When a revert is in place, diff viewer shows differences from current to previous but in normal mode, it shows changes from previous to current


This closes #1752
