### PR TITLE
show files as cards

### DIFF
--- a/frontend-ui/src/components/TaskFileCard.vue
+++ b/frontend-ui/src/components/TaskFileCard.vue
@@ -1,0 +1,173 @@
+<template>
+  <v-card elevation="2" class="h-100 d-flex flex-column border">
+    <v-card-title class="d-flex flex-column align-start pa-4">
+      <div class="d-flex align-center flex-wrap w-100">
+        <div class="text-subtitle-1 text-truncate flex-grow-1">
+          {{ displayName }}
+        </div>
+
+        <div v-if="file.info === undefined" class="text-caption text-grey ml-2">
+          Loading metadata...
+        </div>
+      </div>
+
+      <div v-if="file.info?.metadata" class="d-flex align-center flex-wrap mt-2 ga-2">
+        <v-chip v-if="file.info.metadata.Flavour" size="small" variant="tonal" color="primary">
+          {{ file.info.metadata.Flavour }}
+        </v-chip>
+
+        <v-chip v-if="file.info.metadata.Date" size="small" variant="outlined">
+          <v-icon start size="small">mdi-calendar</v-icon>
+          {{ file.info.metadata.Date }}
+        </v-chip>
+      </div>
+    </v-card-title>
+
+    <v-divider />
+
+    <v-card-text class="pa-4">
+      <div class="d-flex flex-column ga-2">
+        <div class="d-flex justify-space-between align-center">
+          <div class="text-body-2 font-weight-medium">Size</div>
+          <div class="text-body-2 font-weight-medium">
+            {{ formattedBytesSize(file.size) }}
+          </div>
+        </div>
+
+        <div class="d-flex justify-space-between align-center">
+          <div class="text-body-2 font-weight-medium">Created After</div>
+          <v-tooltip :text="formatDt(file.created_timestamp)">
+            <template #activator="{ props: tooltipProps }">
+              <div v-bind="tooltipProps" class="text-body-2 font-weight-medium">
+                {{ createdAfterTime }}
+              </div>
+            </template>
+          </v-tooltip>
+        </div>
+
+        <div class="d-flex justify-space-between align-center">
+          <div class="text-body-2 font-weight-medium">Upload Duration</div>
+          <v-tooltip v-if="file.uploaded_timestamp" :text="formatDt(file.uploaded_timestamp)">
+            <template #activator="{ props: tooltipProps }">
+              <div v-bind="tooltipProps" class="text-body-2 font-weight-medium">
+                {{ uploadDurationTime }}
+              </div>
+            </template>
+          </v-tooltip>
+          <div v-else class="text-body-2 text-grey">-</div>
+        </div>
+
+        <div class="d-flex justify-space-between align-center">
+          <div class="text-body-2 font-weight-medium">Quality Check</div>
+          <div v-if="file.check_result !== undefined" class="d-flex align-center">
+            <v-tooltip :text="`Return code: ${file.check_result}`">
+              <template #activator="{ props: tooltipProps }">
+                <v-icon
+                  v-bind="tooltipProps"
+                  :color="file.check_result === 0 ? 'success' : 'error'"
+                  size="small"
+                >
+                  {{ file.check_result === 0 ? 'mdi-check-circle' : 'mdi-close-circle' }}
+                </v-icon>
+              </template>
+            </v-tooltip>
+            <v-btn
+              v-if="file.check_filename"
+              variant="text"
+              size="x-small"
+              class="ml-1 pa-0"
+              :href="checksUrl"
+              target="_blank"
+              rel="noopener noreferrer"
+              icon
+              density="compact"
+            >
+              <v-icon size="small">mdi-download</v-icon>
+            </v-btn>
+          </div>
+          <div v-else class="text-body-2 text-grey">-</div>
+        </div>
+      </div>
+    </v-card-text>
+
+    <v-divider />
+
+    <v-card-actions class="pa-3 justify-end">
+      <v-menu v-if="file.info" location="bottom" :close-on-content-click="false">
+        <template #activator="{ props: menuProps }">
+          <v-tooltip location="top">
+            <template #activator="{ props: tooltipProps }">
+              <v-btn v-bind="{ ...menuProps, ...tooltipProps }" variant="text" size="small" icon>
+                <v-icon>mdi-information</v-icon>
+              </v-btn>
+            </template>
+            <span>File Info</span>
+          </v-tooltip>
+        </template>
+        <FileInfoTable :file-info="file.info" />
+      </v-menu>
+
+      <ZimUrlButtons v-if="file.zim_urls && file.zim_urls.length > 0" :urls="file.zim_urls" />
+      <v-tooltip v-else location="top">
+        <template #activator="{ props: tooltipProps }">
+          <v-btn
+            v-bind="tooltipProps"
+            :href="fallbackDownloadUrl"
+            target="_blank"
+            variant="text"
+            icon
+            size="small"
+          >
+            <v-icon>mdi-download</v-icon>
+          </v-btn>
+        </template>
+        <span>Download</span>
+      </v-tooltip>
+    </v-card-actions>
+  </v-card>
+</template>
+
+<script setup lang="ts">
+import FileInfoTable from '@/components/FileInfoTable.vue'
+import ZimUrlButtons from '@/components/ZimUrlButtons.vue'
+import type { Task, TaskFile } from '@/types/tasks'
+import { formatDt, formatDurationBetween, formattedBytesSize } from '@/utils/format'
+import { checkUrl } from '@/utils/offliner'
+import { getTimestampStringForStatus } from '@/utils/timestamp'
+import { computed } from 'vue'
+
+// Props
+interface Props {
+  file: TaskFile
+  task: Task
+  kiwixDownloadUrl: string
+  smAndDown: boolean
+}
+
+const props = defineProps<Props>()
+
+const displayName = computed(() => {
+  return props.file.info?.metadata?.Name || props.file.name
+})
+
+const createdAfterTime = computed(() => {
+  return formatDurationBetween(
+    getTimestampStringForStatus(props.task.timestamp, 'scraper_started'),
+    props.file.created_timestamp,
+  )
+})
+
+const uploadDurationTime = computed(() => {
+  if (!props.file.uploaded_timestamp) return '-'
+  return formatDurationBetween(props.file.created_timestamp, props.file.uploaded_timestamp)
+})
+
+const checksUrl = computed(() => {
+  if (!props.file.check_filename) return ''
+  return checkUrl(props.task, props.file.check_filename)
+})
+
+const fallbackDownloadUrl = computed(() => {
+  return `${props.kiwixDownloadUrl}${props.task.config.warehouse_path}/${props.file.name}`
+})
+</script>

--- a/frontend-ui/src/components/ZimUrlButtons.vue
+++ b/frontend-ui/src/components/ZimUrlButtons.vue
@@ -1,33 +1,24 @@
 <template>
   <div v-if="loading" class="d-flex align-center">
     <v-progress-circular indeterminate size="20" width="2" />
-    <span v-if="!compact && !iconOnly" class="ml-2 text-grey">Loading URLs...</span>
   </div>
-  <div v-else-if="urls && urls.length > 0" :class="iconOnly ? 'd-inline-flex align-center' : ''">
+  <div v-else-if="urls && urls.length > 0" class="d-inline-flex align-center">
     <v-tooltip v-for="url in urls" :key="`${url.kind}-${url.collection}`" location="bottom">
       <template #activator="{ props: tooltipProps }">
         <v-btn
           v-bind="tooltipProps"
           :href="url.url"
           target="_blank"
-          :icon="iconOnly || compact"
-          :prepend-icon="
-            iconOnly || compact ? undefined : url.kind === 'download' ? 'mdi-download' : 'mdi-eye'
-          "
-          :variant="iconOnly ? 'text' : compact ? 'text' : 'outlined'"
-          :size="iconOnly ? 'x-small' : compact ? 'x-small' : 'small'"
-          :class="iconOnly ? 'ml-1' : compact ? '' : 'mr-2'"
+          icon
+          variant="text"
+          :size="compact ? 'x-small' : 'small'"
         >
-          <v-icon v-if="iconOnly || compact" :size="iconOnly ? 'small' : undefined">
-            {{ url.kind === 'download' ? 'mdi-download' : 'mdi-eye' }}
-          </v-icon>
-          <span v-else>{{ url.kind === 'download' ? 'Download' : 'View' }}</span>
+          <v-icon>{{ url.kind === 'download' ? 'mdi-download' : 'mdi-eye' }}</v-icon>
         </v-btn>
       </template>
       <span>{{ url.kind === 'download' ? 'Download' : 'View' }} ({{ url.collection }})</span>
     </v-tooltip>
   </div>
-  <span v-else-if="!iconOnly" class="text-grey">{{ emptyText }}</span>
 </template>
 
 <script setup lang="ts">
@@ -38,15 +29,11 @@ withDefaults(
     urls?: ZimUrl[]
     loading?: boolean
     compact?: boolean
-    iconOnly?: boolean
-    emptyText?: string
   }>(),
   {
     urls: undefined,
     loading: false,
     compact: false,
-    iconOnly: false,
-    emptyText: 'No URLs available',
   },
 )
 </script>

--- a/frontend-ui/src/views/TaskDetailView.vue
+++ b/frontend-ui/src/views/TaskDetailView.vue
@@ -199,118 +199,24 @@
                     <div class="text-subtitle-2">Files</div>
                   </v-col>
                   <v-col cols="12" md="9">
-                    <v-data-table
-                      :headers="filesHeaders"
-                      :items="sortedFiles"
-                      :mobile="smAndDown"
-                      :density="smAndDown ? 'compact' : 'comfortable'"
-                      item-key="name"
-                      hide-default-footer
-                      disable-sort
-                      :class="smAndDown ? '' : 'files-table'"
-                    >
-                      <template #[`item.name`]="{ item }">
-                        {{ getDisplayFilename(item) }}
-                      </template>
-
-                      <template #[`item.size`]="{ item }">
-                        {{ formattedBytesSize(item.size) }}
-                      </template>
-
-                      <template #[`item.created_after`]="{ item }">
-                        <v-tooltip :text="formatDt(item.created_timestamp)">
-                          <template #activator="{ props }">
-                            <span v-bind="props">{{ createdAfter(item, task) }}</span>
-                          </template>
-                        </v-tooltip>
-                      </template>
-
-                      <template #[`item.upload_duration`]="{ item }">
-                        <v-tooltip
-                          v-if="item.uploaded_timestamp"
-                          :text="formatDt(item.uploaded_timestamp)"
-                        >
-                          <template #activator="{ props }">
-                            <span v-bind="props">{{ uploadDuration(item) }}</span>
-                          </template>
-                        </v-tooltip>
-                        <span v-else>-</span>
-                      </template>
-
-                      <template #[`item.quality`]="{ item }">
-                        <div
-                          v-if="item.check_result !== undefined"
-                          :class="['d-flex', 'align-center', { 'justify-end': smAndDown }]"
-                        >
-                          <v-tooltip :text="`Return code: ${item.check_result}`">
-                            <template #activator="{ props }">
-                              <v-icon
-                                v-bind="props"
-                                :color="item.check_result === 0 ? 'success' : 'error'"
-                                size="small"
-                              >
-                                {{
-                                  item.check_result === 0 ? 'mdi-check-circle' : 'mdi-close-circle'
-                                }}
-                              </v-icon>
-                            </template>
-                          </v-tooltip>
-                          <v-btn
-                            v-if="item.check_filename"
-                            variant="text"
-                            size="small"
-                            class="ml-2"
-                            :href="zimfarmChecksUrl(item.check_filename)"
-                            target="_blank"
-                            rel="noopener noreferrer"
-                          >
-                            <v-icon>mdi-download</v-icon>
-                          </v-btn>
-                        </div>
-                        <span v-else>-</span>
-                      </template>
-
-                      <template #[`item.info`]="{ item }">
-                        <div :class="['d-flex', { 'justify-end': smAndDown }]">
-                          <v-menu v-if="item.info" location="left" :close-on-content-click="false">
-                            <template #activator="{ props }">
-                              <v-btn v-bind="props" variant="text" size="small">
-                                <v-icon>mdi-information</v-icon>
-                              </v-btn>
-                            </template>
-                            <FileInfoTable :file-info="item.info" />
-                          </v-menu>
-                          <span v-else>-</span>
-                        </div>
-                      </template>
-
-                      <template #[`item.urls`]="{ item }">
-                        <div :class="['d-flex', 'align-center', { 'justify-end': smAndDown }]">
-                          <ZimUrlButtons
-                            v-if="item.zim_urls && item.zim_urls.length > 0"
-                            :urls="item.zim_urls"
-                            :icon-only="!smAndDown"
-                          />
-                          <v-tooltip v-else location="bottom">
-                            <template #activator="{ props: tooltipProps }">
-                              <v-btn
-                                v-bind="tooltipProps"
-                                :href="
-                                  kiwixDownloadUrl + task.config.warehouse_path + '/' + item.name
-                                "
-                                target="_blank"
-                                variant="text"
-                                icon
-                                size="small"
-                              >
-                                <v-icon size="small">mdi-download</v-icon>
-                              </v-btn>
-                            </template>
-                            <span>Download</span>
-                          </v-tooltip>
-                        </div>
-                      </template>
-                    </v-data-table>
+                    <v-row>
+                      <v-col
+                        v-for="file in sortedFiles"
+                        :key="file.name"
+                        cols="12"
+                        sm="12"
+                        md="6"
+                        lg="4"
+                        xl="4"
+                      >
+                        <TaskFileCard
+                          :file="file"
+                          :task="task"
+                          :kiwix-download-url="kiwixDownloadUrl"
+                          :sm-and-down="smAndDown"
+                        />
+                      </v-col>
+                    </v-row>
                   </v-col>
                 </v-row>
               </div>
@@ -616,10 +522,11 @@
 
 <script setup lang="ts">
 import ErrorMessage from '@/components/ErrorMessage.vue'
-import FileInfoTable from '@/components/FileInfoTable.vue'
+
 import FlagsList from '@/components/FlagsList.vue'
 import ResourceBadge from '@/components/ResourceBadge.vue'
-import ZimUrlButtons from '@/components/ZimUrlButtons.vue'
+
+import TaskFileCard from '@/components/TaskFileCard.vue'
 import type { Config } from '@/config'
 import constants from '@/constants'
 import { useAuthStore } from '@/stores/auth'
@@ -628,7 +535,7 @@ import { useNotificationStore } from '@/stores/notification'
 import { useOfflinerStore } from '@/stores/offliner'
 import { useTasksStore } from '@/stores/tasks'
 import type { OfflinerDefinition } from '@/types/offliner'
-import type { Task, TaskFile } from '@/types/tasks'
+import type { Task } from '@/types/tasks'
 import {
   formatDt,
   formatDurationBetween,
@@ -637,7 +544,6 @@ import {
 } from '@/utils/format'
 import {
   artifactsUrl,
-  checkUrl,
   imageHuman as imageHumanFn,
   imageUrl as imageUrlFn,
   logsUrl,
@@ -683,16 +589,6 @@ const eventsHeaders = [
   { title: 'Event', value: 'code' },
   { title: 'Timestamp', value: 'timestamp' },
   { title: 'User', value: 'user' },
-]
-
-const filesHeaders = [
-  { title: 'Filename', value: 'name', width: '30%' },
-  { title: 'Size', value: 'size' },
-  { title: 'Created After', value: 'created_after' },
-  { title: 'Upload Duration', value: 'upload_duration' },
-  { title: 'Quality', value: 'quality' },
-  { title: 'Info', value: 'info' },
-  { title: 'URLs', value: 'urls' },
 ]
 
 // Computed properties
@@ -761,28 +657,6 @@ const sortedFiles = computed(() => {
     return new Date(a.created_timestamp).getTime() - new Date(b.created_timestamp).getTime()
   })
 })
-
-const getDisplayFilename = (file: TaskFile) => {
-  // If there's file info with metadata, build the filename from Name, Date, and Flavour
-  if (file.info?.metadata) {
-    const metadata = file.info.metadata
-    const name = metadata.Name
-    const date = metadata.Date
-    const flavour = metadata.Flavour
-
-    if (name && date) {
-      const parts = [name]
-      if (flavour) {
-        parts.push(flavour)
-      }
-      parts.push(date)
-      return parts.join('/')
-    }
-  }
-
-  // Default to the name attribute
-  return file.name
-}
 
 const command = computed(() => {
   return taskContainer.value?.command?.join(' ') || ''
@@ -856,19 +730,6 @@ const canCancelTasks = computed(() => authStore.hasPermission('tasks', 'cancel')
 const canViewTaskSecrets = computed(() => authStore.hasPermission('tasks', 'secrets'))
 
 // Methods
-const createdAfter = (file: TaskFile, taskData: Task) => {
-  return formatDurationBetween(
-    getTimestampStringForStatus(taskData.timestamp, 'scraper_started'),
-    file.created_timestamp,
-  )
-}
-
-const zimfarmChecksUrl = (fileName: string) => (task.value ? checkUrl(task.value, fileName) : '')
-
-const uploadDuration = (file: TaskFile) => {
-  if (!file.uploaded_timestamp) return '-'
-  return formatDurationBetween(file.created_timestamp, file.uploaded_timestamp)
-}
 
 const copyCommand = async (command: string) => {
   try {
@@ -1015,15 +876,6 @@ pre {
 
 .events-table :deep(tbody tr:nth-of-type(odd)) {
   background-color: rgba(0, 0, 0, 0.05);
-}
-
-.files-table :deep(.v-data-table__td:first-child),
-.files-table :deep(.v-data-table__th:first-child) {
-  max-width: 30%;
-  word-wrap: break-word;
-  word-break: break-word;
-  white-space: normal;
-  overflow-wrap: break-word;
 }
 
 /* Additional word-wrap styles for mobile table cells in this view */


### PR DESCRIPTION
## Rationale
This PR enhances the way files are rendered by showing them as cards instead of tables
<img width="1105" height="780" alt="Screenshot_20260323_155535" src="https://github.com/user-attachments/assets/0ad5a3c9-476a-46ce-b3ae-c078deb8ff8d" />
<img width="1062" height="444" alt="Screenshot_20260323_155402" src="https://github.com/user-attachments/assets/9ad28226-fb20-41b4-a34a-f7e5c676e24d" />
<img width="1098" height="779" alt="Screenshot_20260323_155349" src="https://github.com/user-attachments/assets/4a1b22cb-c869-4f7a-abb0-4ad06259de42" />


## Changes 
- create component `TaskFileCard` for rendering individual task files using vuetify cards


This closes #1765 
