### PR TITLE
remove sudo from update cmd

### DIFF
--- a/worker/contrib/zimfarm.sh
+++ b/worker/contrib/zimfarm.sh
@@ -245,7 +245,7 @@ function inspect() {
 function update() {
     echo "updating $1..."
     dest="${parentdir}/${scriptname}"
-    update_cmd="sudo curl -fsSL ${SOURCE_URL} -o ${dest} && sudo chmod +x ${dest}"
+    update_cmd="curl -fsSL ${SOURCE_URL} -o ${dest} && chmod +x ${dest}"
     if [[ "$2" == "do" ]]; then
         bash -c "${update_cmd}"
     else

--- a/workers/contrib/zimfarm.sh
+++ b/workers/contrib/zimfarm.sh
@@ -244,7 +244,7 @@ function inspect() {
 function update() {
     echo "updating $1..."
     dest="${parentdir}/${scriptname}"
-    update_cmd="sudo curl -fsSL ${SOURCE_URL} -o ${dest} && sudo chmod +x ${dest}"
+    update_cmd="curl -fsSL ${SOURCE_URL} -o ${dest} && chmod +x ${dest}"
     if [[ "$2" == "do" ]]; then
         bash -c "${update_cmd}"
     else


### PR DESCRIPTION

## Changes
- remove `sudo` from `zimfarm update` commands. Instead, the user should use `sudo zimfarm update do` to update the management script.

This closes #1774
