### PR TITLE
add most recent tasks to list of tasks

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/tasks/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/tasks/logic.py
@@ -65,6 +65,7 @@ def get_tasks(
         schedule_name=params.schedule_name,
         sort_criteria=params.sort_criteria,
         offliner=params.offliner,
+        fetch_most_recent_tasks=params.fetch_most_recent_tasks,
     )
     return ListResponse(
         meta=calculate_pagination_metadata(

--- a/backend/src/zimfarm_backend/api/routes/tasks/models.py
+++ b/backend/src/zimfarm_backend/api/routes/tasks/models.py
@@ -27,6 +27,7 @@ class TasksGetSchema(BaseModel):
     schedule_name: NotEmptyString | None = None
     sort_criteria: Literal["done", "doing", "failed", "updated_at"] = "updated_at"
     offliner: NotEmptyString | None = None
+    fetch_most_recent_tasks: bool = False
 
 
 class TaskCreateSchema(BaseModel):

--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -58,6 +58,17 @@ class ConfigWithOnlyOfflinerAndResourcesSchema(ConfigWithOnlyResourcesSchema):
     offliner: str
 
 
+class MostRecentTaskSchema(BaseModel):
+    """
+    Schema for reading a most recent task model with some fields
+    """
+
+    id: UUID
+    status: str
+    updated_at: MadeAwareDateTime
+    timestamp: list[tuple[str, datetime.datetime]]
+
+
 class BaseTaskSchema(BaseModel):
     """
     Schema for reading a task model with some fields
@@ -81,6 +92,8 @@ class TaskLightSchema(BaseTaskSchema):
     """
 
     config: ConfigWithOnlyResourcesSchema
+    schedule_id: UUID | None = Field(exclude=True)
+    schedule_most_recent_task: MostRecentTaskSchema | None = None
 
 
 class ZimUrlSchema(BaseModel):
@@ -234,17 +247,6 @@ class RequestedTaskFullSchema(BaseRequestedTaskSchema):
     offliner_definition_id: UUID = Field(exclude=True)
     offliner: str
     version: str
-
-
-class MostRecentTaskSchema(BaseModel):
-    """
-    Schema for reading a most recent task model with some fields
-    """
-
-    id: UUID
-    status: str
-    updated_at: MadeAwareDateTime
-    timestamp: list[tuple[str, datetime.datetime]]
 
 
 class ConfigOfflinerOnlySchema(BaseModel):

--- a/backend/src/zimfarm_backend/db/tasks.py
+++ b/backend/src/zimfarm_backend/db/tasks.py
@@ -18,6 +18,7 @@ from zimfarm_backend.common.schemas.orms import (
     ConfigResourcesSchema,
     ConfigWithOnlyResourcesSchema,
     ExpandedScheduleConfigSchema,
+    MostRecentTaskSchema,
     OfflinerDefinitionSchema,
     RequestedTaskFullSchema,
     RunningTask,
@@ -172,7 +173,8 @@ def get_tasks(
     schedule_name: str | None = None,
     sort_criteria: Literal["updated_at", "doing", "done", "failed"] = "updated_at",
     offliner: str | None = None,
-):
+    fetch_most_recent_tasks: bool = False,
+) -> TaskListResult:
     # Determine the event/column to sort the results based on sort_criteria
     match sort_criteria:
         case "done":
@@ -205,6 +207,7 @@ def get_tasks(
             Task.updated_at,
             User.display_name.label("requested_by"),
             Schedule.name.label("schedule_name"),
+            Schedule.id.label("schedule_id"),
             Worker.name.label("worker_name"),
         )
         .join(User, Task.requested_by)
@@ -234,6 +237,7 @@ def get_tasks(
         updated_at,
         requested_by,
         _schedule_name,
+        _schedule_id,
         worker_name,
     ) in session.execute(
         stmt  # pyright: ignore[reportUnknownArgumentType]
@@ -257,9 +261,43 @@ def get_tasks(
                 updated_at=updated_at,
                 requested_by=requested_by,
                 schedule_name=_schedule_name,
+                schedule_id=_schedule_id,
                 worker_name=worker_name,
             )
         )
+
+    if fetch_most_recent_tasks:
+        schedule_ids: set[UUID] = {
+            task.schedule_id for task in results.tasks if task.schedule_id
+        }
+        if schedule_ids:
+            stmt = (
+                select(
+                    Task.schedule_id,
+                    Task.id,
+                    Task.status,
+                    Task.updated_at,
+                    Task.timestamp,
+                )
+                .join(Task, Schedule.most_recent_task, isouter=True)
+                .where(Task.schedule_id.in_(list(schedule_ids)))
+            )
+            for (
+                schedule_id,
+                task_id,
+                task_status,
+                task_updated_at,
+                task_timestamp,
+            ) in session.execute(stmt).all():
+                for task in results.tasks:
+                    if schedule_id == task.schedule_id:
+                        task.schedule_most_recent_task = MostRecentTaskSchema(
+                            id=task_id,
+                            status=task_status,
+                            updated_at=task_updated_at,
+                            timestamp=task_timestamp,
+                        )
+
     return results
 
 

--- a/backend/tests/routes/test_task.py
+++ b/backend/tests/routes/test_task.py
@@ -13,25 +13,37 @@ from sqlalchemy.orm.attributes import flag_modified
 from zimfarm_backend.api.routes.tasks import logic as tasks_module
 from zimfarm_backend.api.token import generate_access_token
 from zimfarm_backend.common import getnow
-from zimfarm_backend.common.enums import TaskStatus
+from zimfarm_backend.common.enums import ScheduleCategory, TaskStatus
 from zimfarm_backend.common.roles import RoleEnum
-from zimfarm_backend.common.schemas.models import FileCreateUpdateSchema
-from zimfarm_backend.db.models import RequestedTask, Task, User, Worker
+from zimfarm_backend.common.schemas.models import FileCreateUpdateSchema, LanguageSchema
+from zimfarm_backend.db.models import RequestedTask, Schedule, Task, User, Worker
 from zimfarm_backend.db.tasks import create_or_update_task_file
 
 
+@pytest.mark.parametrize("fetch_most_recent_tasks", ["true", "false"])
 def test_get_tasks(
+    dbsession: OrmSession,
     client: TestClient,
     access_token: str,
     create_task: Callable[..., Task],
+    create_schedule: Callable[..., Schedule],
+    fetch_most_recent_tasks: str,
 ):
     """Test successful retrieval of tasks"""
     # Create some tasks
-    for _ in range(30):
-        create_task()
+    for i in range(30):
+        schedule = create_schedule(
+            name=f"wiki_eng_{i}",
+            category=ScheduleCategory.wikipedia,
+            language=LanguageSchema(code="eng", name="English"),
+            tags=["important"],
+        )
+        schedule.most_recent_task = create_task()
+        dbsession.add(schedule)
+        dbsession.flush()
 
     response = client.get(
-        "/v2/tasks?limit=5&skip=0",
+        f"/v2/tasks?limit=5&skip=0&fetch_most_recent_tasks={fetch_most_recent_tasks}",
         headers={"Authorization": f"Bearer {access_token}"},
     )
     assert response.status_code == HTTPStatus.OK
@@ -41,6 +53,17 @@ def test_get_tasks(
     assert "count" in data["meta"]
     assert data["meta"]["count"] == 30
     assert len(data["items"]) == 5
+
+    for item in data["items"]:
+        most_recent_task = item["schedule_most_recent_task"]
+        if fetch_most_recent_tasks == "true":
+            assert most_recent_task is not None
+            assert "id" in most_recent_task
+            assert "status" in most_recent_task
+            assert "timestamp" in most_recent_task
+            assert "updated_at" in most_recent_task
+        else:
+            assert most_recent_task is None
 
 
 @pytest.mark.parametrize("hide_secrets", ["true", "false"])

--- a/frontend-ui/src/components/PipelineTable.vue
+++ b/frontend-ui/src/components/PipelineTable.vue
@@ -1,23 +1,6 @@
 <template>
   <div>
     <v-card v-if="!errors.length" :class="{ loading: loading }" flat color="transparent">
-      <!-- Load All Last Runs button - only show in failed tab -->
-      <div v-if="showLoadAllButton" class="d-flex justify-end mb-2">
-        <v-btn
-          :loading="loadingAllSchedules"
-          :disabled="loadingAllSchedules || tasks.length === 0"
-          color="primary"
-          variant="tonal"
-          prepend-icon="mdi-refresh"
-          @click="handleLoadAllLastRuns"
-        >
-          Load All Last Runs
-          <v-tooltip activator="parent" location="bottom">
-            Load last run status for all schedules on this page
-          </v-tooltip>
-        </v-btn>
-      </div>
-
       <v-data-table-server
         :headers="headers"
         :items="tasks"
@@ -208,42 +191,20 @@
 
         <template #[`item.last_run`]="{ item }">
           <div
-            v-if="item.schedule_name"
-            :class="['d-flex', 'align-center', { 'justify-end': smAndDown }]"
+            v-if="(item as TaskLight).schedule_most_recent_task"
+            :class="['ga-1', 'd-flex', 'align-center', 'flex-wrap', { 'justify-end': smAndDown }]"
           >
-            <span v-if="schedulesLastRuns[item.schedule_name]">
-              <code :class="statusClass(schedulesLastRuns[item.schedule_name].status)">
-                {{ schedulesLastRuns[item.schedule_name].status }} </code
+            <span>
+              <code :class="statusClass((item as TaskLight).schedule_most_recent_task!.status)">
+                {{ (item as TaskLight).schedule_most_recent_task!.status }} </code
               >,
-              <TaskLink
-                :id="schedulesLastRuns[item.schedule_name].id"
-                :updatedAt="schedulesLastRuns[item.schedule_name].updated_at"
-                :status="schedulesLastRuns[item.schedule_name].status"
-                :timestamp="schedulesLastRuns[item.schedule_name].timestamp"
-              />
             </span>
-            <v-btn
-              :icon="loadingSchedules[item.schedule_name] ? 'mdi-loading' : 'mdi-refresh'"
-              :loading="loadingSchedules[item.schedule_name]"
-              :disabled="loadingSchedules[item.schedule_name]"
-              size="small"
-              variant="text"
-              color="primary"
-              @click="handleLoadLastRun(item.schedule_name)"
-              density="comfortable"
-              class="ml-2"
-            >
-              <v-icon :class="{ 'mdi-spin': loadingSchedules[item.schedule_name] }">
-                {{ loadingSchedules[item.schedule_name] ? 'mdi-loading' : 'mdi-refresh' }}
-              </v-icon>
-              <v-tooltip activator="parent" location="bottom">
-                {{
-                  loadingSchedules[item.schedule_name]
-                    ? 'Loading...'
-                    : 'Load/refresh last run status'
-                }}
-              </v-tooltip>
-            </v-btn>
+            <TaskLink
+              :id="(item as TaskLight).schedule_most_recent_task!.id"
+              :updatedAt="(item as TaskLight).schedule_most_recent_task!.updated_at"
+              :status="(item as TaskLight).schedule_most_recent_task!.status"
+              :timestamp="(item as TaskLight).schedule_most_recent_task!.timestamp"
+            />
           </div>
         </template>
 
@@ -274,12 +235,12 @@ import ErrorMessage from '@/components/ErrorMessage.vue'
 import RemoveRequestedTaskButton from '@/components/RemoveRequestedTaskButton.vue'
 import ResourceBadge from '@/components/ResourceBadge.vue'
 import TaskLink from '@/components/TaskLink.vue'
-import type { MostRecentTask, Paginator } from '@/types/base'
+import type { Paginator } from '@/types/base'
 import type { RequestedTaskLight } from '@/types/requestedTasks'
 import type { TaskLight } from '@/types/tasks'
 import { formatDt, formatDurationBetween, fromNow } from '@/utils/format'
 import { getTimestampStringForStatus } from '@/utils/timestamp'
-import { computed, ref } from 'vue'
+import { ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 import { useDisplay } from 'vuetify'
 
@@ -297,30 +258,20 @@ const props = defineProps<{
   loadingText: string // the text to display when the table is loading
   tasks: TaskLight[] | RequestedTaskLight[] // the tasks to display
   paginator: Paginator // the paginator
-  schedulesLastRuns: Record<string, MostRecentTask> // the last runs for each schedule
   errors: string[] // the errors to display
 }>()
 
 const emit = defineEmits<{
   limitChanged: [limit: number]
   loadData: [limit: number, skip: number]
-  loadLastRun: [scheduleName: string]
-  loadAllLastRuns: []
 }>()
 
 const limits = [10, 20, 50, 100]
-const loadingSchedules = ref<Record<string, boolean>>({})
-const loadingAllSchedules = ref(false)
 
 const isDiagnoseDialogOpen = ref(false)
 const isConfirmDiagnoseOpen = ref(false)
 const selectedTaskToDiagnose = ref<RequestedTaskLight | null>(null)
 const taskToConfirmDiagnose = ref<RequestedTaskLight | null>(null)
-
-// Check if we should show the "Load All Last Runs" button (only in failed tab)
-const showLoadAllButton = computed(() => {
-  return props.headers.some((header) => header.value === 'last_run')
-})
 
 function onUpdateOptions(options: { page: number; itemsPerPage: number }) {
   const query = { ...route.query }
@@ -342,25 +293,6 @@ function statusClass(status: string) {
   if (status === 'succeeded') return 'schedule-succeeded'
   else if (['failed', 'canceled', 'cancel_requested'].includes(status)) return 'schedule-failed'
   else return 'schedule-running'
-}
-
-async function handleLoadLastRun(scheduleName: string) {
-  if (!scheduleName) return
-  loadingSchedules.value[scheduleName] = true
-  try {
-    emit('loadLastRun', scheduleName)
-  } finally {
-    loadingSchedules.value[scheduleName] = false
-  }
-}
-
-async function handleLoadAllLastRuns() {
-  loadingAllSchedules.value = true
-  try {
-    emit('loadAllLastRuns')
-  } finally {
-    loadingAllSchedules.value = false
-  }
 }
 
 function diagnoseTask(task: RequestedTaskLight) {

--- a/frontend-ui/src/stores/requestedTasks.ts
+++ b/frontend-ui/src/stores/requestedTasks.ts
@@ -137,7 +137,7 @@ export const useRequestedTasksStore = defineStore('requestedTasks', () => {
       await service.get<null, null>(`/${id}/diagnose/${worker}`)
       return null
     } catch (_error) {
-      let _errors = translateErrors(_error as ErrorResponse)
+      const _errors = translateErrors(_error as ErrorResponse)
       errors.value = _errors
       return _errors
     }

--- a/frontend-ui/src/stores/tasks.ts
+++ b/frontend-ui/src/stores/tasks.ts
@@ -31,6 +31,7 @@ export const useTasksStore = defineStore('tasks', () => {
       skip?: number
       status?: string[]
       scheduleName?: string
+      fetchMostRecentTasks?: boolean
       sort_criteria?: string
     } = {},
   ) => {
@@ -39,6 +40,7 @@ export const useTasksStore = defineStore('tasks', () => {
       skip = 0,
       status = [],
       scheduleName = null,
+      fetchMostRecentTasks,
       sort_criteria = 'updated_at',
     } = params
     const cleanedParams = Object.fromEntries(
@@ -47,6 +49,7 @@ export const useTasksStore = defineStore('tasks', () => {
         skip,
         status,
         sort_criteria,
+        fetch_most_recent_tasks: fetchMostRecentTasks,
         schedule_name: scheduleName,
       }).filter(([, value]) => !!value),
     )

--- a/frontend-ui/src/types/tasks.ts
+++ b/frontend-ui/src/types/tasks.ts
@@ -1,8 +1,9 @@
-import type { BaseTask, ConfigWithOnlyResources, TaskStatus } from '@/types/base'
+import type { BaseTask, ConfigWithOnlyResources, TaskStatus, MostRecentTask } from '@/types/base'
 import type { ExpandedScheduleConfig, ScheduleNotification } from '@/types/schedule'
 
 export interface TaskLight extends BaseTask {
   config: ConfigWithOnlyResources
+  schedule_most_recent_task?: MostRecentTask | null
 }
 
 export interface TaskEvent {

--- a/frontend-ui/src/views/PipelineView.vue
+++ b/frontend-ui/src/views/PipelineView.vue
@@ -16,11 +16,8 @@
     :canRequestTasks="canRequestTasks"
     :canUnRequestTasks="canUnRequestTasks"
     :canCancelTasks="canCancelTasks"
-    :schedulesLastRuns="schedulesLastRuns"
     @limit-changed="handleLimitChange"
     @load-data="loadData"
-    @load-last-run="handleLoadLastRun"
-    @load-all-last-runs="handleLoadAllLastRuns"
   />
 </template>
 
@@ -29,11 +26,9 @@ import PipelineTable from '@/components/PipelineTable.vue'
 import TasksListTab from '@/components/TasksListTab.vue'
 import { useAuthStore } from '@/stores/auth'
 import { useLoadingStore } from '@/stores/loading'
-import { useNotificationStore } from '@/stores/notification'
 import { useRequestedTasksStore } from '@/stores/requestedTasks'
-import { useScheduleStore } from '@/stores/schedule'
 import { useTasksStore } from '@/stores/tasks'
-import type { Paginator, MostRecentTask } from '@/types/base'
+import type { Paginator } from '@/types/base'
 import type { RequestedTaskLight } from '@/types/requestedTasks'
 import type { TaskLight } from '@/types/tasks'
 import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
@@ -46,8 +41,6 @@ const requestedTasksStore = useRequestedTasksStore()
 const tasksStore = useTasksStore()
 const authStore = useAuthStore()
 const loadingStore = useLoadingStore()
-const scheduleStore = useScheduleStore()
-const notificationStore = useNotificationStore()
 
 // Filter options
 const filterOptions = [
@@ -104,8 +97,6 @@ const currentFilter = computed(() => {
   return (Array.isArray(filter) ? filter[0] : filter) || 'todo'
 })
 
-const schedulesLastRuns = ref<Record<string, MostRecentTask>>({})
-
 const tasks = ref<TaskLight[] | RequestedTaskLight[]>([])
 const defaultLimit = computed(() =>
   currentFilter.value == 'todo' ? requestedTasksStore.defaultLimit : tasksStore.defaultLimit,
@@ -132,11 +123,6 @@ const handleFilterChange = (newFilter: string) => {
     },
   })
 }
-
-// Clear last runs when switching filters
-watch(currentFilter, () => {
-  schedulesLastRuns.value = {}
-})
 
 async function loadData(
   limit: number,
@@ -192,6 +178,7 @@ async function loadData(
         skip,
         status: ['scraper_killed', 'failed', 'canceled'],
         sort_criteria: 'failed',
+        fetchMostRecentTasks: true,
       })
       tasks.value = tasksStore.tasks
       errors.value = tasksStore.errors
@@ -204,33 +191,6 @@ async function loadData(
   if (loadingStore.isLoading) {
     loadingStore.stopLoading()
   }
-}
-
-async function handleLoadLastRun(scheduleName: string) {
-  if (!scheduleName) return
-
-  const result = await scheduleStore.fetchSchedule(scheduleName)
-  if (result && result.most_recent_task) {
-    schedulesLastRuns.value[scheduleName] = result.most_recent_task
-  }
-  if (scheduleStore.errors.length > 0) {
-    for (const error of scheduleStore.errors) {
-      notificationStore.showError(`Failed to load last run for schedule ${scheduleName}: ${error}`)
-    }
-  }
-}
-
-async function handleLoadAllLastRuns() {
-  const scheduleNames = new Set<string>()
-  tasks.value.forEach((task) => {
-    if (task.schedule_name) {
-      scheduleNames.add(task.schedule_name)
-    }
-  })
-
-  const promises = Array.from(scheduleNames).map((scheduleName) => handleLoadLastRun(scheduleName))
-
-  await Promise.all(promises)
 }
 
 async function handleLimitChange(newLimit: number) {


### PR DESCRIPTION
## Rationale
This PR enhances the API to fetch tasks to accept optional parameter `fetch_most_recent_tasks` which determines whether to load the most recent task of the task's schedule.

## Changes
- add params to DB and API to fetch the most recent task of a task's schedule
- refactor UI failed tab to make query with `fetch_most_recent_tasks` set to True
- remove buttons to individually fetch most recent tasks on failed tab

This closes #885

