### PR TITLE
hide most recent task if it's the same failed task

### DIFF
--- a/frontend-ui/src/components/PipelineTable.vue
+++ b/frontend-ui/src/components/PipelineTable.vue
@@ -191,7 +191,10 @@
 
         <template #[`item.last_run`]="{ item }">
           <div
-            v-if="(item as TaskLight).recipe_most_recent_task"
+            v-if="
+              (item as TaskLight).recipe_most_recent_task &&
+              (item as TaskLight).recipe_most_recent_task?.id != item.id
+            "
             :class="['ga-1', 'd-flex', 'align-center', 'flex-wrap', { 'justify-end': smAndDown }]"
           >
             <span>


### PR DESCRIPTION
## Changes
- hide most recent task entry from UI if it's the same failed task
<img width="1572" height="506" alt="Screenshot_20260331_175643" src="https://github.com/user-attachments/assets/7c3beb23-4da0-4bf3-970b-d2725e11f299" />


This closes #1805