### PR TITLE
always return diagnostic reason

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/requested_tasks/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/requested_tasks/logic.py
@@ -1,10 +1,9 @@
-from http import HTTPStatus
 from typing import Annotated, cast
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Path, Query
 from fastapi.requests import Request
-from fastapi.responses import JSONResponse, Response
+from fastapi.responses import JSONResponse
 from sqlalchemy.orm import Session as OrmSession
 
 from zimfarm_backend import logger
@@ -386,6 +385,4 @@ def diagnose_requested_task(
             session, requested_task_id=requested_task_id
         ),
     )
-    if reason:
-        raise BadRequestError(reason)
-    return Response(status_code=HTTPStatus.NO_CONTENT)
+    raise BadRequestError(reason)

--- a/backend/src/zimfarm_backend/db/requested_task.py
+++ b/backend/src/zimfarm_backend/db/requested_task.py
@@ -55,6 +55,7 @@ from zimfarm_backend.db.worker import create_worker_schema, get_worker_or_none
 from zimfarm_backend.utils.offliners import expanded_config
 from zimfarm_backend.utils.timestamp import (
     get_status_timestamp_expr,
+    get_timestamp_for_status,
 )
 
 # Maximum positive integer value for PostgreSQL BigInteger
@@ -664,10 +665,17 @@ def _can_run(task: RequestedTaskWithDuration, resource: ResourcesSchema) -> bool
     return True
 
 
-def _check_worker_unavailable_reason(
+def _get_worker_unavailable_reason(
     worker: WorkerLightSchema, running_tasks: list[RunningTask]
-) -> str | None:
-    running_task_timestamps = [t.updated_at for t in running_tasks]
+) -> str:
+    running_task_timestamps = [
+        get_timestamp_for_status(
+            t.timestamp,
+            status=TaskStatus.reserved,
+        )
+        for t in running_tasks
+    ]
+
     last_seen_reason = ""
     if worker.last_seen:
         last_seen_reason = (
@@ -690,7 +698,10 @@ def _check_worker_unavailable_reason(
         reason = f"Worker '{worker.name}' appears to be offline " + last_seen_reason
         return reason
 
-    return None
+    return (
+        f"We have no reason for this task to not start on worker '{worker.name}' as"
+        f"worker has no running tasks. Worker is {worker.status}"
+    ) + last_seen_reason
 
 
 def diagnose_requested_task(
@@ -698,7 +709,7 @@ def diagnose_requested_task(
     *,
     worker: WorkerLightSchema,
     requested_task: RequestedTask,
-) -> str | None:
+) -> str:
     """Diagnose why a requested task isn't running on worker"""
     if reason := _validate_worker_availability(worker):
         return reason
@@ -753,9 +764,7 @@ def diagnose_requested_task(
     )
 
     if _can_run(task, available_resources):
-        if reason := _check_worker_unavailable_reason(worker, running_tasks):
-            return reason
-        return None
+        return _get_worker_unavailable_reason(worker, running_tasks)
 
     # Calculate when resources will become available
     if reason := _find_task_that_can_run_with_available_resources(
@@ -771,11 +780,7 @@ def diagnose_requested_task(
     ).error:
         return reason
 
-    if reason := _check_worker_unavailable_reason(worker, running_tasks=running_tasks):
-        return reason
-
-    # we shouldn't get here if task can run as
-    return None
+    return _get_worker_unavailable_reason(worker, running_tasks=running_tasks)
 
 
 def _find_task_that_can_run_with_available_resources(

--- a/backend/tests/db/test_requested_task.py
+++ b/backend/tests/db/test_requested_task.py
@@ -20,7 +20,7 @@ from zimfarm_backend.db.models import Recipe, RequestedTask, Task, User, Worker
 from zimfarm_backend.db.requested_task import (
     RequestedTaskWithDuration,
     RunningTask,
-    _check_worker_unavailable_reason,  # pyright: ignore[reportPrivateUsage]
+    _get_worker_unavailable_reason,  # pyright: ignore[reportPrivateUsage]
     compute_requested_task_rank,
     delete_requested_task,
     diagnose_requested_task,
@@ -1075,7 +1075,6 @@ def test_find_requested_task_for_worker(
         "worker_resource",
         "recipe_resource",
         "recipe_context",
-        "result_bool",
         "error_regex",
     ],
     [
@@ -1087,8 +1086,7 @@ def test_find_requested_task_for_worker(
             ResourcesSchema(cpu=1, memory=1, disk=1),
             ResourcesSchema(cpu=1, memory=1, disk=1),
             "",
-            True,
-            None,
+            "We have no reason for this task to not start on worker.*",
             id="worker-matches-recipe",
         ),
         pytest.param(
@@ -1099,7 +1097,6 @@ def test_find_requested_task_for_worker(
             ResourcesSchema(cpu=1, memory=1, disk=1),
             ResourcesSchema(cpu=2, memory=1, disk=1),
             "",
-            False,
             "Worker .* does not have enough resources to run",
             id="worker-does-not-match-recipe-cpu",
         ),
@@ -1111,7 +1108,6 @@ def test_find_requested_task_for_worker(
             ResourcesSchema(cpu=1, memory=1, disk=1),
             ResourcesSchema(cpu=1, memory=2, disk=1),
             "",
-            False,
             "Worker .* does not have enough resources to run",
             id="worker-does-not-match-recipe-memory",
         ),
@@ -1123,7 +1119,6 @@ def test_find_requested_task_for_worker(
             ResourcesSchema(cpu=1, memory=1, disk=1),
             ResourcesSchema(cpu=1, memory=1, disk=2),
             "",
-            False,
             "Worker .* does not have enough resources to run",
             id="worker-does-not-match-recipe-disk",
         ),
@@ -1135,7 +1130,6 @@ def test_find_requested_task_for_worker(
             ResourcesSchema(cpu=1, memory=1, disk=1),
             ResourcesSchema(cpu=1, memory=1, disk=1),
             "priority",  # recipe_context
-            False,
             "Worker .* does not have required context to run",
             id="worker-context-does-not-match-recipe",
         ),
@@ -1147,7 +1141,6 @@ def test_find_requested_task_for_worker(
             ResourcesSchema(cpu=1, memory=1, disk=1),
             ResourcesSchema(cpu=1, memory=1, disk=1),
             "general",  # recipe_context
-            False,
             "Worker .* has required context but IP is not whitelisted to run",
             id="worker-whitelisted-context-ip-does-not-match-last-seen",
         ),
@@ -1159,8 +1152,7 @@ def test_find_requested_task_for_worker(
             ResourcesSchema(cpu=1, memory=1, disk=1),
             ResourcesSchema(cpu=1, memory=1, disk=1),
             "general",  # recipe_context
-            True,
-            None,
+            "We have no reason for this task to not start on worker.*",
             id="worker-whitelisted-context-ip-matches-last-seen",
         ),
         pytest.param(
@@ -1171,7 +1163,6 @@ def test_find_requested_task_for_worker(
             ResourcesSchema(cpu=1, memory=1, disk=1),
             ResourcesSchema(cpu=1, memory=1, disk=1),
             "general",  # recipe_context
-            False,
             "is cordoned/disabled",
             id="worker-cordoned",
         ),
@@ -1183,7 +1174,6 @@ def test_find_requested_task_for_worker(
             ResourcesSchema(cpu=1, memory=1, disk=1),
             ResourcesSchema(cpu=1, memory=1, disk=1),
             "general",  # recipe_context
-            False,
             "is cordoned/disabled",
             id="worker-admin-disabled",
         ),
@@ -1195,8 +1185,7 @@ def test_find_requested_task_for_worker(
             ResourcesSchema(cpu=1, memory=1, disk=1),
             ResourcesSchema(cpu=1, memory=1, disk=1),
             "general",  # recipe_context
-            True,
-            None,
+            "We have no reason for this task to not start on worker.*",
             id="context-has-no-ip",
         ),
     ],
@@ -1217,8 +1206,7 @@ def test_diagnose_requested_task(
     worker_resource: ResourcesSchema,
     recipe_resource: ResourcesSchema,
     recipe_context: str,
-    result_bool: bool,
-    error_regex: str | None,
+    error_regex: str,
 ):
     """Test that diagnose_requested_task accurately reports why a task can't run"""
     worker = create_worker(
@@ -1269,12 +1257,8 @@ def test_diagnose_requested_task(
         requested_task=task,
     )
 
-    if result_bool:
-        assert reason is None
-    else:
-        assert reason is not None
-        if error_regex:
-            assert re.search(error_regex, reason) is not None
+    assert reason is not None
+    assert re.search(error_regex, reason) is not None
 
 
 def test_find_requested_task_first_cannot_run_but_alternative_can(
@@ -1477,11 +1461,11 @@ def test_check_worker_unavailable_reason_with_running_tasks(
     running_tasks = get_currently_running_tasks(dbsession, worker.name)
     worker_schema = create_worker_schema(worker, show_secrets=False)
 
-    reason = _check_worker_unavailable_reason(worker_schema, running_tasks)
+    reason = _get_worker_unavailable_reason(worker_schema, running_tasks)
     assert reason is not None
 
 
 def test_check_worker_unavailable_reason_without_running_tasks(worker: Worker):
     worker_schema = create_worker_schema(worker, show_secrets=False)
-    reason = _check_worker_unavailable_reason(worker_schema, [])
-    assert reason is None
+    reason = _get_worker_unavailable_reason(worker_schema, [])
+    assert reason is not None


### PR DESCRIPTION
## Changes
- always return diagnostic reason for why a task isn't starting
- use task started timestamps to build up list of running task timestamps instead of their `updated_at`. default to `reserved` since all tasks must be reserved
- rename default function that returns diagnostic reason to `_get_worker_unavailable_reason`

This closes #1806

