### PR TITLE
make local auth optional

### DIFF
--- a/.github/workflows/monitor-QA.yml
+++ b/.github/workflows/monitor-QA.yml
@@ -1,0 +1,41 @@
+name: Monitor Parent QA
+
+on:
+  pull_request:
+    paths:
+      - "monitor/parent**"
+  push:
+    paths:
+      - "monitor/parent**"
+    branches:
+      - main
+
+jobs:
+  check-qa:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.13"
+          architecture: x64
+
+      - name: Install dependencies (and project)
+        working-directory: monitor/parent
+        run: |
+          pip install -U pip
+          pip install black ruff pyright
+
+      - name: Check black formatting
+        working-directory: monitor/parent
+        run: black --check --diff .
+
+      - name: Check ruff
+        working-directory: monitor/parent
+        run: ruff check .
+
+      - name: Check pyright
+        working-directory: monitor/parent
+        run: pyright

--- a/backend/src/zimfarm_backend/api/token.py
+++ b/backend/src/zimfarm_backend/api/token.py
@@ -105,18 +105,29 @@ class OAuthOIDCTokenDecoder(TokenDecoder):
             issuer=OAUTH_ISSUER,
             audience=OAUTH_OIDC_CLIENT_ID,
             options={
-                "require": ["exp", "iat", "iss", "sub", "name", "amr", "aud"],
+                "require": ["exp", "iat", "iss", "sub", "aud"],
             },
         )
 
+        if (
+            client_id := decoded_token.get("client_id")
+        ) and client_id != decoded_token.get("sub"):
+            raise ValueError("Oauth client ID does not match.")
+
+        # Check for 2FA requirement only if client_id is not present in the token
+        # as those come from oauth2 clients and not real users.
         # Ensure the user logged in with two authentication factors. As per Ory docs,
         # "password", "code"  and "oidc" are categorized as first methods of login while
         # "totp", "webauthn" and "lookup_secret" are second authentication methods
         # https://www.ory.com/docs/kratos/mfa/overview#authenticator-assurance-level-aal
         amr = set(decoded_token.get("amr", []))
-        if OAUTH_OIDC_LOGIN_REQUIRE_2FA and not (
-            {"password", "oidc", "code"} & amr
-            and {"webauthn", "lookup_secrets", "totp"} & amr
+        if (
+            not decoded_token.get("client_id")
+            and OAUTH_OIDC_LOGIN_REQUIRE_2FA
+            and not (
+                {"password", "oidc", "code"} & amr
+                and {"webauthn", "lookup_secrets", "totp"} & amr
+            )
         ):
             raise ValueError(
                 "2FA authentication is mandatory on Zimfarm but it looks like you only "
@@ -150,6 +161,7 @@ class OAuthSessionTokenDecoder(TokenDecoder):
         Decode and validate an OAuth OIDC token.
         """
         signing_key = self._jwks_client.get_signing_key_from_jwt(token)
+
         decoded_token = jwt.decode(
             token,
             signing_key.key,
@@ -157,11 +169,22 @@ class OAuthSessionTokenDecoder(TokenDecoder):
             issuer=OAUTH_ISSUER,
             audience=OAUTH_SESSION_AUDIENCE_ID,
             options={
-                "require": ["exp", "iat", "iss", "sub", "name", "aud", "aal"],
+                "require": ["exp", "iat", "iss", "sub", "aud"],
             },
         )
 
-        if OAUTH_SESSION_LOGIN_REQUIRE_2FA and decoded_token.get("aal") != "aal2":
+        if (
+            client_id := decoded_token.get("client_id")
+        ) and client_id != decoded_token.get("sub"):
+            raise ValueError("Oauth client ID does not match.")
+
+        # Check for 2FA requirement only if client_id is not present in the token
+        # as those come from oauth2 clients and not real users
+        if (
+            not decoded_token.get("client_id")
+            and OAUTH_SESSION_LOGIN_REQUIRE_2FA
+            and decoded_token.get("aal") != "aal2"
+        ):
             raise ValueError(
                 "2FA authentication is mandatory on Zimfarm but it looks like you only "
                 "have one setup on Ory. Please, configure a second one on Ory at "

--- a/backend/tests/test_token_decoder.py
+++ b/backend/tests/test_token_decoder.py
@@ -44,7 +44,7 @@ def create_test_session_jwt_token(
     audience_id: str = TEST_CLIENT_ID,
     subject: str | None = None,
     exp_delta: datetime.timedelta = datetime.timedelta(hours=1),
-    aal: str = "aal2",
+    aal: str | None = "aal2",
 ) -> str:
     """Create a test JWT token for session authentication."""
     if subject is None:
@@ -57,9 +57,10 @@ def create_test_session_jwt_token(
         "iat": int(now.timestamp()),
         "exp": int((now + exp_delta).timestamp()),
         "aud": audience_id,
-        "aal": aal,
         "name": "Test User",
     }
+    if aal:
+        payload["aal"] = aal
 
     # Create a test token (unsigned for testing purposes)
     return jwt.encode(payload, "test-secret", algorithm="HS256")
@@ -407,3 +408,99 @@ def test_verify_session_access_token_with_2fa_disabled_only_aal1(
         assert result.iss == decoded_payload["iss"]
         assert str(result.sub) == decoded_payload["sub"]
         assert result.name == decoded_payload["name"]
+
+
+def test_verify_session_access_token_with_client_id_requires_no_2fa(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Test that verification succeeds when 2FA is enabled but token contains client_id
+    """
+    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
+    monkeypatch.setattr(
+        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE_ID",
+        TEST_CLIENT_ID,
+    )
+    monkeypatch.setattr(
+        "zimfarm_backend.api.token.OAUTH_SESSION_LOGIN_REQUIRE_2FA", True
+    )
+
+    test_token = create_test_session_jwt_token(aal=None)
+
+    mock_signing_key = MagicMock()
+    mock_signing_key.key = "test-key"
+    sub = str(UUID(int=0))
+
+    decoded_payload = {
+        "iss": TEST_ISSUER,
+        "aud": TEST_CLIENT_ID,
+        "sub": sub,
+        "client_id": sub,
+        "name": "Test User",
+        "iat": int(getnow().timestamp()),
+        "exp": int((getnow() + datetime.timedelta(hours=1)).timestamp()),
+    }
+
+    decoder = OAuthSessionTokenDecoder()
+
+    with (
+        patch.object(
+            decoder._jwks_client,
+            "get_signing_key_from_jwt",
+        ) as mock_get_key,
+        patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
+    ):
+        mock_get_key.return_value = mock_signing_key
+        mock_decode.return_value = decoded_payload
+
+        result = decoder.decode(test_token)
+
+        # The decoder returns a JWTClaims object, not the raw payload
+        assert result.iss == decoded_payload["iss"]
+        assert str(result.sub) == decoded_payload["sub"]
+
+
+def test_verify_session_access_token_verify_client_id_matches_sub(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Test that verification succeeds when 2FA is enabled but token contains client_id
+    """
+    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
+    monkeypatch.setattr(
+        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE_ID",
+        TEST_CLIENT_ID,
+    )
+    monkeypatch.setattr(
+        "zimfarm_backend.api.token.OAUTH_SESSION_LOGIN_REQUIRE_2FA", True
+    )
+
+    test_token = create_test_session_jwt_token(aal=None)
+
+    mock_signing_key = MagicMock()
+    mock_signing_key.key = "test-key"
+
+    decoded_payload = {
+        "iss": TEST_ISSUER,
+        "aud": TEST_CLIENT_ID,
+        "sub": str(UUID(int=0)),
+        "client_id": str(UUID(int=1)),
+        "name": "Test User",
+        "iat": int(getnow().timestamp()),
+        "exp": int((getnow() + datetime.timedelta(hours=1)).timestamp()),
+    }
+
+    decoder = OAuthSessionTokenDecoder()
+
+    with (
+        patch.object(
+            decoder._jwks_client,
+            "get_signing_key_from_jwt",
+        ) as mock_get_key,
+        patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
+    ):
+        mock_get_key.return_value = mock_signing_key
+        mock_decode.return_value = decoded_payload
+
+        with pytest.raises(ValueError, match="Oauth client ID does not match"):
+            decoder.decode(test_token)

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -336,7 +336,7 @@ services:
     environment:
       DEBUG: true
       ZIMFARM_API_URL: http://backend:80/v2
-      ZIMFARM_FRONTEND_URL: http://frontend-ui-dev:80
+      ZIMFARM_FRONTEND_URL: http://frontend-ui:80
       ZIMFARM_USERNAME: admin
       ZIMFARM_PASSWORD: admin
       ZIMFARM_DATABASE_URL: postgresql+psycopg://zimfarm:zimpass@postgresdb:5432/zimfarm
@@ -344,6 +344,12 @@ services:
 
     ports:
       - 127.0.0.1:8005:80
+
+    depends_on:
+      backend:
+        condition: service_healthy
+      frontend-ui-dev:
+        condition: service_started
 
     profiles:
       - healthcheck

--- a/healthcheck/src/healthcheck/constants.py
+++ b/healthcheck/src/healthcheck/constants.py
@@ -27,8 +27,19 @@ ZIMFARM_API_URL = getenv("ZIMFARM_API_URL", default="https://api.farm.openzim.or
 ZIMFARM_FRONTEND_URL = getenv(
     "ZIMFARM_FRONTEND_URL", default="https://farm.openzim.org"
 )
-ZIMFARM_USERNAME = getenv("ZIMFARM_USERNAME", mandatory=True)
-ZIMFARM_PASSWORD = getenv("ZIMFARM_PASSWORD", mandatory=True)
+# Authentication mode: can be either "local" or "oauth"
+AUTH_MODE = getenv("AUTH_MODE", default="local")
+ZIMFARM_USERNAME = getenv("ZIMFARM_USERNAME", default="")
+ZIMFARM_PASSWORD = getenv("ZIMFARM_PASSWORD", default="")
+ZIMFARM_OAUTH_ISSUER = getenv(
+    "ZIMFARM_OAUTH_ISSUER", default="https://ory.login.kiwix.org"
+)
+ZIMFARM_OAUTH_CLIENT_ID = getenv("ZIMFARM_OAUTH_CLIENT_ID", default="")
+ZIMFARM_OAUTH_CLIENT_SECRET = getenv("ZIMFARM_OAUTH_CLIENT_SECRET", default="")
+ZIMFARM_OAUTH_AUDIENCE_ID = getenv("ZIMFARM_OAUTH_AUDIENCE_ID", default="")
+ZIMFARM_TOKEN_RENEWAL_WINDOW = datetime.timedelta(
+    seconds=parse_timespan(getenv("ZIMFARM_TOKEN_RENEWAL_WINDOW", default="5m"))
+)
 ZIMFARM_DATABASE_URL = getenv("ZIMFARM_DATABASE_URL", mandatory=True)
 
 CMS_API_URL = getenv("CMS_API_URL", default="https://api.cms.openzim.org/v1")

--- a/healthcheck/src/healthcheck/status/auth.py
+++ b/healthcheck/src/healthcheck/status/auth.py
@@ -1,9 +1,24 @@
 import datetime
+from http import HTTPStatus
+from typing import cast
 
+from aiohttp.helpers import BasicAuth
 from pydantic import BaseModel
 
-from healthcheck.constants import ZIMFARM_API_URL, ZIMFARM_PASSWORD, ZIMFARM_USERNAME
+from healthcheck.constants import (
+    AUTH_MODE,
+    REQUESTS_TIMEOUT,
+    ZIMFARM_API_URL,
+    ZIMFARM_OAUTH_AUDIENCE_ID,
+    ZIMFARM_OAUTH_CLIENT_ID,
+    ZIMFARM_OAUTH_CLIENT_SECRET,
+    ZIMFARM_OAUTH_ISSUER,
+    ZIMFARM_PASSWORD,
+    ZIMFARM_TOKEN_RENEWAL_WINDOW,
+    ZIMFARM_USERNAME,
+)
 from healthcheck.status import Result
+from healthcheck.status import status_logger as logger
 from healthcheck.status.requests import query_api
 
 
@@ -16,16 +31,142 @@ class Token(BaseModel):
     token_type: str = "Bearer"
 
 
+def getnow():
+    """naive UTC now"""
+    return datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
+
+
+class ClientTokenProvider:
+    """Client to generate access tokens to authenticate with Zimfarm"""
+
+    def __init__(self):
+        self._access_token: str | None = None
+        self._refresh_token: str | None = None
+        self._expires_at: datetime.datetime = datetime.datetime.fromtimestamp(
+            0
+        ).replace(tzinfo=None)
+
+    async def _generate_oauth_access_token(self) -> None:
+        """Generate oauth access token and update expires_at."""
+
+        response = await query_api(
+            f"{ZIMFARM_OAUTH_ISSUER}/oauth2/token",
+            method="POST",
+            data={
+                "grant_type": "client_credentials",
+                "audience": ZIMFARM_OAUTH_AUDIENCE_ID,
+            },
+            auth=BasicAuth(ZIMFARM_OAUTH_CLIENT_ID, ZIMFARM_OAUTH_CLIENT_SECRET),
+            timeout=REQUESTS_TIMEOUT,
+            check_name="zimfarm-api-authentication",
+        )
+        if response.json:
+            self._access_token = cast(str, response.json["access_token"])
+            self._expires_at = getnow() + datetime.timedelta(
+                seconds=response.json["expires_in"]
+            )
+
+    async def _generate_local_access_token(self) -> None:
+        check_name = "zimfarm-api-authentication"
+        if self._refresh_token:
+            response = await query_api(
+                f"{ZIMFARM_API_URL}/auth/refresh",
+                method="POST",
+                payload={
+                    "refresh_token": self._refresh_token,
+                },
+                timeout=REQUESTS_TIMEOUT,
+                check_name=check_name,
+            )
+        else:
+            response = await query_api(
+                f"{ZIMFARM_API_URL}/auth/authorize",
+                method="POST",
+                payload={
+                    "username": ZIMFARM_USERNAME,
+                    "password": ZIMFARM_PASSWORD,
+                },
+                timeout=REQUESTS_TIMEOUT,
+                check_name=check_name,
+            )
+
+        if response.json:
+            self._access_token = cast(str, response.json["access_token"])
+            self._refresh_token = cast(str, response.json["refresh_token"])
+            self._expires_at = datetime.datetime.fromisoformat(
+                response.json["expires_time"]
+            ).replace(tzinfo=None)
+
+    async def get_access_token(self, *, force_refresh: bool = False) -> str:
+        """Retrieve or generate access token depending on if token has expired."""
+        now = getnow()
+        if (
+            force_refresh
+            or self._access_token is None
+            or now >= (self._expires_at - ZIMFARM_TOKEN_RENEWAL_WINDOW)
+        ):
+            if AUTH_MODE == "oauth":
+                await self._generate_oauth_access_token()
+            elif AUTH_MODE == "local":
+                await self._generate_local_access_token()
+            else:
+                raise ValueError(
+                    f"Unknown authentication mode: {AUTH_MODE}. "
+                    "Allowed values are: 'local', 'oauth'"
+                )
+        if self._access_token is None:
+            raise ValueError("Failed to generate access token.")
+        return self._access_token
+
+    @property
+    def expires_at(self) -> datetime.datetime:
+        return self._expires_at
+
+    @property
+    def refresh_token(self) -> str | None:
+        return self._refresh_token
+
+
+_token_provider = ClientTokenProvider()
+
+
 async def authenticate() -> Result[Token]:
-    """Check if authentication is sucessful with Zimfarm"""
-    response = await query_api(
-        f"{ZIMFARM_API_URL}/auth/authorize",
-        method="POST",
-        payload={"username": ZIMFARM_USERNAME, "password": ZIMFARM_PASSWORD},
-        check_name="zimfarm-api-authentication",
-    )
-    return Result(
-        success=response.success,
-        status_code=response.status_code,
-        data=Token.model_validate(response.json) if response.success else None,
-    )
+    """Check if authentication is successful with Zimfarm"""
+    try:
+        access_token = await _token_provider.get_access_token()
+        token = Token(
+            access_token=access_token,
+            expires_time=_token_provider.expires_at,
+            refresh_token=_token_provider.refresh_token or "",
+        )
+
+        response = await query_api(
+            f"{ZIMFARM_API_URL}/auth/test",
+            method="GET",
+            headers={"Authorization": f"Bearer {token.access_token}"},
+            check_name="zimfarm-api-authentication",
+        )
+
+        if response.success:
+            logger.debug(
+                f"Authentication successful using {AUTH_MODE} mode",
+                extra={"checkname": "zimfarm-api-authentication"},
+            )
+
+            return Result(
+                success=True,
+                status_code=HTTPStatus.OK,
+                data=token,
+            )
+        else:
+            return Result(
+                success=False,
+                status_code=HTTPStatus.UNAUTHORIZED,
+                data=None,
+            )
+    except Exception:
+        return Result(
+            success=False,
+            status_code=HTTPStatus.INTERNAL_SERVER_ERROR,
+            data=None,
+        )

--- a/healthcheck/src/healthcheck/status/requests.py
+++ b/healthcheck/src/healthcheck/status/requests.py
@@ -4,6 +4,7 @@ from json import JSONDecodeError
 from typing import Any
 
 import aiohttp
+from aiohttp.helpers import BasicAuth
 
 from healthcheck.constants import REQUESTS_TIMEOUT
 from healthcheck.status import status_logger as logger
@@ -28,6 +29,8 @@ async def query_api(
     payload: dict[str, Any] | None = None,
     params: dict[str, Any] | None = None,
     timeout: float = REQUESTS_TIMEOUT,
+    auth: BasicAuth | None = None,
+    data: dict[str, Any] | None = None,
 ) -> Response:
     req_headers: dict[str, Any] = {}
     req_headers.update(headers if headers else {})
@@ -48,6 +51,8 @@ async def query_api(
             json=payload,
             params=params,
             timeout=aiohttp.ClientTimeout(total=timeout),
+            auth=auth,
+            data=data,
         ) as resp:
             try:
                 text = await resp.text()

--- a/monitor/parent/entrypoint.sh
+++ b/monitor/parent/entrypoint.sh
@@ -1,5 +1,34 @@
 #!/bin/bash
 
+die() {
+    printf 'error: %s\n' "$1" >&2
+    exit 1
+}
+
+AUTH_MODE="${AUTH_MODE:-local}"
+
+case "$AUTH_MODE" in
+    local)
+        if [[ -z "$ZIMFARM_USERNAME" || -z "$ZIMFARM_PASSWORD" ]]; then
+            die "ZIMFARM_USERNAME and ZIMFARM_PASSWORD must be set when AUTH_MODE is 'local'"
+        fi
+        ;;
+
+    oauth)
+        if [[ -z "$ZIMFARM_OAUTH_CLIENT_ID" ||
+              -z "$ZIMFARM_OAUTH_CLIENT_SECRET" ||
+              -z "$ZIMFARM_OAUTH_ISSUER" ||
+              -z "$ZIMFARM_OAUTH_AUDIENCE_ID" ]]; then
+            die "ZIMFARM_OAUTH_CLIENT_ID, ZIMFARM_OAUTH_CLIENT_SECRET and ZIMFARM_OAUTH_AUDIENCE_ID must be set when AUTH_MODE is 'oauth'."
+        fi
+        ;;
+
+    *)
+        die "Unsupported value '$AUTH_MODE' for AUTH_MODE. Only 'local' and 'oauth' are supported."
+        ;;
+esac
+
+
 # setup custom hostname for node in netdata
 if [ ! -z "${NETDATA_HOSTNAME}" ]
 then
@@ -50,6 +79,10 @@ NETDATA_LISTENER_PORT=${NETDATA_LISTENER_PORT}
 ZIMFARM_API_URL=${ZIMFARM_API_URL}
 ZIMFARM_USERNAME=${ZIMFARM_USERNAME}
 ZIMFARM_PASSWORD=${ZIMFARM_PASSWORD}
+AUTH_MODE=${AUTH_MODE}
+ZIMFARM_OAUTH_ISSUERk=${ZIMFARM_OAUTH_ISSUER}
+ZIMFARM_OAUTH_CLIENT_ID=${ZIMFARM_OAUTH_CLIENT_ID}
+ZIMFARM_OAUTH_AUDIENCE_ID=${ZIMFARM_OAUTH_AUDIENCE_ID}
 
 */15 * * * * root /usr/local/bin/update-stream-whitelist.sh >> /var/log/cron.log 2>&1
 EOF

--- a/monitor/parent/regen-stream-conf.py
+++ b/monitor/parent/regen-stream-conf.py
@@ -2,18 +2,28 @@
 
 import json
 import os
-import uuid
 import sys
 import time
 import urllib.error
 import urllib.parse
+import base64
 import urllib.request
+import uuid
 from http import HTTPStatus
 from typing import Any, Tuple, Union
 
 API_URL = os.getenv("ZIMFARM_API_URL")
 if not API_URL:
     raise OSError("Please set the ZIMFARM_API_URL environment variable")
+
+# Authentication mode: can be either "local" or "oauth"
+AUTH_MODE = os.getenv("AUTH_MODE", "local")
+ZIMFARM_USERNAME = os.getenv("ZIMFARM_USERNAME", "")
+ZIMFARM_PASSWORD = os.getenv("ZIMFARM_PASSWORD", "")
+ZIMFARM_OAUTH_ISSUER = os.getenv("ZIMFARM_OAUTH_ISSUER", "https://ory.login.kiwix.org")
+ZIMFARM_OAUTH_CLIENT_ID = os.getenv("ZIMFARM_OAUTH_CLIENT_ID", "")
+ZIMFARM_OAUTH_CLIENT_SECRET = os.getenv("ZIMFARM_OAUTH_CLIENT_SECRET", "")
+ZIMFARM_OAUTH_AUDIENCE_ID = os.getenv("ZIMFARM_OAUTH_AUDIENCE_ID", "")
 
 TEMPLATE = """[__KEY__]
  enabled = yes
@@ -35,27 +45,96 @@ def format_key(fingerprint: str) -> str:
     return str(uuid.uuid5(uuid.NAMESPACE_DNS, fingerprint)).upper()
 
 
-def get_token() -> str:
-    url = f"{API_URL}/auth/authorize"
-    headers = {
-        "Content-type": "application/json",
-    }
+class ClientTokenProvider:
+    """Client to generate access tokens to authenticate with Zimfarm"""
 
-    payload = {
-        "username": os.getenv("ZIMFARM_USERNAME", "n/a"),
-        "password": os.getenv("ZIMFARM_PASSWORD", "n/a"),
-    }
+    def __init__(self):
+        self._access_token: str | None = None
+        self._refresh_token: str | None = None
 
-    data = json.dumps(payload).encode("utf-8")
+    def _generate_oauth_access_token(self) -> None:
+        """Generate oauth access token."""
 
-    req = urllib.request.Request(url, data=data, headers=headers, method="POST")
+        credentials = f"{ZIMFARM_OAUTH_CLIENT_ID}:{ZIMFARM_OAUTH_CLIENT_SECRET}"
+        encoded_credentials = base64.b64encode(credentials.encode("utf-8")).decode(
+            "utf-8"
+        )
 
-    try:
-        with urllib.request.urlopen(req) as response:  # nosec B310
-            data = json.loads(response.read().decode("utf-8"))
-            return data.get("access_token")
-    except urllib.error.HTTPError as e:
-        raise IOError(f"HTTP Error {e.code}: {e.reason}")
+        headers = {
+            "Authorization": f"Basic {encoded_credentials}",
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": "python-urllib/3.11",
+            "Accept": "application/json",
+        }
+
+        payload = {
+            "grant_type": "client_credentials",
+            "audience": ZIMFARM_OAUTH_AUDIENCE_ID,
+        }
+
+        req = urllib.request.Request(
+            f"{ZIMFARM_OAUTH_ISSUER}/oauth2/token",
+            data=urllib.parse.urlencode(payload).encode("utf-8"),
+            headers=headers,
+            method="POST",
+        )
+
+        try:
+            with urllib.request.urlopen(req) as response:  # nosec B310
+                response_data = json.loads(response.read().decode("utf-8"))
+                self._access_token = response_data["access_token"]
+        except urllib.error.HTTPError as e:
+            raise IOError(
+                f"OAuth token generation failed - HTTP Error {e.code}: {e.reason}"
+            )
+
+    def _generate_local_access_token(self) -> None:
+        """Generate local access token."""
+        if self._refresh_token:
+            url = f"{API_URL}/auth/refresh"
+            payload = {
+                "refresh_token": self._refresh_token,
+            }
+        else:
+            url = f"{API_URL}/auth/authorize"
+            payload = {
+                "username": ZIMFARM_USERNAME,
+                "password": ZIMFARM_PASSWORD,
+            }
+
+        data = json.dumps(payload).encode("utf-8")
+        req = urllib.request.Request(
+            url, data=data, headers={"Content-type": "application/json"}, method="POST"
+        )
+
+        try:
+            with urllib.request.urlopen(req) as response:  # nosec B310
+                response_data = json.loads(response.read().decode("utf-8"))
+                self._access_token = response_data.get("access_token")
+                self._refresh_token = response_data.get("refresh_token")
+        except urllib.error.HTTPError as e:
+            raise IOError(
+                f"Local authentication failed - HTTP Error {e.code}: {e.reason}"
+            )
+
+    def get_access_token(self) -> str:
+        """Retrieve or generate access token."""
+        if self._access_token is None:
+            if AUTH_MODE == "oauth":
+                self._generate_oauth_access_token()
+            elif AUTH_MODE == "local":
+                self._generate_local_access_token()
+            else:
+                raise ValueError(
+                    f"Unknown authentication mode: {AUTH_MODE}. "
+                    "Allowed values are: 'local', 'oauth'"
+                )
+        if self._access_token is None:
+            raise ValueError("Failed to generate access token.")
+        return self._access_token
+
+
+token_provider = ClientTokenProvider()
 
 
 def query_api(
@@ -142,7 +221,7 @@ def query_api(
 
 def main() -> None:
     fingerprints = []
-    token = get_token()
+    token = token_provider.get_access_token()
 
     def get_from_api(
         path: str,
@@ -163,7 +242,7 @@ def main() -> None:
 
             # Unauthorised error: attempt to re-auth as scheduler might have restarted?
             if status_code == HTTPStatus.UNAUTHORIZED:
-                token = get_token()
+                token = token_provider.get_access_token()
                 continue
             else:
                 break

--- a/recipesauto/src/recipesauto/context.py
+++ b/recipesauto/src/recipesauto/context.py
@@ -25,8 +25,7 @@ class Context:
     zimfarm_api_url: str = "https://api.farm.openzim.org/v2"
 
     # Credentials to Zimfarm
-    zimfarm_username: str
-    zimfarm_password: str
+    zimfarm_access_token: str
 
     # timeout of HTTP calls
     http_timeout: int = 10

--- a/recipesauto/src/recipesauto/entrypoint.py
+++ b/recipesauto/src/recipesauto/entrypoint.py
@@ -36,11 +36,9 @@ def prepare_context(raw_args: list[str]) -> None:
     )
 
     parser.add_argument(
-        "--zimfarm-username", help="Username to connect to the Zimfarm", required=True
-    )
-
-    parser.add_argument(
-        "--zimfarm-password", help="Password to connect to the Zimfarm", required=True
+        "--zimfarm-access-token",
+        help="Access token to connect to the Zimfarm",
+        required=True,
     )
 
     parser.add_argument(

--- a/recipesauto/src/recipesauto/processor.py
+++ b/recipesauto/src/recipesauto/processor.py
@@ -42,8 +42,9 @@ class Processor:
                 "do_not_delete": [],
             }
 
-        logger.info("Getting Zimfarm authorization")
-        self.get_zf_token()
+        logger.info("Authenticating with zimfarm")
+        self.authenticate()
+        logger.info("Authenticaed with zimfarm")
 
         if context.kind == "ted":
             import recipesauto.ted as setmodule
@@ -426,23 +427,14 @@ class Processor:
     def get_zf_headers(self):
         """Build zimfarm headers"""
         return {
-            "Authorization": f"Bearer {self.zf_access_token}",
+            "Authorization": f"Bearer {context.zimfarm_access_token}",
             "Content-type": "application/json",
         }
 
-    def get_zf_token(self):
-        """Authenticate and get zimfarm tokens"""
-        req = requests.post(
-            url=self.get_zf_url("/auth/authorize"),
-            headers={
-                "Content-type": "application/json",
-            },
+    def authenticate(self):
+        response = requests.get(
+            self.get_zf_url("/auth/me"),
+            headers=self.get_zf_headers(),
             timeout=context.http_timeout,
-            json={
-                "username": context.zimfarm_username,
-                "password": context.zimfarm_password,
-            },
         )
-        req.raise_for_status()
-        self.zf_access_token = req.json().get("access_token")
-        self.zf_refresh_token = req.json().get("refresh_token")
+        response.raise_for_status()

--- a/watcher/watcher.py
+++ b/watcher/watcher.py
@@ -30,7 +30,6 @@ import argparse
 import concurrent.futures as cf
 import datetime
 import json
-from typing import cast
 import logging
 import os
 import pathlib
@@ -42,13 +41,14 @@ import time
 import traceback
 import urllib.parse
 from http import HTTPStatus
-from typing import Any
+from typing import Any, cast
 
 import humanfriendly
-import jwt
 import requests
+from humanfriendly import parse_timespan
 from kiwixstorage import KiwixStorage
 from pif import get_public_ip
+from requests.auth import HTTPBasicAuth
 from xml_to_dict import XMLtoDict
 
 VERSION = "1.0"
@@ -82,6 +82,100 @@ for logger_name in set(["urllib3", "boto3", "botocore", "s3transfer"]):
 HTTP_REQUEST_TIMEOUT = 30
 SUMMARY_FILENAME = "summary.json"
 
+# Authentication mode: can be either "local" or "oauth"
+AUTH_MODE = os.getenv("AUTH_MODE", default="local")
+ZIMFARM_USERNAME = os.getenv("ZIMFARM_USERNAME", default="")
+ZIMFARM_PASSWORD = os.getenv("ZIMFARM_PASSWORD", default="")
+ZIMFARM_OAUTH_ISSUER = os.getenv(
+    "ZIMFARM_OAUTH_ISSUER", default="https://ory.login.kiwix.org"
+)
+ZIMFARM_OAUTH_CLIENT_ID = os.getenv("ZIMFARM_OAUTH_CLIENT_ID", default="")
+ZIMFARM_OAUTH_CLIENT_SECRET = os.getenv("ZIMFARM_OAUTH_CLIENT_SECRET", default="")
+ZIMFARM_OAUTH_AUDIENCE_ID = os.getenv("ZIMFARM_OAUTH_AUDIENCE_ID", default="")
+ZIMFARM_TOKEN_RENEWAL_WINDOW = datetime.timedelta(
+    seconds=parse_timespan(os.getenv("ZIMFARM_TOKEN_RENEWAL_WINDOW", default="5m"))
+)
+
+
+def getnow():
+    """naive UTC now"""
+    return datetime.datetime.now(datetime.UTC).replace(tzinfo=None)
+
+
+class ClientTokenProvider:
+    """Client to generate access tokens to authenticate with Zimfarm"""
+
+    def __init__(self):
+        self._access_token: str | None = None
+        self._refresh_token: str | None = None
+        self._expires_at: datetime.datetime = datetime.datetime.fromtimestamp(
+            0
+        ).replace(tzinfo=None)
+
+    def _generate_oauth_access_token(self) -> None:
+        """Generate oauth access token and update expires_at."""
+        response = requests.post(
+            f"{ZIMFARM_OAUTH_ISSUER}/oauth2/token",
+            data={
+                "grant_type": "client_credentials",
+                "audience": ZIMFARM_OAUTH_AUDIENCE_ID,
+            },
+            auth=HTTPBasicAuth(ZIMFARM_OAUTH_CLIENT_ID, ZIMFARM_OAUTH_CLIENT_SECRET),
+            timeout=HTTP_REQUEST_TIMEOUT,
+        )
+        response.raise_for_status()
+        payload = response.json()
+        self._access_token = cast(str, payload["access_token"])
+        self._expires_at = getnow() + datetime.timedelta(seconds=payload["expires_in"])
+
+    def _generate_local_access_token(self) -> None:
+        if self._refresh_token:
+            response = requests.post(
+                f"{ZIMFARM_API_URL}/auth/refresh",
+                json={
+                    "refresh_token": self._refresh_token,
+                },
+                timeout=HTTP_REQUEST_TIMEOUT,
+            )
+        else:
+            response = requests.post(
+                f"{ZIMFARM_API_URL}/auth/authorize",
+                json={
+                    "username": ZIMFARM_USERNAME,
+                    "password": ZIMFARM_PASSWORD,
+                },
+                timeout=HTTP_REQUEST_TIMEOUT,
+            )
+
+        response.raise_for_status()
+        payload = response.json()
+        self._access_token = cast(str, payload["access_token"])
+        self._refresh_token = cast(str, payload["refresh_token"])
+        self._expires_at = datetime.datetime.fromisoformat(
+            payload["expires_time"]
+        ).replace(tzinfo=None)
+
+    def get_access_token(self, force_refresh: bool = False) -> str:
+        """Retrieve or generate access token depending on if token has expired."""
+        now = getnow()
+        if (
+            force_refresh
+            or self._access_token is None
+            or now >= (self._expires_at - ZIMFARM_TOKEN_RENEWAL_WINDOW)
+        ):
+            if AUTH_MODE == "oauth":
+                self._generate_oauth_access_token()
+            elif AUTH_MODE == "local":
+                self._generate_local_access_token()
+            else:
+                raise ValueError(
+                    f"Unknown cms authentication mode: {AUTH_MODE}. "
+                    "Allowed values are: 'local', 'oauth'"
+                )
+        if self._access_token is None:
+            raise ValueError("Failed to generate access token.")
+        return self._access_token
+
 
 def get_last_modified_for(url: str) -> str | None:
     """the Last-Modified header for an URL"""
@@ -89,23 +183,6 @@ def get_last_modified_for(url: str) -> str | None:
         if resp.status_code == 404:
             raise FileNotFoundError(url)
         return resp.headers.get("last-modified")
-
-
-def get_token(api_url: str, username: str, password: str) -> tuple[str, str]:
-    """Access-token, Refresh-token for a pair of Zimfarm credentials"""
-    req = requests.post(
-        url=f"{api_url}/auth/authorize",
-        headers={
-            "Content-type": "application/json",
-        },
-        json={
-            "username": username,
-            "password": password,
-        },
-        timeout=HTTP_REQUEST_TIMEOUT,
-    )
-    req.raise_for_status()
-    return req.json().get("access_token"), req.json().get("refresh_token")
 
 
 def query_api(
@@ -189,8 +266,6 @@ class WatcherRunner:
         *,
         s3_url_with_credentials: str,
         s3_summary_file_url: str | None,
-        zimfarm_username: str,
-        zimfarm_password: str,
         schedule_on_update: bool,
         nb_threads: int,
         duration: str,
@@ -202,8 +277,6 @@ class WatcherRunner:
         self.running = True
         self.s3_url_with_credentials = s3_url_with_credentials
         self.s3_summary_file_url = s3_summary_file_url
-        self.zimfarm_username = zimfarm_username
-        self.zimfarm_password = zimfarm_password
         self.schedule_on_update = schedule_on_update
         self.nb_threads = nb_threads
         self.duration = duration
@@ -211,11 +284,7 @@ class WatcherRunner:
         self.only = only
         self.runonce = runonce
         self.debug = debug
-
-        self.access_token = self.refresh_token = ""
-        self.token_payload = {}
-        self.authenticated_on = datetime.datetime.fromtimestamp(0)
-        self.authentication_expires_on = datetime.datetime.fromtimestamp(0)
+        self._token_provider = ClientTokenProvider()
 
         # registering exit signals
         signal.signal(signal.SIGTERM, self.exit_gracefully)
@@ -253,29 +322,6 @@ class WatcherRunner:
             return False
         return True
 
-    def authenticate(self, *, force: bool = False):
-        """authenticate to the Zimfarm API"""
-        # our access token should grant us access for 60mn
-        if force or self.authentication_expires_on <= datetime.datetime.now():
-            try:
-                self.access_token, self.refresh_token = get_token(
-                    ZIMFARM_API_URL, self.zimfarm_username, self.zimfarm_password
-                )
-                self.token_payload = jwt.decode(
-                    self.access_token,
-                    algorithms=["HS256"],
-                    options={"verify_signature": False},
-                )
-                self.authenticated_on = datetime.datetime.now()
-                self.authentication_expires_on = datetime.datetime.fromtimestamp(
-                    self.token_payload["exp"]
-                )
-                return True
-            except Exception:
-                logger.exception("authenticate() failure")
-                return False
-        return True
-
     def query_api(
         self,
         method: str,
@@ -287,13 +333,16 @@ class WatcherRunner:
         """success, status_code, response for a query to Zimfarm API"""
         success, status_code, response = False, 0, {}
 
-        if not self.authenticate():
-            return (success, status_code, response)
+        try:
+            access_token = self._token_provider.get_access_token()
+        except Exception:
+            logger.exception("Failed to get access token")
+            return success, status_code, response
 
         attempts = 0
         while attempts <= 1:
             success, status_code, response = query_api(
-                self.access_token,
+                access_token,
                 method,
                 f"{ZIMFARM_API_URL}{path}",
                 payload,
@@ -304,7 +353,12 @@ class WatcherRunner:
 
             # Unauthorised error: attempt to re-auth as scheduler might have restarted?
             if status_code == requests.codes.UNAUTHORIZED:
-                self.authenticate(force=True)
+                try:
+                    access_token = self._token_provider.get_access_token(
+                        force_refresh=True
+                    )
+                except Exception:
+                    logger.exception("Failed to get access token")
                 continue
             else:
                 break
@@ -633,7 +687,6 @@ class WatcherRunner:
 
         logger.info(
             f"Starting watcher:\n"
-            f"  with zimfarm username: {self.zimfarm_username}\n"
             f"  using cache: {self.s3_storage.url.netloc}\n"
             f"  with bucket: {self.s3_storage.bucket_name}"
             + (
@@ -718,21 +771,6 @@ def entrypoint():
         help="S3 URL of caching dumps.",
         default=os.getenv("S3_SUMMARY_FILE_URL"),
     )
-
-    parser.add_argument(
-        "--zimfarm-username",
-        help="Zimfarm API username. Defaults to ZIMFARM_USERNAME environ",
-        dest="zimfarm_username",
-        default=os.getenv("ZIMFARM_USERNAME"),
-        required=not os.getenv("ZIMFARM_USERNAME"),
-    )
-    parser.add_argument(
-        "--zimfarm-password",
-        help="Zimfarm API. Defaults to ZIMFARM_PASSWORD environ",
-        dest="zimfarm_password",
-        default=os.getenv("ZIMFARM_PASSWORD"),
-        required=not os.getenv("ZIMFARM_PASSWORD"),
-    )
     parser.add_argument(
         "--dont-schedule-on-update",
         help="Whether to schedule matching Zimfarm recipes on successful dump update",
@@ -783,11 +821,30 @@ def entrypoint():
     )
 
     args = parser.parse_args()
+
+    if AUTH_MODE == "local":
+        if not (ZIMFARM_USERNAME and ZIMFARM_PASSWORD):
+            raise OSError(
+                "ZIMFARM_USERNAME and ZIMFARM_PASSWORD must be set when AUTH_MODE is 'local'"
+            )
+    elif AUTH_MODE == "oauth":
+        if not (
+            ZIMFARM_OAUTH_CLIENT_ID,
+            ZIMFARM_OAUTH_CLIENT_SECRET,
+            ZIMFARM_OAUTH_AUDIENCE_ID,
+        ):
+            raise OSError(
+                "ZIMFARM_OAUTH_CLIENT_ID, ZIMFARM_OAUTH_CLIENT_SECRET and "
+                "ZIMFARM_OAUTH_AUDIENCE_ID must be set when AUTH_MODE is 'oauth'."
+            )
+    else:
+        raise ValueError(
+            f"Unsupported value '{AUTH_MODE}' for AUTH_MODE. Only 'local' and 'oauth' "
+            "are supported."
+        )
     runner = WatcherRunner(
         s3_url_with_credentials=args.s3_url_with_credentials,
         s3_summary_file_url=args.s3_summary_file_url,
-        zimfarm_username=args.zimfarm_username,
-        zimfarm_password=args.zimfarm_password,
         schedule_on_update=args.schedule_on_update,
         nb_threads=args.nb_threads,
         duration=args.duration,


### PR DESCRIPTION
## Rationale

This PR adds `oauth` authentication mode for monitor, watcher and healthcheck components of the zimfarm. Using env variables, user can toggle between `local` and `oauth` (via Ory) authentication modes.

## Changes
- refactor authentication healthcheck to call `/auth/test` endpoint after retrieving token
- adapt backend oauth token decoders to handle tokens coming from oauth clients
- add `oauth` authentication in monitor parent, watcher and healthcheck components
- pass watcher credentials via env instead of as CLI args as they can show up in command history
- add QA for monitor parent

This closes #1803