### PR TITLE
poll api with remaining resource statistics

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/requested_tasks/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/requested_tasks/logic.py
@@ -25,6 +25,7 @@ from zimfarm_backend.api.routes.requested_tasks.models import (
     RequestedTaskSchema,
     UpdateRequestedTaskSchema,
 )
+from zimfarm_backend.api.routes.workers.models import GetRequestedTaskSchema
 from zimfarm_backend.common import WorkersIpChangesCounts, getnow
 from zimfarm_backend.common.constants import (
     ENABLED_SCHEDULER,
@@ -32,13 +33,7 @@ from zimfarm_backend.common.constants import (
     USES_WORKERS_IPS_WHITELIST,
 )
 from zimfarm_backend.common.external import update_workers_whitelist
-from zimfarm_backend.common.schemas.fields import (
-    ZIMCPU,
-    NotEmptyString,
-    WorkerField,
-    ZIMDisk,
-    ZIMMemory,
-)
+from zimfarm_backend.common.schemas.fields import NotEmptyString
 from zimfarm_backend.common.schemas.models import calculate_pagination_metadata
 from zimfarm_backend.common.schemas.orms import (
     ConfigResourcesSchema,
@@ -183,10 +178,7 @@ def get_requested_tasks(
 @router.get("/worker")
 def get_requested_tasks_for_worker(
     request: Request,
-    worker_name: Annotated[WorkerField, Query()],
-    avail_cpu: Annotated[ZIMCPU, Query()],
-    avail_memory: Annotated[ZIMMemory, Query()],
-    avail_disk: Annotated[ZIMDisk, Query()],
+    query: Annotated[GetRequestedTaskSchema, Query()],
     session: Annotated[OrmSession, Depends(gen_manual_dbsession)],
     current_account: Annotated[
         Account, Depends(get_current_account_with_session(session_type="manual"))
@@ -194,7 +186,7 @@ def get_requested_tasks_for_worker(
 ) -> ListResponse[RequestedTaskLightSchema]:
     """Get list of requested tasks for a worker."""
 
-    worker = get_worker(session, worker_name=worker_name)
+    worker = get_worker(session, worker_name=query.worker_name)
 
     fallback_ip = request.client.host if request.client else None
     x_forwarded_for = request.headers.get("X-Forwarded-For", fallback_ip)
@@ -203,23 +195,30 @@ def get_requested_tasks_for_worker(
 
         if ip_changed:
             logger.info(
-                f"Worker {worker_name} IP changed from {worker.last_ip} to "
+                f"Worker {query.worker_name} IP changed from {worker.last_ip} to "
                 f"{x_forwarded_for}"
             )
-            worker = update_worker(
-                session, worker_name=worker_name, ip_address=x_forwarded_for
-            )
-        else:
-            worker = update_worker(session, worker_name=worker_name)
 
-        # commit explicitly last_ip and last_seen changes, since we are not
-        # using an explicit transaction, and do it before calling Wasabi so
-        # that changes are propagated quickly and transaction is not blocking
+        worker = update_worker(
+            session,
+            worker_name=query.worker_name,
+            ip_address=x_forwarded_for if ip_changed else None,
+            avail_disk=query.avail_disk,
+            avail_memory=query.avail_memory,
+            avail_cpu=query.avail_cpu,
+            total_disk=query.total_disk,
+            total_memory=query.total_memory,
+            total_cpu=query.total_cpu,
+        )
+
+        # commit explicitly since we are not using an automatic transaction,
+        # and do it before calling Wasabi so that changes are propagated quickly
+        # and transaction is not blocking
         session.commit()
 
         if ip_changed and USES_WORKERS_IPS_WHITELIST:
             try:
-                record_ip_change(session, worker_name)
+                record_ip_change(session, query.worker_name)
             except Exception as exc:
                 logger.exception("Pushing IP changes to Wasabi failed")
                 raise ServiceUnavailableError(
@@ -240,9 +239,9 @@ def get_requested_tasks_for_worker(
     task = find_requested_task_for_worker(
         session=session,
         worker=create_worker_schema(worker),
-        avail_cpu=avail_cpu,
-        avail_memory=avail_memory,
-        avail_disk=avail_disk,
+        avail_cpu=query.avail_cpu,
+        avail_memory=query.avail_memory,
+        avail_disk=query.avail_disk,
     ).requested_task
 
     return ListResponse(

--- a/backend/src/zimfarm_backend/api/routes/workers/models.py
+++ b/backend/src/zimfarm_backend/api/routes/workers/models.py
@@ -6,6 +6,7 @@ from pydantic import Field
 from zimfarm_backend.common.schemas import BaseModel
 from zimfarm_backend.common.schemas.fields import (
     ZIMCPU,
+    WorkerField,
     ZIMDisk,
     ZIMMemory,
 )
@@ -25,6 +26,16 @@ class WorkerCheckInSchema(BaseModel):
     offliners: list[str]
     platforms: dict[str, int] | None = None  # mapping of platforms to max tasks
     cordoned: bool | None = None
+
+
+class GetRequestedTaskSchema(BaseModel):
+    worker_name: WorkerField
+    avail_cpu: ZIMCPU
+    avail_disk: ZIMDisk
+    avail_memory: ZIMMemory
+    total_cpu: ZIMCPU | None = None
+    total_disk: ZIMDisk | None = None
+    total_memory: ZIMMemory | None = None
 
 
 class WorkerCheckInResponse(BaseModel):

--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -423,12 +423,17 @@ class Worker(BaseWorkerSchema):
     account_id: UUID
 
 
+class WorkerResourcesSchema(BaseModel):
+    available: ConfigResourcesSchema
+    total: ConfigResourcesSchema
+
+
 class WorkerLightSchema(BaseWorkerSchema):
     """
     Schema for reading a worker model with some fields
     """
 
-    resources: ConfigResourcesSchema
+    resources: WorkerResourcesSchema
     username: str
 
     @computed_field
@@ -559,15 +564,8 @@ class WorkerMetricsSchema(WorkerLightSchema):
     @computed_field
     @property
     def current_usage(self) -> ConfigResourcesSchema:
-        total_cpu = 0
-        total_memory = 0
-        total_disk = 0
-        for task in self.running_tasks:
-            total_cpu += task.config.resources.cpu
-            total_memory += task.config.resources.memory
-            total_disk += task.config.resources.disk
         return ConfigResourcesSchema(
-            cpu=total_cpu,
-            memory=total_memory,
-            disk=total_disk,
+            cpu=self.resources.total.cpu - self.resources.available.cpu,
+            memory=self.resources.total.memory - self.resources.available.memory,
+            disk=self.resources.total.disk - self.resources.available.disk,
         )

--- a/backend/src/zimfarm_backend/db/models.py
+++ b/backend/src/zimfarm_backend/db/models.py
@@ -126,13 +126,16 @@ class Worker(Base):
     )
     name: Mapped[str] = mapped_column(unique=True, index=True)
     selfish: Mapped[bool]
-    cpu: Mapped[int]
-    memory: Mapped[int] = mapped_column(type_=BigInteger)
-    disk: Mapped[int] = mapped_column(type_=BigInteger)
+    total_cpu: Mapped[int]
+    total_memory: Mapped[int] = mapped_column(type_=BigInteger)
+    total_disk: Mapped[int] = mapped_column(type_=BigInteger)
     offliners: Mapped[list[str]]
     platforms: Mapped[dict[str, Any]]
     last_seen: Mapped[datetime | None]
     last_ip: Mapped[IPv4Address | None]
+    available_cpu: Mapped[int]
+    available_memory: Mapped[int] = mapped_column(type_=BigInteger)
+    available_disk: Mapped[int] = mapped_column(type_=BigInteger)
     deleted: Mapped[bool] = mapped_column(default=False, server_default=false())
     contexts: Mapped[dict[str, Any]] = mapped_column(
         default_factory=dict, server_default="{}"

--- a/backend/src/zimfarm_backend/db/requested_task.py
+++ b/backend/src/zimfarm_backend/db/requested_task.py
@@ -97,22 +97,22 @@ def _resource_mismatch_message(
     worker: WorkerLightSchema, resource: ResourcesSchema
 ) -> list[str]:
     mismatched_message: list[str] = []
-    if worker.resources.cpu < resource.cpu:
+    if worker.resources.available.cpu < resource.cpu:
         mismatched_message.append(
             f"cpu: required={format_size(resource.cpu, binary=True)}, "
-            f"available={format_size(worker.resources.cpu, binary=True)}"
+            f"available={format_size(worker.resources.available.cpu, binary=True)}"
         )
 
-    if worker.resources.disk < resource.disk:
+    if worker.resources.available.disk < resource.disk:
         mismatched_message.append(
             f"disk: required={format_size(resource.disk, binary=True)}, "
-            f"available={format_size(worker.resources.disk, binary=True)}"
+            f"available={format_size(worker.resources.available.disk, binary=True)}"
         )
 
-    if worker.resources.memory < resource.memory:
+    if worker.resources.available.memory < resource.memory:
         mismatched_message.append(
             f"memory: required={format_size(resource.memory, binary=True)}, "
-            f"available={format_size(worker.resources.memory, binary=True)}"
+            f"available={format_size(worker.resources.available.memory, binary=True)}"
         )
     return mismatched_message
 
@@ -266,9 +266,9 @@ def _validate_worker_resources(
     identifier = _recipe_or_task_identifier_message(entity)
     resource = ResourcesSchema.model_validate(entity.config["resources"])
     if (
-        worker.resources.cpu < resource.cpu
-        or worker.resources.memory < resource.memory
-        or worker.resources.disk < resource.disk
+        worker.resources.available.cpu < resource.cpu
+        or worker.resources.available.memory < resource.memory
+        or worker.resources.available.disk < resource.disk
     ):
         mismatched_message = _resource_mismatch_message(worker, resource)
         return (
@@ -542,11 +542,11 @@ def get_tasks_doable_by_worker(
         )
         .where(
             RequestedTask.config["resources"]["cpu"].astext.cast(BigInteger)
-            <= worker.resources.cpu,
+            <= worker.resources.available.cpu,
             RequestedTask.config["resources"]["memory"].astext.cast(BigInteger)
-            <= worker.resources.memory,
+            <= worker.resources.available.memory,
             RequestedTask.config["resources"]["disk"].astext.cast(BigInteger)
-            <= worker.resources.disk,
+            <= worker.resources.available.disk,
             RequestedTask.config["offliner"]["offliner_id"].astext.in_(
                 worker.offliners
             ),
@@ -699,7 +699,7 @@ def _get_worker_unavailable_reason(
         return reason
 
     return (
-        f"We have no reason for this task to not start on worker '{worker.name}' as"
+        f"We have no reason for this task to not start on worker '{worker.name}' as "
         f"worker has no running tasks. Worker is {worker.status}"
     ) + last_seen_reason
 
@@ -747,20 +747,10 @@ def diagnose_requested_task(
     )[1]:
         return reason
 
-    avail_memory = worker.resources.memory - sum(
-        t.config.resources.memory for t in running_tasks
-    )
-    avail_disk = worker.resources.disk - sum(
-        t.config.resources.disk for t in running_tasks
-    )
-    avail_cpu = worker.resources.cpu - sum(
-        t.config.resources.cpu for t in running_tasks
-    )
-
     available_resources = ResourcesSchema(
-        cpu=avail_cpu,
-        memory=avail_memory,
-        disk=avail_disk,
+        cpu=worker.resources.available.cpu,
+        memory=worker.resources.available.memory,
+        disk=worker.resources.available.disk,
     )
 
     if _can_run(task, available_resources):
@@ -772,9 +762,9 @@ def diagnose_requested_task(
         candidates=[task],
         available_resources=available_resources,
         missing_resources=ResourcesSchema(
-            cpu=max([task.config.resources.cpu - avail_cpu, 0]),
-            memory=max([task.config.resources.memory - avail_memory, 0]),
-            disk=max([task.config.resources.disk - avail_disk, 0]),
+            cpu=max([task.config.resources.cpu - available_resources.cpu, 0]),
+            memory=max([task.config.resources.memory - available_resources.memory, 0]),
+            disk=max([task.config.resources.disk - available_resources.disk, 0]),
         ),
         running_tasks=running_tasks,
     ).error:

--- a/backend/src/zimfarm_backend/db/worker.py
+++ b/backend/src/zimfarm_backend/db/worker.py
@@ -18,6 +18,7 @@ from zimfarm_backend.common.schemas.orms import (
     ConfigResourcesSchema,
     WorkerLightSchema,
     WorkerMetricsSchema,
+    WorkerResourcesSchema,
 )
 from zimfarm_backend.db.account import create_account
 from zimfarm_backend.db.exceptions import RecordDoesNotExistError
@@ -83,10 +84,17 @@ def create_worker_schema(
         name=worker.name,
         platforms=worker.platforms,
         offliners=worker.offliners,
-        resources=ConfigResourcesSchema(
-            cpu=worker.cpu,
-            disk=worker.disk,
-            memory=worker.memory,
+        resources=WorkerResourcesSchema(
+            total=ConfigResourcesSchema(
+                cpu=worker.total_cpu,
+                disk=worker.total_disk,
+                memory=worker.total_memory,
+            ),
+            available=ConfigResourcesSchema(
+                cpu=worker.available_cpu,
+                disk=worker.available_disk,
+                memory=worker.available_memory,
+            ),
         ),
         username=worker.account.display_name,
         contexts=_deserialize_worker_context(worker.contexts),
@@ -110,6 +118,12 @@ def update_worker(
     contexts: dict[str, IPv4Address | IPv6Address | None] | None = None,
     update_last_seen: bool = True,
     admin_disabled: bool | None = None,
+    avail_disk: int | None = None,
+    avail_memory: int | None = None,
+    avail_cpu: int | None = None,
+    total_disk: int | None = None,
+    total_memory: int | None = None,
+    total_cpu: int | None = None,
 ) -> Worker:
     """Update the last seen time and IP address for a worker."""
     worker = get_worker(session, worker_name=worker_name)
@@ -121,6 +135,19 @@ def update_worker(
         worker.contexts = _serialize_worker_context(contexts)
     if admin_disabled is not None:
         worker.admin_disabled = admin_disabled
+    if avail_disk is not None:
+        worker.available_disk = avail_disk
+    if avail_memory is not None:
+        worker.available_memory = avail_memory
+    if avail_cpu is not None:
+        worker.available_cpu = avail_cpu
+    if total_disk is not None:
+        worker.total_disk = total_disk
+    if total_memory is not None:
+        worker.total_memory = total_memory
+    if total_cpu is not None:
+        worker.total_cpu = total_cpu
+
     session.add(worker)
     session.flush()
     return worker
@@ -192,10 +219,17 @@ def get_worker_metrics(
         last_seen=worker.last_seen,
         username=worker.account.display_name,
         platforms=worker.platforms,
-        resources=ConfigResourcesSchema(
-            cpu=worker.cpu,
-            disk=worker.disk,
-            memory=worker.memory,
+        resources=WorkerResourcesSchema(
+            total=ConfigResourcesSchema(
+                cpu=worker.total_cpu,
+                disk=worker.total_disk,
+                memory=worker.total_memory,
+            ),
+            available=ConfigResourcesSchema(
+                cpu=worker.available_cpu,
+                disk=worker.available_disk,
+                memory=worker.available_memory,
+            ),
         ),
         offliners=worker.offliners,
         contexts=_deserialize_worker_context(worker.contexts),
@@ -238,9 +272,9 @@ def check_in_worker(
         update(Worker)
         .values(
             selfish=selfish,
-            cpu=cpu,
-            memory=memory,
-            disk=disk,
+            total_cpu=cpu,
+            total_memory=memory,
+            total_disk=disk,
             offliners=offliners,
             platforms=platforms if platforms is not None else {},
             cordoned=cordoned,
@@ -273,9 +307,12 @@ def create_worker(
     account = create_account(session, display_name=worker_name, role=RoleEnum.WORKER)
     worker = Worker(
         name=worker_name,
-        cpu=0,
-        memory=0,
-        disk=0,
+        total_cpu=0,
+        total_memory=0,
+        total_disk=0,
+        available_cpu=0,
+        available_memory=0,
+        available_disk=0,
         selfish=True,
         offliners=[],
         cordoned=False,

--- a/backend/src/zimfarm_backend/migrations/versions/83a841b3ca2b_separate_worker_resource_stats_into_.py
+++ b/backend/src/zimfarm_backend/migrations/versions/83a841b3ca2b_separate_worker_resource_stats_into_.py
@@ -1,0 +1,52 @@
+"""separate worker resource stats into total and remaining
+
+Revision ID: 83a841b3ca2b
+Revises: e8556436e74a
+Create Date: 2026-04-14 11:05:05.887945
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "83a841b3ca2b"
+down_revision = "e8556436e74a"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # Add new columns as nullable first
+    op.alter_column("worker", "cpu", new_column_name="total_cpu")
+    op.alter_column("worker", "memory", new_column_name="total_memory")
+    op.alter_column("worker", "disk", new_column_name="total_disk")
+    op.add_column("worker", sa.Column("available_cpu", sa.Integer(), nullable=True))
+    op.add_column(
+        "worker", sa.Column("available_memory", sa.BigInteger(), nullable=True)
+    )
+    op.add_column("worker", sa.Column("available_disk", sa.BigInteger(), nullable=True))
+
+    # Copy existing values to both total and remaining columns
+    op.execute(
+        """
+        UPDATE worker
+        SET available_cpu = total_cpu,
+            available_memory = total_memory,
+            available_disk = total_disk
+        """
+    )
+
+    # Set new columns to non-nullable
+    op.alter_column("worker", "available_cpu", nullable=False)
+    op.alter_column("worker", "available_memory", nullable=False)
+    op.alter_column("worker", "available_disk", nullable=False)
+
+
+def downgrade() -> None:
+    op.alter_column("worker", "total_cpu", new_column_name="cpu")
+    op.alter_column("worker", "total_memory", new_column_name="memory")
+    op.alter_column("worker", "total_disk", new_column_name="disk")
+    op.drop_column("worker", "available_disk")
+    op.drop_column("worker", "available_memory")
+    op.drop_column("worker", "available_cpu")

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -783,9 +783,12 @@ def create_worker(
         worker = Worker(
             name=name,
             selfish=False,
-            cpu=cpu,
-            memory=memory,
-            disk=disk,
+            total_cpu=cpu,
+            total_memory=memory,
+            total_disk=disk,
+            available_cpu=cpu,
+            available_memory=memory,
+            available_disk=disk,
             offliners=offliners or ["mwoffliner", "youtube"],
             platforms=_platforms,
             contexts=(

--- a/backend/tests/db/test_requested_task.py
+++ b/backend/tests/db/test_requested_task.py
@@ -910,7 +910,7 @@ def test_does_platform_allow_worker_to_run(
 ):
     """Test that the platform validates platform constraints correctly."""
     recipe_config = create_recipe_config(
-        cpu=worker.cpu, memory=worker.memory, disk=worker.disk
+        cpu=worker.total_cpu, memory=worker.total_memory, disk=worker.total_disk
     )
     task = RequestedTaskWithDuration(
         id=uuid4(),
@@ -1029,7 +1029,7 @@ def test_find_requested_task_for_worker(
     expect_found: bool,
 ):
     recipe_config = create_recipe_config(
-        cpu=worker.cpu, memory=worker.memory, disk=worker.disk
+        cpu=worker.total_cpu, memory=worker.total_memory, disk=worker.total_disk
     )
     worker.cordoned = worker_cordoned
     worker.admin_disabled = worker_admin_disabled

--- a/backend/tests/db/test_worker.py
+++ b/backend/tests/db/test_worker.py
@@ -49,24 +49,6 @@ def test_update_worker_not_found(dbsession: OrmSession):
         update_worker(dbsession, worker_name="nonexistent")
 
 
-def test_update_worker(dbsession: OrmSession, worker: Worker):
-    """Test that update_worker updates the worker's last_seen and last_ip"""
-    original_last_seen = worker.last_seen
-    original_last_ip = worker.last_ip
-    new_ip = "192.168.1.1"
-
-    updated_worker = update_worker(
-        dbsession, worker_name=worker.name, ip_address=new_ip
-    )
-
-    assert updated_worker.name == worker.name
-    assert updated_worker.last_seen is not None
-    if original_last_seen is not None:
-        assert updated_worker.last_seen > original_last_seen
-    assert updated_worker.last_ip == IPv4Address(new_ip)
-    assert updated_worker.last_ip != original_last_ip
-
-
 def test_get_workers_empty(dbsession: OrmSession):
     """Test that get_workers returns empty list when no workers exist"""
     result = get_workers(dbsession, skip=0, limit=10)
@@ -162,9 +144,9 @@ def test_check_in_worker_update(
     updated_worker = get_worker(dbsession, worker_name=worker.name)
 
     assert updated_worker.name == original_worker_name
-    assert updated_worker.cpu == 8
-    assert updated_worker.memory == 4096
-    assert updated_worker.disk == 4096
+    assert updated_worker.total_cpu == 8
+    assert updated_worker.total_memory == 4096
+    assert updated_worker.total_disk == 4096
     assert updated_worker.selfish is True
     assert updated_worker.offliners == [mwoffliner.id, ted_offliner.id]
     assert updated_worker.platforms == worker.platforms
@@ -186,24 +168,137 @@ def test_update_worker_context(dbsession: OrmSession, worker: Worker):
 
 
 @pytest.mark.parametrize(
-    "admin_disabled, expected_admin_disabled",
+    "ip_address, contexts, update_last_seen, admin_disabled, "
+    "avail_disk, avail_memory, avail_cpu",
     [
-        pytest.param(True, True, id="True"),
-        pytest.param(False, False, id="False"),
-        pytest.param(None, False, id="None"),
+        pytest.param(None, None, True, None, None, None, None, id="all_none"),
+        pytest.param(
+            "192.168.1.100", None, True, None, None, None, None, id="ip_address_set"
+        ),
+        pytest.param(None, None, True, None, None, None, None, id="ip_address_none"),
+        pytest.param(
+            None,
+            {"priority": None, "general": None},
+            True,
+            None,
+            None,
+            None,
+            None,
+            id="contexts_set",
+        ),
+        pytest.param(
+            None,
+            {"priority": IPv4Address("10.0.0.1")},
+            True,
+            None,
+            None,
+            None,
+            None,
+            id="contexts_with_ip",
+        ),
+        pytest.param(None, None, True, None, None, None, None, id="contexts_none"),
+        pytest.param(
+            None, None, True, None, None, None, None, id="update_last_seen_true"
+        ),
+        pytest.param(
+            None, None, False, None, None, None, None, id="update_last_seen_false"
+        ),
+        pytest.param(
+            None, None, True, True, None, None, None, id="admin_disabled_true"
+        ),
+        pytest.param(
+            None, None, True, False, None, None, None, id="admin_disabled_false"
+        ),
+        pytest.param(
+            None, None, True, None, None, None, None, id="admin_disabled_none"
+        ),
+        pytest.param(None, None, True, None, 1024, None, None, id="avail_disk_set"),
+        pytest.param(None, None, True, None, None, None, None, id="avail_disk_none"),
+        pytest.param(None, None, True, None, None, 2048, None, id="avail_memory_set"),
+        pytest.param(None, None, True, None, None, None, None, id="avail_memory_none"),
+        pytest.param(None, None, True, None, None, None, 8, id="avail_cpu_set"),
+        pytest.param(None, None, True, None, None, None, None, id="avail_cpu_none"),
+        pytest.param(
+            "192.168.1.200",
+            {"test": None},
+            True,
+            True,
+            2048,
+            4096,
+            16,
+            id="multiple_params",
+        ),
     ],
 )
-def test_update_worker_scheduling_disabled(
+def test_update_worker(
     dbsession: OrmSession,
     worker: Worker,
     *,
+    ip_address: str | None,
+    contexts: dict[str, IPv4Address | IPv6Address | None] | None,
+    update_last_seen: bool,
     admin_disabled: bool | None,
-    expected_admin_disabled: bool,
+    avail_disk: int | None,
+    avail_memory: int | None,
+    avail_cpu: int | None,
 ):
+    # Store original values
+    original_last_seen = worker.last_seen
+    original_last_ip = worker.last_ip
+    original_contexts = worker.contexts.copy()
+    original_admin_disabled = worker.admin_disabled
+    original_disk = worker.total_disk
+    original_memory = worker.total_memory
+    original_cpu = worker.total_cpu
+
     updated_worker = update_worker(
-        dbsession, worker_name=worker.name, admin_disabled=admin_disabled
+        dbsession,
+        worker_name=worker.name,
+        ip_address=ip_address,
+        contexts=contexts,
+        update_last_seen=update_last_seen,
+        admin_disabled=admin_disabled,
+        avail_disk=avail_disk,
+        avail_memory=avail_memory,
+        avail_cpu=avail_cpu,
     )
-    assert updated_worker.admin_disabled is expected_admin_disabled
+
+    if update_last_seen:
+        assert updated_worker.last_seen is not None
+        if original_last_seen is not None:
+            assert updated_worker.last_seen >= original_last_seen
+    else:
+        assert updated_worker.last_seen == original_last_seen
+
+    if ip_address is not None:
+        assert updated_worker.last_ip == IPv4Address(ip_address)
+    else:
+        assert updated_worker.last_ip == original_last_ip
+
+    if contexts is not None:
+        assert list(updated_worker.contexts.keys()) == list(contexts.keys())
+    else:
+        assert updated_worker.contexts == original_contexts
+
+    if admin_disabled is not None:
+        assert updated_worker.admin_disabled == admin_disabled
+    else:
+        assert updated_worker.admin_disabled == original_admin_disabled
+
+    if avail_disk is not None:
+        assert updated_worker.available_disk == avail_disk
+    else:
+        assert updated_worker.available_disk == original_disk
+
+    if avail_memory is not None:
+        assert updated_worker.available_memory == avail_memory
+    else:
+        assert updated_worker.available_memory == original_memory
+
+    if avail_cpu is not None:
+        assert updated_worker.available_cpu == avail_cpu
+    else:
+        assert updated_worker.available_cpu == original_cpu
 
 
 @pytest.mark.parametrize(

--- a/backend/tests/routes/test_requested_task.py
+++ b/backend/tests/routes/test_requested_task.py
@@ -283,7 +283,7 @@ def test_get_requested_tasks_for_worker_scheduler_disabled(
     monkeypatch.setattr(logic, "ENABLED_SCHEDULER", False)
 
     response = client.get(
-        f"/v2/requested-tasks/worker?worker_name={worker.name}&avail_cpu={worker.cpu}&avail_memory={worker.memory}&avail_disk={worker.disk}",
+        f"/v2/requested-tasks/worker?worker_name={worker.name}&avail_cpu={worker.available_cpu}&avail_memory={worker.available_memory}&avail_disk={worker.available_disk}",
         headers={
             "Authorization": f"Bearer {access_token}",
             "X-Forwarded-For": "127.0.0.1",
@@ -338,7 +338,7 @@ def test_get_requested_tasks_for_worker_success_no_ip_change(
     dbsession.flush()
 
     response = client.get(
-        f"/v2/requested-tasks/worker?worker_name={worker.name}&avail_cpu={worker.cpu}&avail_memory={worker.memory}&avail_disk={worker.disk}",
+        f"/v2/requested-tasks/worker?worker_name={worker.name}&avail_cpu={worker.available_cpu}&avail_memory={worker.available_memory}&avail_disk={worker.available_disk}",
         headers={
             "Authorization": f"Bearer {access_token}",
             "X-Forwarded-For": str(worker.last_ip) if worker.last_ip else "127.0.0.1",
@@ -375,7 +375,7 @@ def test_get_requested_tasks_for_worker_success_with_ip_change(
 
     new_ip = "192.168.1.100"
     response = client.get(
-        f"/v2/requested-tasks/worker?worker_name={worker.name}&avail_cpu={worker.cpu}&avail_memory={worker.memory}&avail_disk={worker.disk}",
+        f"/v2/requested-tasks/worker?worker_name={worker.name}&avail_cpu={worker.available_cpu}&avail_memory={worker.available_memory}&avail_disk={worker.available_disk}",
         headers={
             "Authorization": f"Bearer {access_token}",
             "X-Forwarded-For": new_ip,
@@ -412,7 +412,7 @@ def test_get_requested_tasks_for_worker_ip_change_exception(
 
     new_ip = "192.168.1.100"
     response = client.get(
-        f"/v2/requested-tasks/worker?worker_name={worker.name}&avail_cpu={worker.cpu}&avail_memory={worker.memory}&avail_disk={worker.disk}",
+        f"/v2/requested-tasks/worker?worker_name={worker.name}&avail_cpu={worker.available_cpu}&avail_memory={worker.available_memory}&avail_disk={worker.available_disk}",
         headers={
             "Authorization": f"Bearer {access_token}",
             "X-Forwarded-For": new_ip,
@@ -442,7 +442,7 @@ def test_get_requested_tasks_for_worker_no_tasks_available(
     )
 
     response = client.get(
-        f"/v2/requested-tasks/worker?worker_name={worker.name}&avail_cpu={worker.cpu}&avail_memory={worker.memory}&avail_disk={worker.disk}",
+        f"/v2/requested-tasks/worker?worker_name={worker.name}&avail_cpu={worker.available_cpu}&avail_memory={worker.available_memory}&avail_disk={worker.available_disk}",
         headers={
             "Authorization": f"Bearer {access_token}",
             "X-Forwarded-For": "127.0.0.1",

--- a/frontend-ui/src/components/WorkersTable.vue
+++ b/frontend-ui/src/components/WorkersTable.vue
@@ -405,7 +405,7 @@ function getRowProps({
 }
 
 function getResources(item: CombinedRow) {
-  return item.kind === 'worker' ? item.resources : item.task.config.resources
+  return item.kind === 'worker' ? item.resources.total : item.task.config.resources
 }
 
 function isImageOutdated(workerImage: DockerImageVersion | null): boolean {

--- a/frontend-ui/src/types/workers.ts
+++ b/frontend-ui/src/types/workers.ts
@@ -20,9 +20,14 @@ interface BaseWorker {
   docker_image: DockerImageVersion | null
 }
 
+interface WorkerResourceSchema {
+  total: Resources
+  available: Resources
+}
+
 export interface Worker extends BaseWorker {
   status: 'online' | 'offline'
-  resources: Resources
+  resources: WorkerResourceSchema
   tasks: TaskLight[] // Will be populated with running tasks
   user_id: string
   display_name: string
@@ -43,7 +48,6 @@ export interface RunningTask {
 
 export interface WorkerMetrics extends BaseWorker {
   status: 'online' | 'offline'
-  resources: Resources
   user_id: string
   display_name: string
   running_tasks: RunningTask[]
@@ -52,6 +56,7 @@ export interface WorkerMetrics extends BaseWorker {
   nb_tasks_succeeded: number
   nb_tasks_failed: number
   current_usage: Resources
+  resources: WorkerResourceSchema
   ssh_keys: SshKeyRead[]
 }
 

--- a/frontend-ui/src/views/WorkerDetailView.vue
+++ b/frontend-ui/src/views/WorkerDetailView.vue
@@ -753,18 +753,18 @@ const isDuplicateContextName = (name: string, currentIndex: number): boolean => 
 const workerName = computed(() => props.workerName)
 
 const usageCpu = computed(
-  () => `${worker.value?.current_usage.cpu ?? 0}/${worker.value?.resources.cpu ?? 0}`,
+  () => `${worker.value?.current_usage.cpu ?? 0}/${worker.value?.resources.total.cpu ?? 0}`,
 )
 const usageMemory = computed(
   () =>
     `${formattedBytesSize(worker.value?.current_usage.memory ?? 0)}/${formattedBytesSize(
-      worker.value?.resources.memory ?? 0,
+      worker.value?.resources.total.memory ?? 0,
     )}`,
 )
 const usageDisk = computed(
   () =>
     `${formattedBytesSize(worker.value?.current_usage.disk ?? 0)}/${formattedBytesSize(
-      worker.value?.resources.disk ?? 0,
+      worker.value?.resources.total.disk ?? 0,
     )}`,
 )
 
@@ -775,17 +775,17 @@ function pctColor(pct: number): string {
 }
 
 const percentCpu = computed(() => {
-  const max = worker.value?.resources.cpu ?? 0
+  const max = worker.value?.resources.total.cpu ?? 0
   const cur = worker.value?.current_usage.cpu ?? 0
   return max > 0 ? Math.min(100, Math.round((cur * 100) / max)) : 0
 })
 const percentMemory = computed(() => {
-  const max = worker.value?.resources.memory ?? 0
+  const max = worker.value?.resources.total.memory ?? 0
   const cur = worker.value?.current_usage.memory ?? 0
   return max > 0 ? Math.min(100, Math.round((cur * 100) / max)) : 0
 })
 const percentDisk = computed(() => {
-  const max = worker.value?.resources.disk ?? 0
+  const max = worker.value?.resources.total.disk ?? 0
   const cur = worker.value?.current_usage.disk ?? 0
   return max > 0 ? Math.min(100, Math.round((cur * 100) / max)) : 0
 })

--- a/frontend-ui/src/views/WorkersView.vue
+++ b/frontend-ui/src/views/WorkersView.vue
@@ -172,21 +172,22 @@ const filteredWorkers = computed(() => (showingAll.value ? workers.value : onlin
 const workerNames = computed(() => filteredWorkers.value.map((worker) => worker.name))
 
 const canCreateWorkers = computed(() => authStore.hasPermission('workers', 'create'))
+// Compute workers with total resources (remaining + used by running tasks)
 
 const tasks = computed(() => {
   return runningTasks.value.filter((task) => workerNames.value.indexOf(task.worker_name) !== -1)
 })
 
 const maxCpu = computed(() => {
-  return onlineWorkers.value.reduce((sum, worker) => sum + worker.resources.cpu, 0)
+  return onlineWorkers.value.reduce((sum, worker) => sum + worker.resources.total.cpu, 0)
 })
 
 const maxMemory = computed(() => {
-  return onlineWorkers.value.reduce((sum, worker) => sum + worker.resources.memory, 0)
+  return onlineWorkers.value.reduce((sum, worker) => sum + worker.resources.total.memory, 0)
 })
 
 const maxDisk = computed(() => {
-  return onlineWorkers.value.reduce((sum, worker) => sum + worker.resources.disk, 0)
+  return onlineWorkers.value.reduce((sum, worker) => sum + worker.resources.total.disk, 0)
 })
 
 const currentCpu = computed(() => {
@@ -263,8 +264,10 @@ async function loadRunningTasks(): Promise<void> {
       'started',
       'scraper_started',
       'scraper_completed',
+      'scraper_running',
       'scraper_killed',
       'cancel_requested',
+      'canceling',
     ],
   })
   if (tasks) {

--- a/worker/src/zimfarm_worker/common/docker.py
+++ b/worker/src/zimfarm_worker/common/docker.py
@@ -218,47 +218,34 @@ class ResourceStats:
 
 
 @dataclass(kw_only=True)
-class ResourceStatsWithRemaining(ResourceStats):
-    remaining: int = 0
-
-
-@dataclass(kw_only=True)
 class HostStats:
     cpu: ResourceStats
-    disk: ResourceStatsWithRemaining
-    memory: ResourceStatsWithRemaining
+    disk: ResourceStats
+    memory: ResourceStats
 
 
-def query_host_stats(client: DockerClient, workdir: Path):
+def query_host_stats(client: DockerClient):
     # query cpu and ram usage in our containers
     stats = query_containers_resources(client)
-
-    # disk space
-    workir_fs_stats = os.statvfs(workdir)
     disk_used = stats.disk
-    disk_free = workir_fs_stats.f_bavail * workir_fs_stats.f_frsize
-
-    # CPU cores
     cpu_used = stats.cpu_shares // DEFAULT_CPU_SHARE
-    cpu_avail = as_pos_int(ZIMFARM_CPUS - cpu_used)
-
-    # RAM
     mem_used = stats.memory
-    mem_avail = as_pos_int(ZIMFARM_MEMORY - mem_used)
 
     return HostStats(
-        cpu=ResourceStats(total=ZIMFARM_CPUS, used=cpu_used, available=cpu_avail),
-        disk=ResourceStatsWithRemaining(
+        cpu=ResourceStats(
+            total=ZIMFARM_CPUS,
+            used=cpu_used,
+            available=as_pos_int(ZIMFARM_CPUS - cpu_used),
+        ),
+        disk=ResourceStats(
             total=ZIMFARM_DISK_SPACE,
             used=disk_used,
-            available=disk_free,
-            remaining=ZIMFARM_DISK_SPACE - disk_used,
+            available=as_pos_int(ZIMFARM_DISK_SPACE - disk_used),
         ),
-        memory=ResourceStatsWithRemaining(
+        memory=ResourceStats(
             total=ZIMFARM_MEMORY,
             used=mem_used,
-            available=mem_avail,
-            remaining=ZIMFARM_MEMORY - mem_used,
+            available=ZIMFARM_MEMORY - mem_used,
         ),
     )
 

--- a/worker/src/zimfarm_worker/manager/worker.py
+++ b/worker/src/zimfarm_worker/manager/worker.py
@@ -2,6 +2,7 @@
 # vim: ai ts=4 sts=4 et sw=4 nu
 
 import datetime
+import os
 import shutil
 import signal
 import time
@@ -40,7 +41,7 @@ from zimfarm_worker.common.docker import (
     stop_container,
     stop_task_worker,
 )
-from zimfarm_worker.common.utils import as_pos_int, format_size
+from zimfarm_worker.common.utils import format_size
 from zimfarm_worker.common.worker import BaseWorker
 
 
@@ -124,11 +125,27 @@ class WorkerManager(BaseWorker):
         # ensure we have access to docker API
         self.check_docker()
 
-        # display resources
-        host_stats = query_host_stats(self.docker, self.workdir)
+        # display resources. These aren't the actual "host" statistics but an
+        # aggregation of the total stats used by our own containers.
+        host_stats = query_host_stats(self.docker)
+        disk_free = self.free_disk_space()
+        if host_stats.disk.available > disk_free:
+            self.should_stop = True
+            logger.critical(
+                "Configured disk space is not available. Only "
+                f"{format_size(disk_free)} currently available while we expect at "
+                f"least {format_size(host_stats.disk.available)} to be available. This "
+                "computation is based on running tasks expected disk consumption and a "
+                f"configured total of {format_size(host_stats.disk.total)} available "
+                "for Zimfarm on the machine. Potential causes might be a task which "
+                "consumes more disk than configured in its recipe, dangling objects "
+                "(containers, volumes, images) or something else on the host "
+                "consuming more disk than anticipated. Exiting..."
+            )
+            return
 
         logger.info(
-            "Host hardware resources:"
+            "Hardware resources:"
             f"\n\tCPU : {host_stats.cpu.total} (total) ;  {host_stats.cpu.available} "
             "(avail)"
             f"\n\tRAM : {format_size(host_stats.memory.total)} (total) ;  "
@@ -136,13 +153,7 @@ class WorkerManager(BaseWorker):
             f"\n\tDisk: {format_size(host_stats.disk.total)} (configured) ; "
             f"{format_size(host_stats.disk.available)} (avail) ; "
             f"{format_size(host_stats.disk.used)} (reserved) ; "
-            f"{format_size(host_stats.disk.remaining)} (remaining)"
         )
-
-        if host_stats.disk.available < host_stats.disk.remaining:
-            self.should_stop = True
-            logger.critical("Configured disk space is not available. Exiting.")
-            return
 
         self.check_in()
 
@@ -190,13 +201,15 @@ class WorkerManager(BaseWorker):
         logger.debug(f"polling {webapi_uri}…")
         self.last_poll = getnow()
 
-        host_stats = query_host_stats(self.docker, self.workdir)
-        expected_disk_avail = as_pos_int(host_stats.disk.total - host_stats.disk.used)
-        if host_stats.disk.available < expected_disk_avail:
+        host_stats = query_host_stats(self.docker)
+        disk_free = self.free_disk_space()
+        if host_stats.disk.available > disk_free:
             self.should_stop = True
             logger.critical(
-                f"Available disk space ({format_size(host_stats.disk.available)})"
-                f" is lower than expected ({format_size(expected_disk_avail)}). Exiting"
+                f"Available disk space ({format_size(disk_free)}) "
+                "is lower than expected "
+                f"({format_size(host_stats.disk.available)}). "
+                "Exiting..."
             )
             return False
 
@@ -205,6 +218,9 @@ class WorkerManager(BaseWorker):
             path="/requested-tasks/worker",
             params={
                 "worker_name": self.worker_name,
+                "total_cpu": host_stats.cpu.total,
+                "total_memory": host_stats.memory.total,
+                "total_disk": host_stats.disk.total,
                 "avail_cpu": host_stats.cpu.available,
                 "avail_memory": host_stats.memory.available,
                 "avail_disk": host_stats.disk.available,
@@ -249,7 +265,7 @@ class WorkerManager(BaseWorker):
         netloc = urllib.parse.urlparse(webapi_uri).netloc
         logger.info(f"checking-in with the API at {netloc}…")
 
-        host_stats = query_host_stats(self.docker, self.workdir)
+        host_stats = query_host_stats(self.docker)
         try:
             container_info = inspect_container(
                 self.docker, get_running_container_name()
@@ -529,6 +545,12 @@ class WorkerManager(BaseWorker):
             workdir=self.workdir,
             worker_name=self.worker_name,
         )
+
+    def free_disk_space(self):
+        """Get the available disk space on the host machine"""
+        workir_fs_stats = os.statvfs(self.workdir)
+        disk_free = workir_fs_stats.f_bavail * workir_fs_stats.f_frsize
+        return disk_free
 
     def exit_gracefully(self, signum: int, _: Any):
         signame = signal.strsignal(signum)

--- a/worker/src/zimfarm_worker/task/worker.py
+++ b/worker/src/zimfarm_worker/task/worker.py
@@ -87,17 +87,16 @@ class TaskWorker(BaseWorker):
         # ensure we have access to docker API
         self.check_docker()
 
-        host_stats = query_host_stats(self.docker, self.workdir)
+        host_stats = query_host_stats(self.docker)
         logger.info(
-            "Host hardware resources:"
+            "Hardware resources:"
             f"\n\tCPU : {host_stats.cpu.total} (total) ;  {host_stats.cpu.available} "
             "(avail)"
-            f"\n\tRAM : {format_size(host_stats.memory.total)} (total) ;"
-            f"  {format_size(host_stats.memory.available)} (avail)"
-            f"\n\tDisk: {format_size(host_stats.disk.total)} (configured) ;"
-            f"  {format_size(host_stats.disk.available)} (avail) ; "
-            f"{format_size(host_stats.disk.used)} (reserved) ;"
-            f"  {format_size(host_stats.disk.remaining)} (remaining)"
+            f"\n\tRAM : {format_size(host_stats.memory.total)} (total) ;  "
+            f"{format_size(host_stats.memory.available)} (avail)"
+            f"\n\tDisk: {format_size(host_stats.disk.total)} (configured) ; "
+            f"{format_size(host_stats.disk.available)} (avail) ; "
+            f"{format_size(host_stats.disk.used)} (reserved) ; "
         )
 
         self.task: dict[str, Any] | None = None


### PR DESCRIPTION
## Rationale
This PR updates worker manager to correctly poll the API with remaining resources instead of the available resources (see #1795)

## Changes
- poll API with remaining resources
- update worker resources with those sent in poll requests
- adapt UI to compute total as the sum of the worker resource and the tasks it is currently executing
- adapt logic to diagnose requested task to use the worker's reported stats for diagnosis`

This closes #1795 