### PR TITLE
Hide workers from users list

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/accounts/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/accounts/logic.py
@@ -80,7 +80,12 @@ def get_accounts(
 ) -> ListResponse[AccountSchema]:
     """Get a list of accounts"""
     results = db_get_accounts(
-        db_session, skip=params.skip, limit=params.limit, username=params.username
+        db_session,
+        skip=params.skip,
+        limit=params.limit,
+        username=params.username,
+        show_workers=params.show_workers,
+        show_viewers=params.show_viewers,
     )
     return ListResponse(
         meta=calculate_pagination_metadata(

--- a/backend/src/zimfarm_backend/api/routes/accounts/models.py
+++ b/backend/src/zimfarm_backend/api/routes/accounts/models.py
@@ -31,3 +31,4 @@ class AccountsGetSchema(BaseModel):
     skip: SkipField = 0
     limit: LimitFieldMax200 = 20
     username: NotEmptyString | None = None
+    show_workers: bool = False  # show accounts which have "worker" role

--- a/backend/src/zimfarm_backend/api/routes/accounts/models.py
+++ b/backend/src/zimfarm_backend/api/routes/accounts/models.py
@@ -31,4 +31,5 @@ class AccountsGetSchema(BaseModel):
     skip: SkipField = 0
     limit: LimitFieldMax200 = 20
     username: NotEmptyString | None = None
-    show_workers: bool = False  # show accounts which have "worker" role
+    show_workers: bool = True  # show accounts which have "worker" role
+    show_viewers: bool = True  # show accounts which have "viewer" role

--- a/backend/src/zimfarm_backend/db/account.py
+++ b/backend/src/zimfarm_backend/db/account.py
@@ -123,7 +123,8 @@ def get_accounts(
     skip: int,
     limit: int,
     username: str | None = None,
-    show_workers: bool = False,
+    show_workers: bool = True,
+    show_viewers: bool = True,
 ) -> AccountList:
     """Get a list of accounts"""
     query = (
@@ -133,7 +134,8 @@ def get_accounts(
         )
         .where(
             Account.deleted.is_(False),
-            (Account.role != "worker") | (show_workers is True),
+            (Account.role != RoleEnum.WORKER) | (show_workers is True),
+            (Account.role != RoleEnum.VIEWER) | (show_viewers is True),
             (
                 Account.display_name.ilike(
                     f"%{username if username is not None else ''}%"

--- a/backend/src/zimfarm_backend/db/account.py
+++ b/backend/src/zimfarm_backend/db/account.py
@@ -118,7 +118,12 @@ def create_account_schema(account: Account) -> AccountSchema:
 
 
 def get_accounts(
-    session: OrmSession, *, skip: int, limit: int, username: str | None = None
+    session: OrmSession,
+    *,
+    skip: int,
+    limit: int,
+    username: str | None = None,
+    show_workers: bool = False,
 ) -> AccountList:
     """Get a list of accounts"""
     query = (
@@ -128,6 +133,7 @@ def get_accounts(
         )
         .where(
             Account.deleted.is_(False),
+            (Account.role != "worker") | (show_workers is True),
             (
                 Account.display_name.ilike(
                     f"%{username if username is not None else ''}%"

--- a/backend/tests/db/test_account.py
+++ b/backend/tests/db/test_account.py
@@ -1,3 +1,4 @@
+from collections.abc import Callable
 from uuid import uuid4
 
 import pytest
@@ -66,6 +67,22 @@ def test_get_accounts_pagination(dbsession: OrmSession, accounts: list[Account])
     result = get_accounts(dbsession, skip=0, limit=1)
     assert result.nb_records == len(accounts)
     assert len(result.accounts) == 1
+
+
+@pytest.mark.parametrize("show_workers", [True, False])
+def test_get_accounts_filter_workers(
+    dbsession: OrmSession, create_account: Callable[..., Account], *, show_workers: bool
+):
+    """Test that get_accounts filters workers."""
+    create_account(permission=RoleEnum.WORKER)
+
+    results = get_accounts(dbsession, skip=0, limit=1, show_workers=show_workers)
+    if show_workers:
+        assert results.nb_records == 1
+        assert len(results.accounts) == 1
+    else:
+        assert results.nb_records == 0
+        assert len(results.accounts) == 0
 
 
 def test_create_account(dbsession: OrmSession):

--- a/frontend-ui/src/components/UsersTable.vue
+++ b/frontend-ui/src/components/UsersTable.vue
@@ -1,6 +1,18 @@
 <template>
   <div>
     <v-card v-if="!errors.length" :class="{ loading: loading }" flat>
+      <v-card-title class="d-flex align-center justify-end">
+        <v-btn
+          size="small"
+          variant="outlined"
+          color="secondary"
+          class="text-none"
+          @click="$emit('toggleUsersList')"
+        >
+          {{ toggleText }}
+        </v-btn>
+      </v-card-title>
+
       <v-data-table-server
         :headers="headers"
         :items="users"
@@ -65,10 +77,12 @@ const props = defineProps<{
   loading: boolean
   errors: string[]
   loadingText: string
+  toggleText: string
 }>()
 
 const emit = defineEmits<{
   limitChanged: [limit: number]
+  toggleUsersList: []
 }>()
 
 const limits = [10, 20, 50, 100]

--- a/frontend-ui/src/stores/user.ts
+++ b/frontend-ui/src/stores/user.ts
@@ -44,9 +44,15 @@ export const useUserStore = defineStore('user', () => {
     }
   }
 
-  const fetchUsers = async (skip: number = 0, limit: number = 20, username?: string) => {
+  const fetchUsers = async (
+    skip: number = 0,
+    limit: number = 20,
+    username?: string,
+    show_viewers: boolean = false,
+    show_workers: boolean = false,
+  ) => {
     const service = await authStore.getApiService('accounts')
-    // filter out undefined values from params
+    // filter out undefined/falsy string values but keep booleans separate
     const cleanedParams = Object.fromEntries(
       Object.entries({
         limit,
@@ -56,7 +62,7 @@ export const useUserStore = defineStore('user', () => {
     )
     try {
       const response = await service.get<null, ListResponse<User>>('', {
-        params: cleanedParams,
+        params: { ...cleanedParams, show_viewers, show_workers },
       })
       errors.value = []
       users.value = response.items

--- a/frontend-ui/src/views/UsersView.vue
+++ b/frontend-ui/src/views/UsersView.vue
@@ -50,7 +50,9 @@
         :loading="loadingStore.isLoading"
         :loading-text="loadingStore.loadingText"
         :errors="userStore.errors"
+        :toggle-text="toggleText"
         @limit-changed="handleLimitChange"
+        @toggle-users-list="toggleViewersList"
       />
     </div>
 
@@ -181,6 +183,7 @@ const isCreating = ref(false)
 const error = ref<string | null>(null)
 const searchUsername = ref<string>('')
 const showCreateDialog = ref(false)
+const showingViewers = ref<boolean>(getViewersPreference())
 
 const paginator = ref({
   page: Number(route.query.page) || 1,
@@ -202,6 +205,8 @@ const showPassword = ref(false)
 // Computed properties
 const canReadUsers = computed(() => authStore.hasPermission('accounts', 'read'))
 
+const toggleText = computed(() => (showingViewers.value ? 'Hide Viewers' : 'Show Viewers'))
+
 const canCreateUsers = computed(() => authStore.hasPermission('accounts', 'create'))
 
 const isFormValid = computed(() => {
@@ -222,6 +227,21 @@ const rules = {
 }
 
 // Methods
+function getViewersPreference(): boolean {
+  const value = localStorage.getItem('users-show-viewers')
+  return value === null ? false : JSON.parse(value)
+}
+
+function saveViewersPreference(value: boolean): void {
+  localStorage.setItem('users-show-viewers', JSON.stringify(value))
+}
+
+function toggleViewersList(): void {
+  showingViewers.value = !showingViewers.value
+  saveViewersPreference(showingViewers.value)
+  loadData(paginator.value.limit, paginator.value.skip)
+}
+
 const createUser = async () => {
   const { valid } = await formRef.value?.validate()
   if (!valid) return
@@ -273,7 +293,12 @@ const loadData = async (limit: number, skip: number) => {
 
   loadingStore.startLoading('Fetching users...')
 
-  const response = await userStore.fetchUsers(skip, limit, searchUsername.value || undefined)
+  const response = await userStore.fetchUsers(
+    skip,
+    limit,
+    searchUsername.value || undefined,
+    showingViewers.value,
+  )
   if (response) {
     users.value = response
     paginator.value = { ...userStore.paginator }


### PR DESCRIPTION
## Rationale
This PR enhances the API to show/hide worker accounts while fetching accounts. In addition, it also adds the ability to hide users with viewer role

## Changes
- hide accounts with `worker` role unless `show_workers` is set to True
- add query param to hide users with viewer role from the UI

This closes #1812
This closes #1813 
