### PR TITLE
create worker from API/UI

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/workers/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/workers/logic.py
@@ -21,6 +21,7 @@ from zimfarm_backend.api.routes.workers.models import (
     KeySchema,
     WorkerCheckInResponse,
     WorkerCheckInSchema,
+    WorkerCreateSchema,
     WorkerUpdateSchema,
 )
 from zimfarm_backend.common.constants import GITHUB_TOKEN
@@ -43,24 +44,21 @@ from zimfarm_backend.db.account import check_account_permission
 from zimfarm_backend.db.models import Account
 from zimfarm_backend.db.ssh_key import (
     create_ssh_key,
+    create_ssh_key_read_schema,
     delete_ssh_key,
     get_ssh_key_by_fingerprint,
-    get_ssh_key_by_fingerprint_or_none,
 )
 from zimfarm_backend.db.ssh_key import get_ssh_keys as db_get_ssh_keys
 from zimfarm_backend.db.worker import check_in_worker as db_check_in_worker
+from zimfarm_backend.db.worker import (
+    create_worker as db_create_worker,
+)
 from zimfarm_backend.db.worker import (
     get_worker as db_get_worker,
 )
 from zimfarm_backend.db.worker import get_worker_metrics as db_get_worker_metrics
 from zimfarm_backend.db.worker import get_workers as db_get_workers
 from zimfarm_backend.db.worker import update_worker as db_update_worker
-from zimfarm_backend.exceptions import PublicKeyLoadError
-from zimfarm_backend.utils.cryptography import (
-    get_public_key_fingerprint,
-    get_public_key_type,
-    load_public_key,
-)
 from zimfarm_backend.utils.github_registry import (
     WorkerManagerVersion,
     get_latest_worker_manager_version,
@@ -121,6 +119,22 @@ def get_workers(
         ),
         items=results.workers,
     )
+
+
+@router.post(
+    "",
+    dependencies=[Depends(require_permission(namespace="workers", name="create"))],
+)
+def create_worker(
+    session: Annotated[OrmSession, Depends(gen_dbsession)],
+    request: WorkerCreateSchema,
+):
+    db_create_worker(
+        session,
+        worker_name=request.name,
+        ssh_key=request.ssh_key,
+    )
+    return Response(status_code=HTTPStatus.CREATED)
 
 
 @router.put(
@@ -251,26 +265,9 @@ def create_worker_key(
 ) -> SshKeyRead:
     """Create a new SSH key for a worker"""
     worker = db_get_worker(db_session, worker_name=worker_name)
-    try:
-        public_key = load_public_key(bytes(ssh_key.key, encoding="ascii"))
-    except PublicKeyLoadError as e:
-        raise BadRequestError("Invalid public key") from e
-
-    fingerprint = get_public_key_fingerprint(public_key)
-
-    db_ssh_key = get_ssh_key_by_fingerprint_or_none(db_session, fingerprint=fingerprint)
-    if db_ssh_key:
-        raise BadRequestError("SSH key already exists")
-
-    db_ssh_key = create_ssh_key(
-        db_session,
-        fingerprint=fingerprint,
-        worker_id=worker.id,
-        key=ssh_key.key,
-        name=ssh_key.name,
-        type_=get_public_key_type(public_key),
+    return create_ssh_key_read_schema(
+        create_ssh_key(db_session, worker_id=worker.id, ssh_key=ssh_key)
     )
-    return SshKeyRead.model_validate(db_ssh_key)
 
 
 @router.get(

--- a/backend/src/zimfarm_backend/api/routes/workers/models.py
+++ b/backend/src/zimfarm_backend/api/routes/workers/models.py
@@ -1,15 +1,15 @@
 from ipaddress import IPv4Address, IPv6Address
+from typing import Annotated
 
-from pydantic import computed_field, field_validator
+from pydantic import Field
 
 from zimfarm_backend.common.schemas import BaseModel
 from zimfarm_backend.common.schemas.fields import (
     ZIMCPU,
-    NotEmptyString,
     ZIMDisk,
     ZIMMemory,
 )
-from zimfarm_backend.common.schemas.models import DockerImageVersionSchema
+from zimfarm_backend.common.schemas.models import DockerImageVersionSchema, KeySchema
 
 
 class WorkerCheckInSchema(BaseModel):
@@ -44,22 +44,19 @@ class WorkerUpdateSchema(BaseModel):
     admin_disabled: bool | None = None
 
 
-class KeySchema(BaseModel):
+WorkerName = Annotated[
+    str,
+    Field(
+        pattern=r"^[a-z0-9-]+$",
+        min_length=3,
+    ),
+]
+
+
+class WorkerCreateSchema(BaseModel):
     """
-    Schema for creating a ssh key
+    Schema for creating a worker.
     """
 
-    key: NotEmptyString
-
-    @field_validator("key", mode="after")
-    @classmethod
-    def validate_key(cls, value: str) -> str:
-        value = value.strip()
-        if len(value.split(" ")) != 3:  # noqa: PLR2004
-            raise ValueError("Key does not appear to be an SSH public file.")
-        return value
-
-    @computed_field
-    @property
-    def name(self) -> str:
-        return self.key.split(" ")[2]
+    name: WorkerName
+    ssh_key: KeySchema

--- a/backend/src/zimfarm_backend/common/schemas/models.py
+++ b/backend/src/zimfarm_backend/common/schemas/models.py
@@ -11,6 +11,7 @@ from pydantic import (
     Field,
     HttpUrl,
     SerializeAsAny,
+    computed_field,
     field_validator,
     model_validator,
 )
@@ -176,3 +177,24 @@ class DockerImageVersionSchema(ZimfarmBaseModel):
 
     hash: str
     created_at: datetime.datetime
+
+
+class KeySchema(BaseModel):
+    """
+    Schema for creating a ssh key
+    """
+
+    key: NotEmptyString
+
+    @field_validator("key", mode="after")
+    @classmethod
+    def validate_key(cls, value: str) -> str:
+        value = value.strip()
+        if len(value.split(" ")) != 3:  # noqa: PLR2004
+            raise ValueError("Key does not appear to be an SSH public file.")
+        return value
+
+    @computed_field
+    @property
+    def name(self) -> str:
+        return self.key.split(" ")[2]

--- a/backend/src/zimfarm_backend/db/ssh_key.py
+++ b/backend/src/zimfarm_backend/db/ssh_key.py
@@ -6,9 +6,16 @@ from sqlalchemy.orm import selectinload
 
 from zimfarm_backend.common import getnow
 from zimfarm_backend.common.schemas import BaseModel
+from zimfarm_backend.common.schemas.models import KeySchema
 from zimfarm_backend.common.schemas.orms import SshKeyRead
 from zimfarm_backend.db.exceptions import RecordDoesNotExistError
 from zimfarm_backend.db.models import Sshkey, Worker
+from zimfarm_backend.exceptions import PublicKeyLoadError
+from zimfarm_backend.utils.cryptography import (
+    get_public_key_fingerprint,
+    get_public_key_type,
+    load_public_key,
+)
 
 
 def get_ssh_key_by_fingerprint_or_none(
@@ -56,28 +63,33 @@ def get_ssh_keys(session: OrmSession, *, worker_id: UUID) -> SshKeyList:
 
 
 def create_ssh_key(
-    session: OrmSession,
-    *,
-    fingerprint: str,
-    worker_id: UUID,
-    key: str,
-    name: str,
-    type_: str,
+    session: OrmSession, *, worker_id: UUID, ssh_key: KeySchema
 ) -> Sshkey:
     """Create a new ssh key"""
-    ssh_key = Sshkey(
+    try:
+        public_key = load_public_key(bytes(ssh_key.key, encoding="ascii"))
+    except PublicKeyLoadError as e:
+        raise ValueError("Invalid public key") from e
+
+    fingerprint = get_public_key_fingerprint(public_key)
+
+    db_ssh_key = get_ssh_key_by_fingerprint_or_none(session, fingerprint=fingerprint)
+    if db_ssh_key:
+        raise ValueError("SSH key already exists")
+
+    db_ssh_key = Sshkey(
         fingerprint=fingerprint,
-        key=key,
-        name=name,
-        type=type_,
+        key=ssh_key.key,
+        name=ssh_key.name,
+        type=get_public_key_type(public_key),
         added=getnow(),
     )
 
-    ssh_key.worker_id = worker_id
-    session.add(ssh_key)
+    db_ssh_key.worker_id = worker_id
+    session.add(db_ssh_key)
     session.flush()
 
-    return ssh_key
+    return db_ssh_key
 
 
 def get_ssh_key_by_fingerprint(session: OrmSession, *, fingerprint: str) -> Sshkey:

--- a/backend/src/zimfarm_backend/db/worker.py
+++ b/backend/src/zimfarm_backend/db/worker.py
@@ -11,16 +11,21 @@ from sqlalchemy.orm.strategy_options import selectinload
 from zimfarm_backend.common import getnow, to_naive_utc
 from zimfarm_backend.common.constants import WORKER_OFFLINE_DELAY_DURATION
 from zimfarm_backend.common.enums import TaskStatus
+from zimfarm_backend.common.roles import RoleEnum
 from zimfarm_backend.common.schemas import BaseModel
-from zimfarm_backend.common.schemas.models import DockerImageVersionSchema
+from zimfarm_backend.common.schemas.models import DockerImageVersionSchema, KeySchema
 from zimfarm_backend.common.schemas.orms import (
     ConfigResourcesSchema,
     WorkerLightSchema,
     WorkerMetricsSchema,
 )
+from zimfarm_backend.db.account import create_account
 from zimfarm_backend.db.exceptions import RecordDoesNotExistError
 from zimfarm_backend.db.models import Account, Task, Worker
-from zimfarm_backend.db.ssh_key import create_ssh_key_read_schema
+from zimfarm_backend.db.ssh_key import (
+    create_ssh_key,
+    create_ssh_key_read_schema,
+)
 from zimfarm_backend.db.tasks import get_currently_running_tasks
 
 
@@ -251,3 +256,36 @@ def check_in_worker(
         .where(Worker.name == worker_name)
     )
     session.execute(stmt)
+
+
+def create_worker(
+    session: OrmSession,
+    *,
+    worker_name: str,
+    ssh_key: KeySchema,
+):
+    """Create a new worker.
+
+    A new account bearing the same name as the worker will be created. This new
+    account will be created with the "worker" role.
+    """
+
+    account = create_account(session, display_name=worker_name, role=RoleEnum.WORKER)
+    worker = Worker(
+        name=worker_name,
+        cpu=0,
+        memory=0,
+        disk=0,
+        selfish=True,
+        offliners=[],
+        cordoned=False,
+        platforms={},
+        last_seen=None,
+        last_ip=None,
+    )
+
+    worker.account_id = account.id
+    session.add(worker)
+    session.flush()
+
+    create_ssh_key(session, worker_id=worker.id, ssh_key=ssh_key)

--- a/backend/tests/db/test_worker.py
+++ b/backend/tests/db/test_worker.py
@@ -8,12 +8,15 @@ from pytest import MonkeyPatch
 from sqlalchemy.orm import Session as OrmSession
 
 from zimfarm_backend.common import getnow
+from zimfarm_backend.common.roles import RoleEnum
+from zimfarm_backend.common.schemas.models import KeySchema
 from zimfarm_backend.common.schemas.orms import BaseWorkerSchema, OfflinerSchema
 from zimfarm_backend.db import worker as worker_module
 from zimfarm_backend.db.exceptions import RecordDoesNotExistError
 from zimfarm_backend.db.models import Account, Worker
 from zimfarm_backend.db.worker import (
     check_in_worker,
+    create_worker,
     get_worker,
     get_worker_or_none,
     get_workers,
@@ -257,3 +260,50 @@ def test_worker_ip_changed(
         docker_image=None,
     )
     assert worker.ip_changed is ip_changed
+
+
+def test_create_worker_success(
+    dbsession: OrmSession,
+    rsa_public_key_data: bytes,
+):
+    """Test that create_worker creates a worker with an account and SSH key"""
+    worker_name = "newworker"
+    ssh_key = KeySchema(key=rsa_public_key_data.decode("ascii") + " test@localhost")
+    create_worker(
+        dbsession,
+        worker_name=worker_name,
+        ssh_key=ssh_key,
+    )
+    db_worker = get_worker(dbsession, worker_name=worker_name)
+    assert db_worker.name == worker_name
+    assert db_worker.account.role == RoleEnum.WORKER
+    assert db_worker.account.display_name == worker_name
+    assert len(db_worker.ssh_keys) == 1
+
+
+def test_create_worker_invalid_public_key(
+    dbsession: OrmSession,
+):
+    """Test that create_worker raises ValueError for invalid public keys"""
+    ssh_key = KeySchema(key="invalid-type AAAAINVALIDDATA test@localhost")
+    with pytest.raises(ValueError, match="Invalid public key"):
+        create_worker(
+            dbsession,
+            worker_name="newworker",
+            ssh_key=ssh_key,
+        )
+
+
+def test_create_worker_duplicate_ssh_key(
+    dbsession: OrmSession,
+    worker: Worker,  # noqa: ARG001 needed for side effect
+    rsa_public_key_data: bytes,
+):
+    """Test that create_worker raises ValueError when the SSH key already exists"""
+    ssh_key = KeySchema(key=rsa_public_key_data.decode("ascii") + " test@localhost")
+    with pytest.raises(ValueError, match="SSH key already exists"):
+        create_worker(
+            dbsession,
+            worker_name="anotherworker",
+            ssh_key=ssh_key,
+        )

--- a/backend/tests/routes/test_worker.py
+++ b/backend/tests/routes/test_worker.py
@@ -493,3 +493,85 @@ def test_delete_account_key_forbidden(
     )
     response = client.delete(url, headers={"Authorization": f"Bearer {access_token}"})
     assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+def test_create_worker_success(
+    client: TestClient,
+    access_token: str,
+):
+    """Test successful creation of a worker"""
+    new_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    public_key_bytes = new_key.public_key().public_bytes(
+        encoding=serialization.Encoding.OpenSSH,
+        format=serialization.PublicFormat.OpenSSH,
+    )
+    key_str = public_key_bytes.decode("ascii") + " test@localhost"
+    response = client.post(
+        "/v2/workers",
+        json={
+            "name": "myworker",
+            "offliners": ["mwoffliner"],
+            "ssh_key": {"key": key_str},
+        },
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == HTTPStatus.CREATED
+
+
+@pytest.mark.parametrize(
+    "permission",
+    [
+        pytest.param(RoleEnum.EDITOR, id="editor"),
+        pytest.param(RoleEnum.MANAGER, id="manager"),
+    ],
+)
+def test_create_worker_forbidden(
+    client: TestClient,
+    create_account: Callable[..., Account],
+    *,
+    permission: RoleEnum,
+):
+    """Test that creating a worker without proper permission raises forbidden error"""
+    account = create_account(permission=permission)
+    token = generate_access_token(
+        issue_time=getnow(),
+        account_id=str(account.id),
+    )
+    response = client.post(
+        "/v2/workers",
+        json={
+            "name": "myworker",
+            "offliners": ["mwoffliner"],
+            "ssh_key": {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAA test@localhost"},
+        },
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert response.status_code == HTTPStatus.FORBIDDEN
+
+
+@pytest.mark.parametrize(
+    "worker_name",
+    [
+        pytest.param("ab", id="too-short"),
+        pytest.param("MY-WORKER", id="uppercase-and-dash"),
+        pytest.param("my_worker", id="underscore"),
+        pytest.param("my worker", id="space"),
+    ],
+)
+def test_create_worker_invalid_name(
+    client: TestClient,
+    access_token: str,
+    *,
+    worker_name: str,
+):
+    """Test that creating a worker with an invalid name fails due to validation error"""
+    response = client.post(
+        "/v2/workers",
+        json={
+            "name": worker_name,
+            "offliners": ["mwoffliner"],
+            "ssh_key": {"key": "ssh-rsa AAAAB3NzaC1yc2EAAAA test@localhost"},
+        },
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == HTTPStatus.UNPROCESSABLE_ENTITY

--- a/frontend-ui/src/components/CreateWorkerDialog.vue
+++ b/frontend-ui/src/components/CreateWorkerDialog.vue
@@ -1,0 +1,125 @@
+<template>
+  <v-dialog v-model="dialog" max-width="800px" persistent>
+    <v-card>
+      <v-card-title>
+        <span class="text-h5">Create Worker</span>
+      </v-card-title>
+      <v-card-text>
+        <v-form ref="form" v-model="valid" @submit.prevent="createWorker">
+          <v-row>
+            <v-col cols="12">
+              <v-text-field
+                v-model="workerData.name"
+                label="Worker Name"
+                :rules="nameRules"
+                required
+                variant="outlined"
+                density="compact"
+                hint="Only lowercase alphanumeric and dashes."
+              />
+            </v-col>
+          </v-row>
+
+          <v-divider class="my-4" />
+          <h3 class="text-h6 mb-2">SSH Key</h3>
+          <SshKeyInput v-model="sshKeyData" />
+        </v-form>
+      </v-card-text>
+      <v-card-actions>
+        <v-spacer />
+        <v-btn color="error" variant="text" @click="close">Cancel</v-btn>
+        <v-btn
+          color="primary"
+          variant="elevated"
+          :disabled="!isValid"
+          :loading="saving"
+          @click="createWorker"
+        >
+          Create
+        </v-btn>
+      </v-card-actions>
+    </v-card>
+  </v-dialog>
+</template>
+
+<script setup lang="ts">
+import SshKeyInput from '@/components/SshKeyInput.vue'
+import { useNotificationStore } from '@/stores/notification'
+import { useWorkersStore } from '@/stores/workers'
+import type { WorkerCreateSchema } from '@/types/workers'
+import { computed, ref, watch } from 'vue'
+import type { VForm } from 'vuetify/components'
+
+const props = defineProps<{
+  modelValue: boolean
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void
+  (e: 'created'): void
+}>()
+
+const notificationStore = useNotificationStore()
+const workersStore = useWorkersStore()
+
+const dialog = computed({
+  get: () => props.modelValue,
+  set: (val) => emit('update:modelValue', val),
+})
+
+const valid = ref(false)
+const saving = ref(false)
+const form = ref<VForm | null>(null)
+
+const initialWorkerData = {
+  name: '',
+}
+
+const workerData = ref({ ...initialWorkerData })
+const sshKeyData = ref({ name: '', key: '' })
+
+const nameRules = [
+  (v: string) => !!v || 'Name is required',
+  (v: string) => v.length > 2 || 'Name must be greater than 2 characters',
+  (v: string) => /^[a-z0-9-]+$/.test(v) || 'Only lowercase alphanumeric and dashes allowed',
+]
+
+const isValid = computed(() => {
+  return valid.value && sshKeyData.value.name.length > 0 && sshKeyData.value.key.length > 0
+})
+
+watch(dialog, async (newVal) => {
+  if (newVal) {
+    workerData.value = { ...initialWorkerData }
+    sshKeyData.value = { name: '', key: '' }
+    if (form.value) form.value.resetValidation()
+  }
+})
+
+const close = () => {
+  dialog.value = false
+}
+
+const createWorker = async () => {
+  if (!isValid.value) return
+
+  saving.value = true
+  const payload: WorkerCreateSchema = {
+    name: workerData.value.name,
+    ssh_key: { key: sshKeyData.value.key },
+  }
+
+  const result = await workersStore.createWorker(payload)
+  saving.value = false
+
+  if (result) {
+    notificationStore.showSuccess(`Worker ${workerData.value.name} created successfully!`)
+    emit('created')
+    close()
+  } else {
+    for (const error of workersStore.errors) {
+      notificationStore.showError(error)
+    }
+  }
+}
+</script>

--- a/frontend-ui/src/components/SshKeyInput.vue
+++ b/frontend-ui/src/components/SshKeyInput.vue
@@ -1,0 +1,120 @@
+<template>
+  <div>
+    <v-row>
+      <v-col cols="12">
+        <v-tabs v-model="keyInputMode" color="primary" align-tabs="start">
+          <v-tab value="file">Upload File</v-tab>
+          <v-tab value="text">Enter Text</v-tab>
+        </v-tabs>
+      </v-col>
+    </v-row>
+    <v-row>
+      <v-col cols="12">
+        <!-- File Upload Mode -->
+        <v-file-input
+          v-if="keyInputMode === 'file'"
+          v-model="keyFile"
+          label="RSA Public Key"
+          placeholder="Select an RSA public key file (.pub)"
+          hint="Choose an RSA public key file (usually ends with .pub)"
+          accept=".pub,text/plain"
+          variant="outlined"
+          density="compact"
+          @update:model-value="keyFileSelected"
+        />
+        <!-- Text Input Mode -->
+        <v-textarea
+          v-else
+          v-model="keyFormData.key"
+          label="SSH Public Key"
+          placeholder="ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... user@hostname"
+          :hint="
+            keyFormData.key && !validateSSHKey(keyFormData.key)
+              ? 'Invalid SSH key format'
+              : 'Paste your complete SSH public key here (including the name at the end)'
+          "
+          :error="!!(keyFormData.key && !validateSSHKey(keyFormData.key))"
+          variant="outlined"
+          density="compact"
+          rows="3"
+          auto-grow
+          @update:model-value="keyTextChanged"
+        />
+      </v-col>
+    </v-row>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, watch } from 'vue'
+import { useNotificationStore } from '@/stores/notification'
+
+const props = defineProps<{
+  modelValue: { name: string; key: string }
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: { name: string; key: string }): void
+}>()
+
+const notificationStore = useNotificationStore()
+
+const keyFormData = ref({ name: props.modelValue?.name || '', key: props.modelValue?.key || '' })
+const keyFile = ref<File | File[] | null>(null)
+const keyInputMode = ref<'file' | 'text'>('file')
+
+watch(
+  () => keyFormData.value,
+  (newVal) => {
+    emit('update:modelValue', { name: newVal.name, key: newVal.key })
+  },
+  { deep: true },
+)
+
+const validateSSHKey = (key: string): boolean => {
+  if (!key.trim()) return false
+  const parts = key.trim().split(/\s+/)
+  return parts.length === 3
+}
+
+const keyTextChanged = () => {
+  if (!keyFormData.value.key) {
+    keyFormData.value.name = ''
+    return
+  }
+  const parts = keyFormData.value.key.trim().split(/\s+/)
+  keyFormData.value.name = parts.length >= 3 ? parts[2].trim() : ''
+}
+
+const keyFileSelected = () => {
+  keyFormData.value.key = ''
+  keyFormData.value.name = ''
+
+  const file = Array.isArray(keyFile.value) ? keyFile.value[0] : keyFile.value
+  if (!file) return
+  if (file.size > 1024) {
+    notificationStore.showError(
+      `File ${file.name} doesn't appear to be an RSA public file (too large). ${file.size}`,
+    )
+    keyFile.value = null
+    return
+  }
+  const reader = new FileReader()
+  reader.onerror = (evt) => {
+    notificationStore.showError(`File ${file.name} failed to read: ${evt}`)
+    keyFile.value = null
+  }
+  reader.onload = (evt) => {
+    const result = evt.target?.result as string
+    const parts = result.trim().split(/\s+/)
+    if (parts.length !== 3) {
+      notificationStore.showError(`File ${file.name} doesn't appear to be an SSH public file.`)
+      keyFile.value = null
+      return
+    }
+    keyFormData.value.key = result.trim()
+    keyFormData.value.name = parts[2].trim()
+  }
+  reader.readAsText(file, 'UTF-8')
+}
+</script>

--- a/frontend-ui/src/constants.ts
+++ b/frontend-ui/src/constants.ts
@@ -18,7 +18,6 @@ export default {
     'editor-requester',
     'manager',
     'processor',
-    'worker',
     'custom',
     'viewer',
   ] as const,

--- a/frontend-ui/src/stores/workers.ts
+++ b/frontend-ui/src/stores/workers.ts
@@ -7,6 +7,7 @@ import type {
   Worker,
   WorkerMetrics,
   WorkerUpdateSchema,
+  WorkerCreateSchema,
   SshKeyRead,
 } from '@/types/workers'
 import { translateErrors } from '@/utils/errors'
@@ -78,6 +79,19 @@ export const useWorkersStore = defineStore('workers', () => {
     }
   }
 
+  const createWorker = async (payload: WorkerCreateSchema) => {
+    try {
+      const service = await authStore.getApiService('workers')
+      await service.post<WorkerCreateSchema, Worker>('', payload)
+      errors.value = []
+      return true
+    } catch (_error) {
+      console.error('Failed to create worker', _error)
+      errors.value = translateErrors(_error as ErrorResponse)
+      return false
+    }
+  }
+
   const updateWorker = async (name: string, payload: WorkerUpdateSchema) => {
     // Remove null values from the payload
     const cleanedPayload = Object.fromEntries(
@@ -146,6 +160,7 @@ export const useWorkersStore = defineStore('workers', () => {
     updateWorkerTasks,
     savePaginatorLimit,
     fetchWorkerMetrics,
+    createWorker,
     updateWorker,
     fetchLatestWorkerImage,
     deleteSshKey,

--- a/frontend-ui/src/types/workers.ts
+++ b/frontend-ui/src/types/workers.ts
@@ -60,6 +60,13 @@ export interface WorkerUpdateSchema {
   admin_disabled: boolean | null
 }
 
+export interface WorkerCreateSchema {
+  name: string
+  ssh_key: {
+    key: string
+  }
+}
+
 export interface BaseSshKey {
   key: string
   name: string

--- a/frontend-ui/src/views/WorkerDetailView.vue
+++ b/frontend-ui/src/views/WorkerDetailView.vue
@@ -522,53 +522,16 @@
             </v-card-title>
             <v-card-text>
               <v-form @submit.prevent="addSshKey">
-                <v-row>
+                <v-row no-gutters>
                   <v-col cols="12">
-                    <v-tabs v-model="keyInputMode" color="primary" align-tabs="start">
-                      <v-tab value="file">Upload File</v-tab>
-                      <v-tab value="text">Enter Text</v-tab>
-                    </v-tabs>
+                    <SshKeyInput v-model="keyFormData" />
                   </v-col>
-                </v-row>
-                <v-row>
-                  <v-col cols="12" sm="8" md="6">
-                    <!-- File Upload Mode -->
-                    <v-file-input
-                      v-if="keyInputMode === 'file'"
-                      v-model="keyFile"
-                      label="RSA Public Key"
-                      placeholder="Select an RSA public key file (.pub)"
-                      hint="Choose an RSA public key file (usually ends with .pub)"
-                      accept=".pub,text/plain"
-                      variant="outlined"
-                      density="compact"
-                      @update:model-value="keyFileSelected"
-                    />
-                    <!-- Text Input Mode -->
-                    <v-textarea
-                      v-else
-                      v-model="keyFormData.key"
-                      label="SSH Public Key"
-                      placeholder="ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQC... user@hostname"
-                      :hint="
-                        keyFormData.key && !validateSSHKey(keyFormData.key)
-                          ? 'Invalid SSH key format'
-                          : 'Paste your complete SSH public key here (including the name at the end)'
-                      "
-                      :error="!!(keyFormData.key && !validateSSHKey(keyFormData.key))"
-                      variant="outlined"
-                      density="compact"
-                      rows="3"
-                      auto-grow
-                      @update:model-value="keyTextChanged"
-                    />
-                  </v-col>
-                  <v-col>
+                  <v-col cols="12" sm="4" class="ml-auto">
                     <v-btn
                       type="submit"
                       color="primary"
                       variant="elevated"
-                      :disabled="!keyPayload.name || !keyPayload.key"
+                      :disabled="!keyPayload.key"
                       block
                     >
                       Add SSH Key
@@ -634,6 +597,7 @@ import ConfirmDialog from '@/components/ConfirmDialog.vue'
 import DiffViewer from '@/components/DiffViewer.vue'
 import ErrorMessage from '@/components/ErrorMessage.vue'
 import ResourceBadge from '@/components/ResourceBadge.vue'
+import SshKeyInput from '@/components/SshKeyInput.vue'
 import SwitchButton from '@/components/SwitchButton.vue'
 import TaskLink from '@/components/TaskLink.vue'
 import type { Config } from '@/config'
@@ -926,68 +890,11 @@ let pendingSshKey: SshKeyRead | null = null
 
 // Add-key form state
 const keyFormData = ref({ name: '', key: '' })
-const keyFile = ref<File | null>(null)
-const keyInputMode = ref<'file' | 'text'>('file')
-
 const keyPayload = computed(() => {
   if (!keyFormData.value.name.length || !keyFormData.value.key.length) {
-    return { name: '', key: '' }
+    return { key: '' }
   }
-  return { name: keyFormData.value.name, key: keyFormData.value.key }
-})
-
-const validateSSHKey = (key: string): boolean => {
-  if (!key.trim()) return false
-  const parts = key.trim().split(/\s/)
-  return parts.length === 3
-}
-
-const keyTextChanged = () => {
-  if (!keyFormData.value.key) {
-    keyFormData.value.name = ''
-    return
-  }
-  const parts = keyFormData.value.key.trim().split(/\s/)
-  keyFormData.value.name = parts.length >= 3 ? parts[2].trim() : ''
-}
-
-const keyFileSelected = () => {
-  keyFormData.value.key = ''
-  keyFormData.value.name = ''
-  const file = keyFile.value as File
-  if (!file) return
-  if (file.size > 1024) {
-    notificationStore.showError(
-      `File ${file.name} doesn't appear to be an RSA public file (too large). ${file.size}`,
-    )
-    keyFile.value = null
-    return
-  }
-  const reader = new FileReader()
-  reader.onerror = (evt) => {
-    notificationStore.showError(`File ${file.name} failed to read: ${evt}`)
-    keyFile.value = null
-  }
-  reader.onload = (evt) => {
-    const result = evt.target?.result as string
-    const parts = result.trim().split(/\s/)
-    if (parts.length !== 3) {
-      notificationStore.showError(`File ${file.name} doesn't appear to be an SSH public file.`)
-      keyFile.value = null
-      return
-    }
-    keyFormData.value.key = result.trim()
-    keyFormData.value.name = parts[2].trim()
-  }
-  reader.readAsText(file, 'UTF-8')
-}
-
-watch(keyInputMode, (newMode) => {
-  if (newMode === 'file') {
-    keyFormData.value = { name: '', key: '' }
-  } else {
-    keyFile.value = null
-  }
+  return { key: keyFormData.value.key }
 })
 
 const confirmDeleteSshKey = (sshKey: SshKeyRead) => {
@@ -1029,19 +936,12 @@ const deleteSshKeyAction = async (sshKey: SshKeyRead) => {
 }
 
 const addSshKey = async () => {
-  if (!keyPayload.value.name || !keyPayload.value.key) return
-  if (keyInputMode.value === 'text' && !validateSSHKey(keyFormData.value.key)) {
-    notificationStore.showError(
-      'Invalid SSH key format. Please ensure it starts with a valid key type (ssh-rsa, ssh-ed25519, etc.)',
-    )
-    return
-  }
+  if (!keyPayload.value.key) return
   loadingStore.startLoading('Adding key...')
   const ok = await workersStore.addSshKey(workerName.value, keyPayload.value)
   if (ok) {
-    notificationStore.showSuccess(`Key added! SSH Key "${keyPayload.value.name}" has been added.`)
+    notificationStore.showSuccess(`Key added! SSH Key has been added.`)
     keyFormData.value = { name: '', key: '' }
-    keyFile.value = null
     await refreshData()
   } else {
     for (const err of workersStore.errors) {

--- a/frontend-ui/src/views/WorkersView.vue
+++ b/frontend-ui/src/views/WorkersView.vue
@@ -1,5 +1,12 @@
 <template>
   <div>
+    <div v-if="canCreateWorkers" class="d-flex justify-end mb-4">
+      <v-btn color="primary" @click="createWorkerDialog = true">
+        <v-icon class="mr-2">mdi-plus</v-icon>
+        Create Worker
+      </v-btn>
+    </div>
+
     <v-card v-if="!errors.length" class="mb-4" flat>
       <v-card-text>
         <v-row align="stretch">
@@ -100,14 +107,21 @@
       @toggle-workers-list="toggleWorkersList"
     />
 
+    <CreateWorkerDialog
+      v-model="createWorkerDialog"
+      @created="loadData(paginator.limit, paginator.skip, false)"
+    />
+
     <ErrorMessage v-for="error in errors" :key="error" :message="error" />
   </div>
 </template>
 
 <script setup lang="ts">
+import CreateWorkerDialog from '@/components/CreateWorkerDialog.vue'
 import ErrorMessage from '@/components/ErrorMessage.vue'
 import WorkersTable from '@/components/WorkersTable.vue'
 
+import { useAuthStore } from '@/stores/auth'
 import { useLoadingStore } from '@/stores/loading'
 import { useNotificationStore } from '@/stores/notification'
 import { useTasksStore } from '@/stores/tasks'
@@ -124,10 +138,12 @@ const workersStore = useWorkersStore()
 const tasksStore = useTasksStore()
 const notificationStore = useNotificationStore()
 const loadingStore = useLoadingStore()
+const authStore = useAuthStore()
 const router = useRouter()
 const route = useRoute()
 
 // Reactive state
+const createWorkerDialog = ref(false)
 const errors = ref<string[]>([])
 const intervalId = ref<number | null>(null)
 const runningTasks = ref<TaskLight[]>([])
@@ -154,6 +170,8 @@ const paginator = ref({
 const onlineWorkers = computed(() => workers.value.filter((worker) => worker.status === 'online'))
 const filteredWorkers = computed(() => (showingAll.value ? workers.value : onlineWorkers.value))
 const workerNames = computed(() => filteredWorkers.value.map((worker) => worker.name))
+
+const canCreateWorkers = computed(() => authStore.hasPermission('workers', 'create'))
 
 const tasks = computed(() => {
   return runningTasks.value.filter((task) => workerNames.value.indexOf(task.worker_name) !== -1)


### PR DESCRIPTION
## Rationale

This PR enhances the API to be able to create new workers (and their associated accounts). Accordingly, the UI has an interface to invoke this endpoint

<img width="1141" height="752" alt="Screenshot_20260409_061320" src="https://github.com/user-attachments/assets/f1db30e3-3fbc-4984-a555-2917920bff62" />


## Changes
- add API to create workers
- refactor logic to create ssh key by moving validation to the DB code
- refactor SSH input logic into a component and share between CreateWorkerDialog and view for editing worker
- remove `worker` role from constants (used to create role options in user update and creation views)

This closes #1816
This closes #1817 