### PR TITLE
Reorganize user details screen

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/accounts/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/accounts/logic.py
@@ -58,12 +58,14 @@ def require_permission_if_not_self(namespace: str, name: str):
     ):
         if (
             is_valid_uuid(account_identifier)
-            and account_identifier != str(current_account.id)
-        ) or (account_identifier != current_account.username):
-            if not check_account_permission(
-                current_account, namespace=namespace, name=name
-            ):
-                raise ForbiddenError("You are not allowed to access this resource")
+            and account_identifier == str(current_account.id)
+        ) or (account_identifier == current_account.username):
+            return
+
+        if not check_account_permission(
+            current_account, namespace=namespace, name=name
+        ):
+            raise ForbiddenError("You are not allowed to access this resource")
 
     return _require_permission_if_not_self
 
@@ -148,15 +150,11 @@ def get_account(
 
 @router.patch(
     "/{account_identifier}",
-    dependencies=[
-        Depends(require_permission_if_not_self(namespace="accounts", name="update"))
-    ],
+    dependencies=[Depends(require_permission(namespace="accounts", name="update"))],
 )
 @users_router.patch(
     "/{account_identifier}",
-    dependencies=[
-        Depends(require_permission_if_not_self(namespace="accounts", name="update"))
-    ],
+    dependencies=[Depends(require_permission(namespace="accounts", name="update"))],
 )
 def update_account(
     account_identifier: Annotated[str, Path()],
@@ -174,15 +172,11 @@ def update_account(
 
 @router.delete(
     "/{account_identifier}",
-    dependencies=[
-        Depends(require_permission_if_not_self(namespace="accounts", name="delete"))
-    ],
+    dependencies=[Depends(require_permission(namespace="accounts", name="delete"))],
 )
 @users_router.delete(
     "/{account_identifier}",
-    dependencies=[
-        Depends(require_permission_if_not_self(namespace="accounts", name="delete"))
-    ],
+    dependencies=[Depends(require_permission(namespace="accounts", name="delete"))],
 )
 def delete_account(
     account_identifier: Annotated[str, Path()],
@@ -225,9 +219,15 @@ def update_account_password(
     if not account.username:
         raise BadRequestError("Only accounts with username can have passwords.")
 
-    # Accounts changing their own password must provide their password if one exists and
-    # it must match the existing one
-    if current_account.id == account.id and account.password_hash is not None:
+    # Accounts without necessary permissions that are changing their own password must
+    #  provide their password if one exists and it must match the existing one
+    if (
+        current_account.id == account.id
+        and account.password_hash is not None
+        and not check_account_permission(
+            current_account, namespace="accounts", name="change_password"
+        )
+    ):
         if password_update.current is None:
             raise BadRequestError("You must enter your current password.")
 

--- a/frontend-ui/src/components/UpdateUser.vue
+++ b/frontend-ui/src/components/UpdateUser.vue
@@ -1,15 +1,42 @@
 <template>
-  <div>
-    <!-- Update User Form -->
-    <v-card class="mb-4">
-      <v-card-text>
-        <v-form @submit.prevent="updateUser">
-          <v-row class="justify-end">
+  <v-card class="mb-4">
+    <v-card-text>
+      <v-form @submit.prevent="submitForm">
+        <v-row>
+          <v-col cols="12" md="6">
+            <v-text-field
+              v-model="form.display_name"
+              label="Display Name"
+              hint="User's display name"
+              placeholder="Display Name"
+              variant="outlined"
+              density="compact"
+              persistent-hint
+              :error-messages="displayNameError ? [displayNameError] : []"
+              required
+            />
+          </v-col>
+
+          <v-col cols="12" md="6">
+            <v-select
+              v-model="form.role"
+              :items="roles"
+              label="Role"
+              variant="outlined"
+              density="compact"
+            />
+          </v-col>
+        </v-row>
+
+        <template v-if="hasLocalAuth">
+          <v-divider class="my-4"></v-divider>
+          <div class="text-subtitle-1 mb-2 font-weight-bold">Local Authentication</div>
+          <v-row>
             <v-col cols="12" md="6">
               <v-text-field
                 v-model="form.username"
                 label="Username"
-                hint="Username for authentication"
+                hint="Username for local authentication"
                 placeholder="username"
                 variant="outlined"
                 density="compact"
@@ -20,27 +47,24 @@
 
             <v-col cols="12" md="6">
               <v-text-field
-                v-model="form.display_name"
-                label="Display Name"
-                hint="User's display name"
-                placeholder="Display Name"
+                v-model="form.password"
+                label="New Password"
+                hint="Password for local authentication (leave unchanged to keep current, clear to remove)"
+                placeholder="Enter new password"
                 variant="outlined"
                 density="compact"
                 persistent-hint
-                :error-messages="displayNameError ? [displayNameError] : []"
-                required
+                append-inner-icon="mdi-refresh"
+                @click:append-inner="generateNewPassword"
               />
             </v-col>
+          </v-row>
+        </template>
 
-            <v-col cols="12" md="6">
-              <v-select
-                v-model="form.role"
-                :items="roles"
-                label="Role"
-                variant="outlined"
-                density="compact"
-              />
-            </v-col>
+        <template v-if="hasOauth">
+          <v-divider class="my-4"></v-divider>
+          <div class="text-subtitle-1 mb-2 font-weight-bold">External Identity Provider</div>
+          <v-row>
             <v-col cols="12" md="6">
               <v-text-field
                 v-model="form.idp_sub"
@@ -52,67 +76,42 @@
                 persistent-hint
               />
             </v-col>
-            <v-col cols="12" md="6">
-              <v-btn type="submit" color="primary" variant="elevated" :disabled="!payload" block>
-                Update User Profile
-              </v-btn>
-            </v-col>
           </v-row>
+        </template>
 
-          <v-row v-if="isCustomRole">
-            <v-col cols="12">
-              <v-textarea
-                v-model="form.customScope"
-                label="Custom Scope (JSON)"
-                placeholder='{"tasks": {"read": true, "create": false}, "recipes": {"read": true}}'
-                hint="Enter the custom scope as JSON. Include all namespaces (tasks, recipes, users, workers, zim, requested_tasks, offliners) with their permissions."
-                persistent-hint
-                :error-messages="customScopeError ? [customScopeError] : []"
-                variant="outlined"
-                density="compact"
-                rows="10"
-                auto-grow
-              />
-            </v-col>
-          </v-row>
-        </v-form>
-      </v-card-text>
-    </v-card>
+        <v-row v-if="isCustomRole">
+          <v-col cols="12">
+            <v-textarea
+              v-model="form.customScope"
+              label="Custom Scope (JSON)"
+              placeholder='{"tasks": {"read": true, "create": false}, "recipes": {"read": true}}'
+              hint="Enter the custom scope as JSON. Include all namespaces (tasks, recipes, accounts, workers, zim, requested_tasks, offliners) with their permissions."
+              persistent-hint
+              :error-messages="customScopeError ? [customScopeError] : []"
+              variant="outlined"
+              density="compact"
+              rows="10"
+              auto-grow
+            />
+          </v-col>
+        </v-row>
 
-    <!-- Change Password Form (only if user has username) -->
-    <v-card v-if="props.user.username" class="mb-4">
-      <v-card-text>
-        <v-form
-          @submit.prevent="
-            emit('change-password', form.password.trim() ? form.password.trim() : null)
-          "
-        >
-          <v-row>
-            <v-col cols="12" sm="8" md="6">
-              <v-text-field
-                v-model="form.password"
-                label="Password"
-                placeholder="Enter new password or leave empty to clear"
-                variant="outlined"
-                density="compact"
-                hide-details
-              />
-            </v-col>
-            <v-col>
-              <v-btn type="submit" color="primary" variant="elevated" block>
-                Change Password
-              </v-btn>
-            </v-col>
-          </v-row>
-        </v-form>
-      </v-card-text>
-    </v-card>
-  </div>
+        <v-row class="mt-4">
+          <v-col cols="12">
+            <v-btn type="submit" color="primary" variant="elevated" :disabled="!hasChanges" block>
+              Update User Profile
+            </v-btn>
+          </v-col>
+        </v-row>
+      </v-form>
+    </v-card-text>
+  </v-card>
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, inject, onMounted, ref, watch } from 'vue'
 
+import type { Config } from '@/config'
 import constants from '@/constants'
 import { generatePassword } from '@/utils/browsers'
 import type { User } from '@/types/user'
@@ -139,6 +138,15 @@ const emit = defineEmits<{
 }>()
 
 const roles = constants.ROLES
+const config = inject<Config>(constants.config)
+
+const hasLocalAuth = computed(
+  () => config?.LOGIN_MODES.includes('local') || !!props.user.username || props.user.has_password,
+)
+
+const hasOauth = computed(() => config?.LOGIN_MODES.includes('oauth') || !!props.user.idp_sub)
+
+const PASSWORD_PLACEHOLDER = '******'
 
 // Reactive data
 const form = ref({
@@ -166,6 +174,10 @@ const displayNameError = computed(() => {
     return 'Display name is required'
   }
   return null
+})
+
+const passwordChanged = computed(() => {
+  return form.value.password !== (props.user.has_password ? PASSWORD_PLACEHOLDER : '')
 })
 
 const payload = computed(() => {
@@ -234,8 +246,9 @@ const customScopeError = computed(() => {
   }
 })
 
-// Simple password generator
-const genPassword = () => generatePassword(8)
+const generateNewPassword = () => {
+  form.value.password = generatePassword(8)
+}
 
 // Watchers
 // Watch for role changes to help populate custom scope template
@@ -251,9 +264,17 @@ watch(
 )
 
 // Methods
-const updateUser = () => {
-  if (!payload.value) return
-  emit('update-user', payload.value)
+const hasChanges = computed(() => {
+  return payload.value !== null || passwordChanged.value
+})
+
+const submitForm = () => {
+  if (payload.value) {
+    emit('update-user', payload.value)
+  }
+  if (passwordChanged.value) {
+    emit('change-password', form.value.password.trim() ? form.value.password.trim() : null)
+  }
 }
 
 const initializeForm = () => {
@@ -272,7 +293,7 @@ const initializeForm = () => {
     username: props.user.username || '',
     display_name: props.user.display_name || '',
     role,
-    password: genPassword(),
+    password: props.user.has_password ? PASSWORD_PLACEHOLDER : '',
     customScope,
     idp_sub: props.user.idp_sub || '',
   }

--- a/frontend-ui/src/views/ChangePasswordView.vue
+++ b/frontend-ui/src/views/ChangePasswordView.vue
@@ -8,7 +8,7 @@
 <template>
   <v-container class="fill-height">
     <v-row justify="center" align="center">
-      <v-col cols="12" sm="8" md="6" lg="4">
+      <v-col cols="12" sm="8">
         <v-card class="elevation-12">
           <v-card-title class="text-center text-h5 py-4"> Change Password </v-card-title>
 
@@ -137,11 +137,7 @@ const changePassword = async () => {
 
   if (success) {
     notificationStore.showSuccess('Password changed successfully')
-    if (window.history.length > 1) {
-      router.back()
-    } else {
-      router.push({ name: 'home' })
-    }
+    router.push({ name: 'home' })
   } else {
     error.value = 'Failed to change password'
     for (const error of userStore.errors) {

--- a/frontend-ui/src/views/UserView.vue
+++ b/frontend-ui/src/views/UserView.vue
@@ -5,14 +5,19 @@
 
 <template>
   <v-container>
+    <ErrorMessage
+      v-if="!canReadAccounts"
+      message="You don't have permission to view user accounts."
+    />
+
     <!-- Loading state when data hasn't been loaded yet -->
-    <div v-if="!dataLoaded && loadingStore.isLoading" class="text-center pa-8">
+    <div v-if="canReadAccounts && !dataLoaded && loadingStore.isLoading" class="text-center pa-8">
       <v-progress-circular indeterminate size="64" />
       <div class="mt-4 text-body-1">{{ loadingStore.loadingText }}</div>
     </div>
 
     <!-- Content only shown when data is loaded -->
-    <div v-if="dataLoaded">
+    <div v-if="canReadAccounts && dataLoaded">
       <v-row>
         <v-col cols="12">
           <h2 class="text-h4 mb-4">
@@ -27,9 +32,10 @@
             <!-- Tabs -->
             <v-tabs v-model="selectedTab" color="primary" class="mb-4">
               <v-tab value="details" :to="{ name: 'user-detail', params: { userId: userId } }">
-                Profile
+                View
               </v-tab>
               <v-tab
+                v-if="canUpdateAccounts"
                 value="edit"
                 :to="{
                   name: 'user-detail-tab',
@@ -57,10 +63,76 @@
               <v-window-item value="details">
                 <v-card flat>
                   <v-card-text>
-                    <!-- IDP Sub -->
-                    <p v-if="user.idp_sub" class="mb-4">
-                      <strong>IDP Sub:</strong> <code>{{ user.idp_sub }}</code>
-                    </p>
+                    <v-row class="mb-4">
+                      <!-- Basic Info Card -->
+                      <v-col cols="12">
+                        <v-card variant="outlined" class="h-100">
+                          <v-card-title class="text-subtitle-1">
+                            <v-icon class="mr-2">mdi-card-account-details</v-icon>
+                            Basic Information
+                          </v-card-title>
+                          <v-list density="compact">
+                            <v-list-item>
+                              <v-list-item-title>
+                                <div class="d-flex align-center mt-1">
+                                  <span class="mr-2">Display Name:</span>
+                                  <span class="font-weight-medium">{{ user.display_name }}</span>
+                                </div>
+                                <div class="d-flex align-center mt-1">
+                                  <span class="mr-2">Role:</span>
+                                  <code>{{ user.role }}</code>
+                                </div>
+                              </v-list-item-title>
+                            </v-list-item>
+                          </v-list>
+                        </v-card>
+                      </v-col>
+
+                      <!-- Authentication Card -->
+                      <v-col cols="12" v-if="user.username || user.idp_sub">
+                        <v-card variant="outlined" class="h-100">
+                          <v-card-title class="text-subtitle-1">
+                            <v-icon class="mr-2">mdi-shield-key-outline</v-icon>
+                            Authentication
+                          </v-card-title>
+                          <v-list density="compact">
+                            <v-list-item v-if="user.username">
+                              <v-list-item-subtitle>Local Authentication</v-list-item-subtitle>
+                              <v-list-item-title>
+                                <div class="d-flex align-center mt-1">
+                                  <span class="mr-2">Username:</span>
+                                  <code v-if="user.username">{{ user.username }}</code>
+                                  <span v-else class="text-medium-emphasis text-body-2"
+                                    >Not set</span
+                                  >
+                                </div>
+                                <div class="d-flex align-center mt-1">
+                                  <span class="mr-2">Password:</span>
+                                  <span class="text-body-2">{{
+                                    user.has_password ? '**********' : 'Not set'
+                                  }}</span>
+                                </div>
+                              </v-list-item-title>
+                            </v-list-item>
+
+                            <v-divider
+                              class="my-2"
+                              v-if="user.idp_sub && user.username"
+                            ></v-divider>
+
+                            <v-list-item v-if="user.idp_sub">
+                              <v-list-item-subtitle
+                                >External Identity Provider</v-list-item-subtitle
+                              >
+                              <v-list-item-title class="mt-1">
+                                <span class="mr-2">IDP Sub:</span>
+                                <code>{{ user.idp_sub }}</code>
+                              </v-list-item-title>
+                            </v-list-item>
+                          </v-list>
+                        </v-card>
+                      </v-col>
+                    </v-row>
 
                     <!-- Permissions List -->
                     <v-card class="mb-4" variant="outlined">
@@ -186,6 +258,8 @@ const dataLoaded = ref(false)
 // Computed properties
 const scope = computed(() => user.value?.scope || {})
 
+const canReadAccounts = computed(() => authStore.hasPermission('accounts', 'read'))
+const canUpdateAccounts = computed(() => authStore.hasPermission('accounts', 'update'))
 const canDeleteUser = computed(() => authStore.hasPermission('accounts', 'delete'))
 
 const getNamespaceIcon = (namespace: string): string => {
@@ -242,7 +316,9 @@ const getAllPermissionsForNamespace = (namespace: string): string[] => {
 const changePassword = async (password: string | null) => {
   loadingStore.startLoading('Changing password...')
 
-  const success = await userStore.changePassword(props.userId, { new: password })
+  const success = await userStore.changePassword(props.userId, {
+    new: password,
+  })
   if (success) {
     if (password === null) {
       notificationStore.showSuccess(
@@ -302,6 +378,12 @@ const deleteUser = async () => {
 }
 
 const loadUser = async () => {
+  if (!canReadAccounts.value) {
+    notificationStore.showError('You do not have permission to read user accounts.')
+    router.push({ name: 'home' })
+    return
+  }
+
   loadingStore.startLoading('Fetching user...')
 
   try {
@@ -325,6 +407,10 @@ const loadUser = async () => {
 }
 
 const refreshData = async () => {
+  if (!canReadAccounts.value) {
+    return
+  }
+
   if (!user.value) {
     dataLoaded.value = false
   }
@@ -357,6 +443,9 @@ watch(
 watch(
   () => props.userId,
   async () => {
+    if (!canReadAccounts.value) {
+      return
+    }
     // Reset data and reload the new user
     user.value = null
     selectedTab.value = 'details'
@@ -366,6 +455,9 @@ watch(
 
 // Lifecycle
 onMounted(async () => {
+  if (!canReadAccounts.value) {
+    return
+  }
   loadingStore.startLoading('Fetching user...')
   await loadUser()
   loadingStore.stopLoading()


### PR DESCRIPTION
## Rationale
This PR re-organizes the user details screen by including additional information in the view tab
<img width="1190" height="699" alt="Screenshot_20260414_100014" src="https://github.com/user-attachments/assets/0d15c015-c445-4386-b6fc-8e3343f242b0" />

<img width="1210" height="768" alt="Screenshot_20260410_085935" src="https://github.com/user-attachments/assets/c4226457-25a0-4313-b592-bfcb5768e4ba" />


## Changes
- show display name, role and authentication settings in user details view
- use single update button to update both user basic information and password
- require current password when it's the same that's changing the password

This closes #1818
