### PR TITLE
require specific fields during account creation based on auth mode

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/accounts/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/accounts/logic.py
@@ -1,5 +1,5 @@
 from http import HTTPStatus
-from typing import Annotated
+from typing import Annotated, cast
 
 from fastapi import APIRouter, Depends, Path, Query, Response
 from sqlalchemy.orm import Session
@@ -114,10 +114,15 @@ def create_account(
         account = db_create_account(
             db_session,
             username=user_schema.username,
-            display_name=user_schema.username,
-            password_hash=generate_password_hash(user_schema.password),
+            display_name=cast(str, user_schema.display_name),
+            password_hash=(
+                generate_password_hash(user_schema.password)
+                if user_schema.password
+                else None
+            ),
             scope=None,
             role=user_schema.role,
+            idp_sub=user_schema.idp_sub,
         )
     except RecordAlreadyExistsError as exc:
         raise BadRequestError("Account already exists") from exc

--- a/backend/src/zimfarm_backend/api/routes/accounts/models.py
+++ b/backend/src/zimfarm_backend/api/routes/accounts/models.py
@@ -1,3 +1,8 @@
+from typing import Self
+from uuid import UUID
+
+from pydantic import Field, model_validator
+
 from zimfarm_backend.common.roles import RoleEnum
 from zimfarm_backend.common.schemas import BaseModel
 from zimfarm_backend.common.schemas.fields import (
@@ -22,9 +27,33 @@ class AccountCreateSchema(BaseModel):
     Schema for creating an account
     """
 
-    username: NotEmptyString
-    password: NotEmptyString
+    username: NotEmptyString | None = Field(default=None, min_length=3)
+    display_name: NotEmptyString | None = Field(default=None, min_length=3)
+    password: NotEmptyString | None = Field(default=None, min_length=8)
     role: RoleEnum
+    idp_sub: UUID | None = None
+
+    @model_validator(mode="after")
+    def check_username_and_displayname(self) -> Self:
+        if not (self.username or self.display_name):
+            raise ValueError("Display name or username must be set.")
+
+        if not self.display_name:
+            self.display_name = self.username
+
+        return self
+
+    @model_validator(mode="after")
+    def check_role(self) -> Self:
+        if self.role == RoleEnum.WORKER:
+            raise ValueError("Worker accounts cannot be created.")
+        return self
+
+    @model_validator(mode="after")
+    def check_username_and_password(self) -> Self:
+        if self.password and not self.username:
+            raise ValueError("Username must be set when password is set.")
+        return self
 
 
 class AccountsGetSchema(BaseModel):

--- a/backend/tests/routes/test_account.py
+++ b/backend/tests/routes/test_account.py
@@ -1,13 +1,81 @@
 from collections.abc import Callable
+from contextlib import nullcontext as does_not_raise
 from http import HTTPStatus
 
 import pytest
+from _pytest.python_api import RaisesContext
 from fastapi.testclient import TestClient
+from pydantic import ValidationError
 from sqlalchemy.orm import Session as OrmSession
 
+from zimfarm_backend.api.routes.accounts.models import AccountCreateSchema
 from zimfarm_backend.api.token import generate_access_token
 from zimfarm_backend.common import getnow
+from zimfarm_backend.common.roles import RoleEnum
 from zimfarm_backend.db.models import Account
+
+
+@pytest.mark.parametrize(
+    "username,display_name,password,role,expected",
+    [
+        pytest.param(
+            None,
+            None,
+            "testpassword",
+            RoleEnum.ADMIN,
+            pytest.raises(ValidationError),
+            id="no-username-and-displayname",
+        ),
+        pytest.param(
+            "testuser",
+            None,
+            "testpassword",
+            RoleEnum.WORKER,
+            pytest.raises(ValidationError),
+            id="worker-role",
+        ),
+        pytest.param(
+            None,
+            "Test User",
+            "testpassword",
+            RoleEnum.EDITOR,
+            pytest.raises(ValidationError),
+            id="no-username-with-password",
+        ),
+        pytest.param(
+            "testuser",
+            "Test User",
+            "testpassword",
+            RoleEnum.EDITOR,
+            does_not_raise(),
+            id="valid-inputs",
+        ),
+    ],
+)
+def test_account_creation_schema(
+    username: str | None,
+    display_name: str | None,
+    password: str | None,
+    role: RoleEnum,
+    expected: RaisesContext[Exception],
+):
+    with expected:
+        AccountCreateSchema(
+            username=username,
+            display_name=display_name,
+            password=password,
+            role=role,
+        )
+
+
+def test_display_username_set_from_username_if_no_display_name():
+    account = AccountCreateSchema(
+        username="testuser",
+        role=RoleEnum.ADMIN,
+        password="testpassword",
+    )
+
+    assert account.display_name is not None
 
 
 def test_list_accounts_no_auth(client: TestClient):
@@ -131,7 +199,7 @@ def test_create_account(client: TestClient, account: Account):
         headers={"Authorization": f"Bearer {access_token}"},
         json={
             "username": "test",
-            "password": "test",
+            "password": "testpassword",
             "role": "admin",
         },
     )
@@ -149,7 +217,7 @@ def test_create_account_duplicate(client: TestClient, account: Account):
         headers={"Authorization": f"Bearer {access_token}"},
         json={
             "username": account.username,
-            "password": "test",
+            "password": "testpassword",
             "role": "admin",
         },
     )

--- a/frontend-ui/src/stores/user.ts
+++ b/frontend-ui/src/stores/user.ts
@@ -24,17 +24,25 @@ export const useUserStore = defineStore('user', () => {
     localStorage.setItem('users-table-limit', limit.toString())
   }
 
-  const createUser = async (username: string, role: string, password: string) => {
+  const createUser = async (payload: {
+    display_name: string
+    role: string
+    username?: string
+    password?: string
+    idp_sub?: string
+  }) => {
     const service = await authStore.getApiService('accounts')
     try {
       const response = await service.post<
-        { username: string; role: string; password: string },
+        {
+          display_name: string
+          role: string
+          username?: string
+          password?: string
+          idp_sub?: string
+        },
         User
-      >('', {
-        username,
-        role,
-        password,
-      })
+      >('', payload)
       errors.value = []
       return response
     } catch (error) {

--- a/frontend-ui/src/views/UsersView.vue
+++ b/frontend-ui/src/views/UsersView.vue
@@ -69,9 +69,9 @@
             <v-row>
               <v-col cols="12">
                 <v-text-field
-                  v-model="form.username"
-                  label="Username"
-                  placeholder="Enter username"
+                  v-model="form.display_name"
+                  label="Display Name"
+                  placeholder="Enter display name"
                   variant="outlined"
                   density="compact"
                   hide-details="auto"
@@ -93,18 +93,44 @@
                 />
               </v-col>
 
-              <v-col cols="12">
+              <v-col cols="12" v-if="showLocalLogin">
+                <v-text-field
+                  v-model="form.username"
+                  label="Username"
+                  placeholder="Enter username"
+                  hint="Used for local authentication"
+                  persistent-hint
+                  variant="outlined"
+                  density="compact"
+                  :validate-on="'blur'"
+                  :rules="
+                    !showOAuthLogin || form.password ? [rules.required, rules.minLength(3)] : []
+                  "
+                />
+              </v-col>
+
+              <v-col cols="12" v-if="showLocalLogin">
                 <v-text-field
                   v-model="form.password"
                   label="Password"
                   placeholder="Enter password or generate one"
+                  hint="Used for local authentication"
+                  persistent-hint
                   variant="outlined"
                   density="compact"
-                  hide-details="auto"
                   :type="showPassword ? 'text' : 'password'"
-                  :rules="[rules.required, rules.minLength(8)]"
+                  :rules="!showOAuthLogin ? [rules.required, rules.minLength(8)] : []"
                 >
                   <template #append-inner>
+                    <v-btn
+                      icon
+                      size="small"
+                      variant="text"
+                      @click="generateNewPassword"
+                      tabindex="-1"
+                    >
+                      <v-icon>mdi-refresh</v-icon>
+                    </v-btn>
                     <v-btn
                       icon
                       size="small"
@@ -118,11 +144,18 @@
                 </v-text-field>
               </v-col>
 
-              <v-col cols="12">
-                <v-btn variant="outlined" color="primary" block @click="generateNewPassword">
-                  <v-icon class="mr-2">mdi-refresh</v-icon>
-                  Generate New Password
-                </v-btn>
+              <v-col cols="12" v-if="showOAuthLogin">
+                <v-text-field
+                  v-model="form.idp_sub"
+                  label="IDP Sub (UUID)"
+                  placeholder="00000000-0000-0000-0000-000000000000"
+                  hint="Identifier issued by external identity provider"
+                  persistent-hint
+                  variant="outlined"
+                  density="compact"
+                  :validate-on="'blur'"
+                  :rules="!showLocalLogin ? [rules.required] : []"
+                />
               </v-col>
             </v-row>
           </v-form>
@@ -148,9 +181,10 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from 'vue'
+import { computed, inject, onMounted, ref, watch } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
 
+import type { Config } from '@/config'
 import ErrorMessage from '@/components/ErrorMessage.vue'
 import UsersTable from '@/components/UsersTable.vue'
 import constants from '@/constants'
@@ -162,6 +196,12 @@ import type { User } from '@/types/user'
 import { generatePassword } from '@/utils/browsers'
 
 const roles = constants.ROLES.filter((role) => role !== 'custom')
+
+// Inject config
+const config = inject<Config>(constants.config)
+if (!config) {
+  throw new Error('Config is not defined')
+}
 
 // Simple password generator function
 const genPassword = () => generatePassword(8)
@@ -195,14 +235,19 @@ const paginator = ref({
 
 // Form data
 const form = ref({
+  display_name: '',
   username: '',
   role: 'editor' as const,
   password: '',
+  idp_sub: '',
 })
 
 const showPassword = ref(false)
 
 // Computed properties
+const showLocalLogin = computed(() => config.LOGIN_MODES.includes('local'))
+const showOAuthLogin = computed(() => config.LOGIN_MODES.includes('oauth'))
+
 const canReadUsers = computed(() => authStore.hasPermission('accounts', 'read'))
 
 const toggleText = computed(() => (showingViewers.value ? 'Hide Viewers' : 'Show Viewers'))
@@ -210,7 +255,20 @@ const toggleText = computed(() => (showingViewers.value ? 'Hide Viewers' : 'Show
 const canCreateUsers = computed(() => authStore.hasPermission('accounts', 'create'))
 
 const isFormValid = computed(() => {
-  return form.value.username && form.value.role && form.value.password
+  if (!form.value.display_name || !form.value.role) return false
+
+  if (showLocalLogin.value && !showOAuthLogin.value) {
+    if (!form.value.username || !form.value.password) return false
+  }
+
+  if (form.value.password && !form.value.username) {
+    return false
+  }
+
+  if (showOAuthLogin.value && !showLocalLogin.value) {
+    if (!form.value.idp_sub) return false
+  }
+  return true
 })
 
 // Table headers
@@ -249,24 +307,40 @@ const createUser = async () => {
   isCreating.value = true
   loadingStore.startLoading('Creating user...')
 
-  const response = await userStore.createUser(
-    form.value.username,
-    form.value.role,
-    form.value.password,
-  )
+  const payload: {
+    display_name: string
+    role: string
+    username?: string
+    password?: string
+    idp_sub?: string
+  } = {
+    display_name: form.value.display_name,
+    role: form.value.role,
+  }
+  if (showLocalLogin.value) {
+    payload.username = form.value.username
+    payload.password = form.value.password
+  }
+  if (showOAuthLogin.value && form.value.idp_sub) {
+    payload.idp_sub = form.value.idp_sub
+  }
+
+  const response = await userStore.createUser(payload)
 
   if (response) {
     // Show success notification
-    notificationStore.showSuccess(
-      `User "${response.display_name}" has been created with password "${form.value.password}".`,
-      8000,
-    )
+    const msg = showLocalLogin.value
+      ? `User "${response.display_name}" has been created with password "${form.value.password}".`
+      : `User "${response.display_name}" has been created.`
+    notificationStore.showSuccess(msg, 8000)
 
     // Reset form
     form.value = {
+      display_name: '',
       username: '',
       role: 'editor' as const,
       password: '',
+      idp_sub: '',
     }
     formRef.value?.reset()
     showPassword.value = false
@@ -324,9 +398,11 @@ const handleSearchChange = async () => {
 const closeCreateDialog = () => {
   showCreateDialog.value = false
   form.value = {
+    display_name: '',
     username: '',
     role: 'editor' as const,
     password: '',
+    idp_sub: '',
   }
   formRef.value?.reset()
   showPassword.value = false
@@ -361,10 +437,22 @@ onMounted(async () => {
 
 // Watch for dialog open to generate password
 watch(showCreateDialog, (newValue) => {
-  if (newValue) {
+  if (newValue && showLocalLogin.value) {
     generateNewPassword()
   }
 })
+
+// Auto-fill username from display name if it hasn't been manually edited
+watch(
+  () => form.value.display_name,
+  (newName, oldName) => {
+    if (showLocalLogin.value) {
+      if (!form.value.username || form.value.username === oldName) {
+        form.value.username = newName
+      }
+    }
+  },
+)
 
 watch(
   () => router.currentRoute.value.query,


### PR DESCRIPTION
## Rationale
This PR enhances the user creation screen to require speicifc fields depending on auth mode. It also enhances the API request schema to restrict the range of input values.
<img width="1106" height="714" alt="Screenshot_20260410_124340" src="https://github.com/user-attachments/assets/b2841910-6bf7-4223-86be-083d4f037008" />


## Changes
- require idp_sub when only oauth mode is configured and make optional when both auth modes configured
- require username and password when only local mode is configured and make optional when both auth modes configured 
- make username mandatory when password is set irrespective of configured mode
- set display name from username when it is missing

This closes #1820 
