### PR TITLE
authenticate workers with ssh bearer tokens

### DIFF
--- a/backend/src/zimfarm_backend/api/routes/auth/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/auth/logic.py
@@ -116,8 +116,8 @@ def refresh_access_token(
     return _refresh_access_token(db_session, request.refresh_token, response)
 
 
-@router.post("/ssh-authorize")
-def authenticate_worker_with_ssh_keys(
+@router.post("/ssh-authorize", deprecated=True)
+def authenticate_account_with_ssh_keys(
     db_session: Annotated[OrmSession, Depends(gen_dbsession)],
     x_sshauth_message: Annotated[
         str,

--- a/backend/src/zimfarm_backend/api/routes/dependencies.py
+++ b/backend/src/zimfarm_backend/api/routes/dependencies.py
@@ -27,38 +27,48 @@ AuthorizationCredentials = Annotated[
 ]
 
 
-def get_jwt_claims_or_none(
-    authorization: AuthorizationCredentials,
-) -> JWTClaims | None:
-    """
-    Get the JWT claims or None if the account is not authenticated.
+def get_jwt_claims_or_none_with_session(
+    session_type: Literal["auto", "manual"] = "auto",
+):
+    def _get_jwt_claims_or_none(
+        authorization: AuthorizationCredentials,
+        session: Annotated[
+            OrmSession,
+            Depends(gen_dbsession if session_type == "auto" else gen_manual_dbsession),
+        ],
+    ) -> JWTClaims | None:
+        """
+        Get the JWT claims or None if the account is not authenticated.
+        """
 
-    Tries to decode as Zimfarm token first, then as Kiwix token.
-    """
-    if authorization is None:
-        return None
-    token = authorization.credentials
+        if authorization is None:
+            return None
+        token = authorization.credentials
 
-    try:
-        return token_decoder.decode(token)
-    except jwt_exceptions.ExpiredSignatureError as exc:
-        raise UnauthorizedError("Token has expired.") from exc
-    except (jwt_exceptions.InvalidTokenError, jwt_exceptions.PyJWTError) as exc:
-        raise UnauthorizedError("Invalid token") from exc
-    except ValueError as exc:
-        raise UnauthorizedError(exc.args[0]) from exc
-    except Exception as exc:
-        raise UnauthorizedError("Unable to verify token") from exc
+        try:
+            return token_decoder.decode(token, session)
+        except jwt_exceptions.ExpiredSignatureError as exc:
+            raise UnauthorizedError("Token has expired.") from exc
+        except (jwt_exceptions.InvalidTokenError, jwt_exceptions.PyJWTError) as exc:
+            raise UnauthorizedError("Invalid token") from exc
+        except ValueError as exc:
+            raise UnauthorizedError(exc.args[0]) from exc
+        except Exception as exc:
+            raise UnauthorizedError("Unable to verify token") from exc
+
+    return _get_jwt_claims_or_none
 
 
 def get_current_account_or_none_with_session(
     session_type: Literal["auto", "manual"] = "auto",
 ):
     def _get_current_account_or_none(
-        claims: Annotated[JWTClaims | None, Depends(get_jwt_claims_or_none)],
         session: Annotated[
             OrmSession,
             Depends(gen_dbsession if session_type == "auto" else gen_manual_dbsession),
+        ],
+        claims: Annotated[
+            JWTClaims | None, Depends(get_jwt_claims_or_none_with_session(session_type))
         ],
     ) -> Account | None:
         if claims is None:
@@ -122,6 +132,8 @@ get_current_account_or_none = get_current_account_or_none_with_session(
     session_type="auto"
 )
 get_current_account = get_current_account_with_session(session_type="auto")
+
+get_jwt_claims_or_none = get_jwt_claims_or_none_with_session(session_type="auto")
 
 
 def require_permission(*, namespace: str, name: str):

--- a/backend/src/zimfarm_backend/api/token.py
+++ b/backend/src/zimfarm_backend/api/token.py
@@ -1,12 +1,16 @@
 import abc
+import base64
+import binascii
 import datetime
 import uuid
+from typing import NamedTuple
 
 import jwt
 from jwt import PyJWKClient
 from jwt import exceptions as jwt_exceptions
 from pydantic import Field
 from pydantic import ValidationError as PydanticValidationError
+from sqlalchemy.orm import Session as OrmSession
 
 from zimfarm_backend import logger
 from zimfarm_backend.api.constants import (
@@ -21,7 +25,19 @@ from zimfarm_backend.api.constants import (
     OAUTH_SESSION_AUDIENCE_ID,
     OAUTH_SESSION_LOGIN_REQUIRE_2FA,
 )
+from zimfarm_backend.common import getnow
+from zimfarm_backend.common.constants import MESSAGE_VALIDITY_DURATION
 from zimfarm_backend.common.schemas import BaseModel
+from zimfarm_backend.db.exceptions import RecordDoesNotExistError
+from zimfarm_backend.db.worker import get_worker
+from zimfarm_backend.exceptions import PublicKeyLoadError
+from zimfarm_backend.utils.cryptography import verify_signed_message
+
+
+class SSHTokenParts(NamedTuple):
+    worker_name: str
+    timestamp: str
+    signature: bytes
 
 
 class JWTClaims(BaseModel):
@@ -36,7 +52,7 @@ class TokenDecoder(abc.ABC):
     """Abstract base class for token decoders."""
 
     @abc.abstractmethod
-    def decode(self, token: str) -> JWTClaims:
+    def decode(self, token: str, session: OrmSession | None = None) -> JWTClaims:
         """
         Decode and validate a token.
         """
@@ -50,13 +66,96 @@ class TokenDecoder(abc.ABC):
         """
         pass
 
-    @property
     @abc.abstractmethod
-    def can_decode(self) -> bool:
+    def can_decode(self, token: str) -> bool:
         """
         Check if this decoder can potentially decode the given token.
         """
         pass
+
+
+class SshTokenDecoder(TokenDecoder):
+    """Decoder for SSH bearer tokens"""
+
+    def decode(self, token: str, session: OrmSession | None = None) -> JWTClaims:
+        """
+        Decode and validate an ssh authentication message.
+        """
+        worker_name, timestamp, signature = self._extract_token_parts(token)
+
+        exp = datetime.datetime.fromisoformat(timestamp) + datetime.timedelta(
+            seconds=MESSAGE_VALIDITY_DURATION
+        )
+        if getnow() > exp:
+            raise ValueError(
+                "Difference betweeen message time and server time is "
+                f"greater than {MESSAGE_VALIDITY_DURATION}s"
+            )
+
+        if session is None:
+            raise ValueError("OrmSession is required to decode SSH bearer tokens.")
+
+        try:
+            db_worker = get_worker(session, worker_name=worker_name)
+        except RecordDoesNotExistError as exc:
+            raise ValueError(f"Worker {worker_name} does not exist.") from exc
+
+        authenticated = False
+        # Verify signature with workers' public keys
+        for ssh_key in db_worker.ssh_keys:
+            try:
+                if verify_signed_message(
+                    bytes(ssh_key.key, encoding="ascii"),
+                    signature,
+                    bytes(f"{worker_name}.{timestamp}", encoding="ascii"),
+                ):
+                    authenticated = True
+                    break
+            except PublicKeyLoadError as exc:
+                logger.exception("error while verifying message using public key")
+                raise ValueError("Unable to load public_key") from exc
+
+        if not authenticated:
+            raise ValueError("Could not find matching key for signature.")
+
+        return JWTClaims(
+            iss="zimfarm-worker",
+            exp=exp,
+            iat=datetime.datetime.fromisoformat(timestamp),
+            # use the account id so route permission checks are done against the worker
+            # account
+            subject=db_worker.account_id,
+        )
+
+    def _extract_token_parts(self, token: str) -> SSHTokenParts:
+        """Extract SSH token parts"""
+        try:
+            worker_name, timestamp, signature = token.split(".", 2)
+            datetime.datetime.fromisoformat(timestamp)
+        except ValueError as exc:
+            raise ValueError("Invalid message format.") from exc
+
+        try:
+            signature = base64.standard_b64decode(signature)
+        except binascii.Error as exc:
+            raise ValueError("Invalid signature format (not base64)") from exc
+
+        return SSHTokenParts(
+            worker_name=worker_name, timestamp=timestamp, signature=signature
+        )
+
+    @property
+    def name(self) -> str:
+        return "ssh"
+
+    def can_decode(self, token: str) -> bool:
+        # First few checks that don't require should fail early  if this is not
+        # an SSH bearer token.
+        try:
+            self._extract_token_parts(token)
+        except Exception:
+            return False
+        return True
 
 
 class LocalTokenDecoder(TokenDecoder):
@@ -66,7 +165,11 @@ class LocalTokenDecoder(TokenDecoder):
         self.secret = secret
         self.algorithm = algorithm
 
-    def decode(self, token: str) -> JWTClaims:
+    def decode(
+        self,
+        token: str,
+        session: OrmSession | None = None,  # noqa: ARG002
+    ) -> JWTClaims:
         """
         Decode and validate a local Zimfarm token.
         """
@@ -77,9 +180,25 @@ class LocalTokenDecoder(TokenDecoder):
     def name(self) -> str:
         return "local"
 
-    @property
-    def can_decode(self) -> bool:
-        return "local" in AUTH_MODES
+    def can_decode(self, token: str) -> bool:
+        if "local" not in AUTH_MODES:
+            return False
+        try:
+            payload = jwt.decode(
+                token,
+                options={
+                    "verify_signature": False,
+                    "verify_exp": False,
+                    "verify_aud": False,
+                    "verify_iss": False,
+                },
+            )
+        except Exception:
+            return False
+
+        if payload.get("iss") != JWT_TOKEN_ISSUER:
+            return False
+        return True
 
 
 class OAuthOIDCTokenDecoder(TokenDecoder):
@@ -93,7 +212,11 @@ class OAuthOIDCTokenDecoder(TokenDecoder):
             headers={"User-Agent": "PyJWT/2.11.0"},
         )
 
-    def decode(self, token: str) -> JWTClaims:
+    def decode(
+        self,
+        token: str,
+        session: OrmSession | None = None,  # noqa: ARG002
+    ) -> JWTClaims:
         """
         Decode and validate an OAuth OIDC token.
         """
@@ -140,9 +263,29 @@ class OAuthOIDCTokenDecoder(TokenDecoder):
     def name(self) -> str:
         return "oauth-oidc"
 
-    @property
-    def can_decode(self) -> bool:
-        return "oauth-oidc" in AUTH_MODES
+    def can_decode(self, token: str) -> bool:
+        if "oauth-oidc" not in AUTH_MODES:
+            return False
+        try:
+            payload = jwt.decode(
+                token,
+                options={
+                    "verify_signature": False,
+                    "verify_exp": False,
+                    "verify_aud": False,
+                    "verify_iss": False,
+                },
+            )
+        except Exception:
+            return False
+
+        if (
+            payload.get("iss") != OAUTH_ISSUER
+            or payload.get("aud") != OAUTH_OIDC_CLIENT_ID
+        ):
+            return False
+
+        return True
 
 
 class OAuthSessionTokenDecoder(TokenDecoder):
@@ -156,7 +299,11 @@ class OAuthSessionTokenDecoder(TokenDecoder):
             headers={"User-Agent": "PyJWT/2.11.0"},
         )
 
-    def decode(self, token: str) -> JWTClaims:
+    def decode(
+        self,
+        token: str,
+        session: OrmSession | None = None,  # noqa: ARG002
+    ) -> JWTClaims:
         """
         Decode and validate an OAuth OIDC token.
         """
@@ -196,9 +343,28 @@ class OAuthSessionTokenDecoder(TokenDecoder):
     def name(self) -> str:
         return "oauth-session"
 
-    @property
-    def can_decode(self) -> bool:
-        return "oauth-session" in AUTH_MODES
+    def can_decode(self, token: str) -> bool:
+        if "oauth-session" not in AUTH_MODES:
+            return False
+        try:
+            payload = jwt.decode(
+                token,
+                options={
+                    "verify_signature": False,
+                    "verify_exp": False,
+                    "verify_aud": False,
+                    "verify_iss": False,
+                },
+            )
+        except Exception:
+            return False
+
+        if (
+            payload.get("iss") != OAUTH_ISSUER
+            or payload.get("aud") != OAUTH_SESSION_AUDIENCE_ID
+        ):
+            return False
+        return True
 
 
 class TokenDecoderChain:
@@ -210,27 +376,37 @@ class TokenDecoderChain:
         """
         self.decoders = decoders
 
-    def decode(self, token: str) -> JWTClaims:
+    def decode(self, token: str, session: OrmSession) -> JWTClaims:
         """
         Try to decode token using each decoder in order.
         """
         exc_cls: Exception | None = None
-        decoders = [decoder for decoder in self.decoders if decoder.can_decode]
+        decoders = [decoder for decoder in self.decoders if decoder.can_decode(token)]
         if not decoders:
-            raise ValueError("No decoders registered for decoding token.")
+            raise ValueError("No decoders can decode token.")
+
+        if len(decoders) > 1:
+            logger.warning(
+                "Multiple token decoders detected. Set configuration values to match "
+                "only one token decoder to avoid overwriting exception messages."
+            )
+
+        logger.debug(f"{len(decoders)} decoder(s) can decode token")
 
         for decoder in decoders:
-            if decoder.can_decode:
-                try:
-                    return decoder.decode(token)
-                except (
-                    jwt_exceptions.PyJWTError,
-                    PydanticValidationError,
-                    Exception,
-                ) as exc:
-                    logger.debug(f"{decoder.name}: unable to decode token: {exc!s}")
-                    # keep track of the most recent exception class
-                    exc_cls = exc
+            try:
+                logger.debug(f"{decoder.name}-decoder: attempting to decode token.")
+                claims = decoder.decode(token, session)
+            except (
+                jwt_exceptions.PyJWTError,
+                PydanticValidationError,
+                Exception,
+            ) as exc:
+                logger.debug(f"{decoder.name}-decoder: unable to decode token: {exc!s}")
+                exc_cls = exc
+            else:
+                logger.debug(f"{decoder.name}-decoder: decoded token successfully.")
+                return claims
 
         if exc_cls:
             raise exc_cls
@@ -239,7 +415,12 @@ class TokenDecoderChain:
 
 
 token_decoder = TokenDecoderChain(
-    decoders=[LocalTokenDecoder(), OAuthOIDCTokenDecoder(), OAuthSessionTokenDecoder()]
+    decoders=[
+        SshTokenDecoder(),
+        LocalTokenDecoder(),
+        OAuthOIDCTokenDecoder(),
+        OAuthSessionTokenDecoder(),
+    ]
 )
 
 

--- a/backend/tests/routes/test_auth.py
+++ b/backend/tests/routes/test_auth.py
@@ -94,54 +94,47 @@ def test_refresh_access_token_expired_token(
 
 
 @pytest.mark.parametrize(
-    ["datetime_str", "expected_status", "expected_response_contents"],
+    ["datetime_str", "expected_status"],
     [
         pytest.param(
             datetime.datetime.fromtimestamp(0, tz=datetime.UTC)
             .replace(tzinfo=None)
-            .isoformat(),
+            .isoformat(timespec="seconds"),
             HTTPStatus.UNAUTHORIZED,
-            [],
             id="outdated-timestamp",
         ),
-        pytest.param("hello", HTTPStatus.BAD_REQUEST, [], id="invalid-message"),
+        pytest.param("hello", HTTPStatus.UNAUTHORIZED, id="invalid-message"),
         pytest.param(
             # Before CI fully sets up, default timer has expired, so, add
             # additional 5 minutes
-            (getnow() + datetime.timedelta(minutes=5)).isoformat(),
-            HTTPStatus.OK,
-            ["access_token", "token_type", "expires_time"],
+            (getnow() + datetime.timedelta(minutes=5)).isoformat(timespec="seconds"),
+            HTTPStatus.NO_CONTENT,
             id="valid-message",
         ),
     ],
 )
-def test_authenticate_worker(
+def test_ssh_authenticate_account(
     client: TestClient,
     account: Account,
     rsa_private_key: RSAPrivateKey,
     datetime_str: str,
     expected_status: int,
-    expected_response_contents: list[str],
     create_worker: Callable[..., Worker],
 ):
     worker = create_worker(account=account)
-    message = f"{worker.name}:{datetime_str}"
+    message = f"{worker.name}.{datetime_str}"
     signature = sign_message_with_rsa_key(
         rsa_private_key, bytes(message, encoding="ascii")
     )
     x_sshauth_signature = base64.b64encode(signature).decode()
-    response = client.post(
-        "/v2/auth/ssh-authorize",
+    response = client.get(
+        "/v2/auth/test",
         headers={
             "Content-type": "application/json",
-            "X-SSHAuth-Message": message,
-            "X-SSHAuth-Signature": x_sshauth_signature,
+            "Authorization": f"Bearer {message}.{x_sshauth_signature}",
         },
     )
     assert response.status_code == expected_status
-    data = response.text
-    for content in expected_response_contents:
-        assert content in data
 
 
 def test_authentication_token(

--- a/backend/tests/routes/test_dependencies.py
+++ b/backend/tests/routes/test_dependencies.py
@@ -3,6 +3,7 @@ from collections.abc import Callable
 
 import pytest
 from fastapi.security import HTTPAuthorizationCredentials
+from sqlalchemy.orm import Session as OrmSession
 
 from zimfarm_backend.api.routes.dependencies import get_jwt_claims_or_none
 from zimfarm_backend.api.token import generate_access_token
@@ -19,14 +20,15 @@ def create_mock_authorization() -> Callable[..., HTTPAuthorizationCredentials]:
     return _create_auth
 
 
-def test_get_jwt_claims_or_none_with_no_authorization():
+def test_get_jwt_claims_or_none_with_no_authorization(dbsession: OrmSession):
     """Test that None is returned when no authorization is provided."""
-    result = get_jwt_claims_or_none(None)
+    result = get_jwt_claims_or_none(None, dbsession)
     assert result is None
 
 
 def test_get_jwt_claims_or_none_with_valid_zimfarm_token(
     create_mock_authorization: Callable[..., HTTPAuthorizationCredentials],
+    dbsession: OrmSession,
 ):
     """Test successful JWT claims extraction from a valid Zimfarm token."""
     account_id = str(uuid.uuid4())
@@ -34,7 +36,7 @@ def test_get_jwt_claims_or_none_with_valid_zimfarm_token(
     access_token = generate_access_token(issue_time=now, account_id=account_id)
 
     auth = create_mock_authorization(access_token)
-    claims = get_jwt_claims_or_none(auth)
+    claims = get_jwt_claims_or_none(auth, dbsession)
 
     assert claims is not None
     assert claims.sub == uuid.UUID(account_id)

--- a/backend/tests/test_token_decoder.py
+++ b/backend/tests/test_token_decoder.py
@@ -1,13 +1,26 @@
 # pyright: strict, reportPrivateUsage=false
+# ruff: noqa: ARG005
+import base64
 import datetime
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 from uuid import UUID
 
 import jwt
 import pytest
+from cryptography.hazmat.primitives.asymmetric.rsa import RSAPrivateKey
+from sqlalchemy.orm import Session as OrmSession
 
-from zimfarm_backend.api.token import OAuthOIDCTokenDecoder, OAuthSessionTokenDecoder
+from zimfarm_backend.api.token import (
+    JWTClaims,
+    LocalTokenDecoder,
+    OAuthOIDCTokenDecoder,
+    OAuthSessionTokenDecoder,
+    SshTokenDecoder,
+)
 from zimfarm_backend.common import getnow
+from zimfarm_backend.db.models import Account, Worker
+from zimfarm_backend.utils.cryptography import sign_message_with_rsa_key
 
 # Authentication method constants for testing
 FIRST_FACTOR_METHODS = ["password", "oidc"]
@@ -504,3 +517,320 @@ def test_verify_session_access_token_verify_client_id_matches_sub(
 
         with pytest.raises(ValueError, match="Oauth client ID does not match"):
             decoder.decode(test_token)
+
+
+def test_ssh_token_decoder_can_decode_valid_format(
+    account: Account,
+    rsa_private_key: RSAPrivateKey,
+    create_worker: Callable[..., Worker],
+):
+    """Test SSH token decoder can_decode with valid token format."""
+    worker = create_worker(account=account)
+    datetime_str = (getnow() + datetime.timedelta(minutes=5)).isoformat()
+    message_to_sign = f"{worker.name}.{datetime_str}"
+    signature = sign_message_with_rsa_key(
+        rsa_private_key, bytes(message_to_sign, encoding="ascii")
+    )
+    b64_signature = base64.b64encode(signature).decode()
+    token = f"{worker.name}.{datetime_str}.{b64_signature}"
+
+    decoder = SshTokenDecoder()
+    assert decoder.can_decode(token) is True
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        pytest.param("worker.timestamp", id="invalid-format"),
+        pytest.param("worker.not-a-timestamp.signature", id="invalid-timestamp"),
+        pytest.param(
+            "worker.2026-04-14T11:03:03:not-valid-base64-!@#", id="invalid-base64"
+        ),
+        pytest.param("random-string", id="random-string"),
+    ],
+)
+def test_ssh_token_decoder_can_decode_invalid_format(token: str):
+    """Test SSH token decoder can_decode with invalid token formats."""
+    decoder = SshTokenDecoder()
+    assert decoder.can_decode(token) is False
+
+
+def test_local_token_decoder_can_decode_with_auth_mode_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test local token decoder can_decode returns False when auth mode disabled."""
+    monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["oauth-oidc"])
+
+    decoder = LocalTokenDecoder()
+    token = create_test_jwt_token(issuer="zimfarm_backend")
+    assert decoder.can_decode(token) is False
+
+
+def test_local_token_decoder_can_decode_with_correct_issuer(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test local token decoder can_decode with correct issuer."""
+    monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["local"])
+    monkeypatch.setattr("zimfarm_backend.api.token.JWT_TOKEN_ISSUER", "zimfarm_backend")
+
+    decoder = LocalTokenDecoder()
+    token = create_test_jwt_token(issuer="zimfarm_backend")
+    assert decoder.can_decode(token) is True
+
+
+def test_local_token_decoder_can_decode_with_wrong_issuer(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test local token decoder can_decode with wrong issuer."""
+    monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["local"])
+    monkeypatch.setattr("zimfarm_backend.api.token.JWT_TOKEN_ISSUER", "zimfarm_backend")
+
+    decoder = LocalTokenDecoder()
+    token = create_test_jwt_token(issuer="wrong-issuer")
+    assert decoder.can_decode(token) is False
+
+
+def test_oauth_oidc_token_decoder_can_decode_with_auth_mode_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test OAuth OIDC can_decode returns False when disabled."""
+    monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["local"])
+
+    decoder = OAuthOIDCTokenDecoder()
+    token = create_test_jwt_token()
+    assert decoder.can_decode(token) is False
+
+
+def test_oauth_oidc_token_decoder_can_decode_with_correct_issuer_and_audience(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test OAuth OIDC token decoder can_decode with correct issuer and audience."""
+    monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["oauth-oidc"])
+    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
+    monkeypatch.setattr(
+        "zimfarm_backend.api.token.OAUTH_OIDC_CLIENT_ID", TEST_CLIENT_ID
+    )
+
+    decoder = OAuthOIDCTokenDecoder()
+
+    now = getnow()
+    payload = {
+        "iss": TEST_ISSUER,
+        "sub": str(UUID(int=0)),
+        "iat": int(now.timestamp()),
+        "exp": int((now + datetime.timedelta(hours=1)).timestamp()),
+        "aud": TEST_CLIENT_ID,
+    }
+    token = jwt.encode(payload, "test-secret", algorithm="HS256")
+
+    assert decoder.can_decode(token) is True
+
+
+def test_oauth_oidc_token_decoder_can_decode_with_wrong_issuer(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test OAuth OIDC token decoder can_decode with wrong issuer."""
+    monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["oauth-oidc"])
+    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
+    monkeypatch.setattr(
+        "zimfarm_backend.api.token.OAUTH_OIDC_CLIENT_ID", TEST_CLIENT_ID
+    )
+
+    decoder = OAuthOIDCTokenDecoder()
+
+    now = getnow()
+    payload = {
+        "iss": "wrong-issuer",
+        "sub": str(UUID(int=0)),
+        "iat": int(now.timestamp()),
+        "exp": int((now + datetime.timedelta(hours=1)).timestamp()),
+        "aud": TEST_CLIENT_ID,
+    }
+    token = jwt.encode(payload, "test-secret", algorithm="HS256")
+
+    assert decoder.can_decode(token) is False
+
+
+def test_oauth_oidc_token_decoder_can_decode_with_wrong_audience(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test OAuth OIDC token decoder can_decode with wrong audience."""
+    monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["oauth-oidc"])
+    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
+    monkeypatch.setattr(
+        "zimfarm_backend.api.token.OAUTH_OIDC_CLIENT_ID", TEST_CLIENT_ID
+    )
+
+    decoder = OAuthOIDCTokenDecoder()
+
+    now = getnow()
+    payload = {
+        "iss": TEST_ISSUER,
+        "sub": str(UUID(int=0)),
+        "iat": int(now.timestamp()),
+        "exp": int((now + datetime.timedelta(hours=1)).timestamp()),
+        "aud": "wrong-audience",
+    }
+    token = jwt.encode(payload, "test-secret", algorithm="HS256")
+
+    assert decoder.can_decode(token) is False
+
+
+def test_oauth_session_token_decoder_can_decode_with_auth_mode_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test OAuth Session can_decode returns False when disabled."""
+    monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["local"])
+
+    decoder = OAuthSessionTokenDecoder()
+    token = create_test_session_jwt_token()
+    assert decoder.can_decode(token) is False
+
+
+def test_oauth_session_token_decoder_can_decode_with_correct_issuer_and_audience(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test OAuth Session token decoder can_decode with correct issuer and audience."""
+    monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["oauth-session"])
+    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
+    monkeypatch.setattr(
+        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE_ID", TEST_CLIENT_ID
+    )
+
+    decoder = OAuthSessionTokenDecoder()
+    token = create_test_session_jwt_token(
+        issuer=TEST_ISSUER, audience_id=TEST_CLIENT_ID
+    )
+    assert decoder.can_decode(token) is True
+
+
+def test_oauth_session_token_decoder_can_decode_with_wrong_issuer(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test OAuth Session token decoder can_decode with wrong issuer."""
+    monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["oauth-session"])
+    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
+    monkeypatch.setattr(
+        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE_ID", TEST_CLIENT_ID
+    )
+
+    decoder = OAuthSessionTokenDecoder()
+    token = create_test_session_jwt_token(
+        issuer="wrong-issuer", audience_id=TEST_CLIENT_ID
+    )
+    assert decoder.can_decode(token) is False
+
+
+def test_oauth_session_token_decoder_can_decode_with_wrong_audience(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test OAuth Session token decoder can_decode with wrong audience."""
+    monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["oauth-session"])
+    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
+    monkeypatch.setattr(
+        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE_ID", TEST_CLIENT_ID
+    )
+
+    decoder = OAuthSessionTokenDecoder()
+    token = create_test_session_jwt_token(
+        issuer=TEST_ISSUER, audience_id="wrong-audience"
+    )
+    assert decoder.can_decode(token) is False
+
+
+@pytest.mark.parametrize(
+    ["datetime_str", "message_modifier", "expected_exception", "exception_msg"],
+    [
+        pytest.param(
+            datetime.datetime.fromtimestamp(0, tz=datetime.UTC)
+            .replace(tzinfo=None)
+            .isoformat(timespec="seconds"),
+            lambda w, t, s: f"{w}.{t}.{s}",  # pyright: ignore[reportUnknownArgumentType, reportUnknownLambdaType]
+            ValueError,
+            "Difference betweeen message time and server time is greater than",
+            id="outdated-timestamp",
+        ),
+        pytest.param(
+            (getnow() + datetime.timedelta(minutes=5)).isoformat(timespec="seconds"),
+            lambda w, t, s: "hello",  # pyright: ignore[reportUnknownArgumentType, reportUnknownLambdaType]
+            ValueError,
+            "Invalid message format.",
+            id="invalid-message-format",
+        ),
+        pytest.param(
+            (getnow() + datetime.timedelta(minutes=5)).isoformat(timespec="seconds"),
+            lambda w, t, s: f"{w}.{t}.not-base64-!@#",  # pyright: ignore[reportUnknownArgumentType, reportUnknownLambdaType]
+            ValueError,
+            "Invalid signature format.*",
+            id="invalid-signature-format",
+        ),
+        pytest.param(
+            (getnow() + datetime.timedelta(minutes=5)).isoformat(timespec="seconds"),
+            lambda w, t, s: f"unknownworker.{t}.{s}",  # pyright: ignore[reportUnknownArgumentType, reportUnknownLambdaType]
+            ValueError,
+            "Worker unknownworker does not exist.",
+            id="worker-does-not-exist",
+        ),
+        pytest.param(
+            # Before CI fully sets up, default timer has expired, so, add
+            # additional 5 minutes
+            (getnow() + datetime.timedelta(minutes=5)).isoformat(timespec="seconds"),
+            lambda w, t, s: f"{w}.{t}.{s}",  # pyright: ignore[reportUnknownArgumentType, reportUnknownLambdaType]
+            None,
+            "",
+            id="valid-message",
+        ),
+    ],
+)
+def test_ssh_token_decoder(
+    account: Account,
+    rsa_private_key: RSAPrivateKey,
+    datetime_str: str,
+    message_modifier: Callable[[str, str, str], str],
+    expected_exception: type[Exception] | None,
+    exception_msg: str,
+    create_worker: Callable[..., Worker],
+    dbsession: OrmSession,
+):
+    worker = create_worker(account=account)
+
+    # signature is created with f"{worker_name}.{timestamp_str}"
+    message_to_sign = f"{worker.name}.{datetime_str}"
+    signature = sign_message_with_rsa_key(
+        rsa_private_key, bytes(message_to_sign, encoding="ascii")
+    )
+    b64_signature = base64.b64encode(signature).decode()
+
+    token = message_modifier(worker.name, datetime_str, b64_signature)
+
+    decoder = SshTokenDecoder()
+
+    if expected_exception:
+        with pytest.raises(expected_exception, match=exception_msg):
+            decoder.decode(token, session=dbsession)
+    else:
+        claims = decoder.decode(token, session=dbsession)
+        assert isinstance(claims, JWTClaims)
+        assert claims.iss == "zimfarm-worker"
+        assert claims.sub == worker.account_id
+
+
+def test_ssh_token_decoder_no_session(
+    account: Account,
+    rsa_private_key: RSAPrivateKey,
+    create_worker: Callable[..., Worker],
+):
+    worker = create_worker(account=account)
+    datetime_str = (getnow() + datetime.timedelta(minutes=5)).isoformat()
+    message_to_sign = f"{worker.name}.{datetime_str}"
+    signature = sign_message_with_rsa_key(
+        rsa_private_key, bytes(message_to_sign, encoding="ascii")
+    )
+    b64_signature = base64.b64encode(signature).decode()
+    token = f"{worker.name}.{datetime_str}.{b64_signature}"
+
+    decoder = SshTokenDecoder()
+    with pytest.raises(
+        ValueError, match="OrmSession is required to decode SSH bearer tokens."
+    ):
+        decoder.decode(token)

--- a/worker/src/zimfarm_worker/common/cryptography.py
+++ b/worker/src/zimfarm_worker/common/cryptography.py
@@ -26,7 +26,8 @@ from zimfarm_worker.common import getnow
 class AuthMessage:
     """An authentication message for a worker"""
 
-    body: str
+    worker_name: str
+    timestamp_str: str
     signature: str
 
 
@@ -116,7 +117,11 @@ def generate_auth_message(
     private_key: RSAPrivateKey | EllipticCurvePrivateKey | Ed25519PrivateKey,
 ) -> AuthMessage:
     """Generate an authentication message for a worker"""
-    body = f"{worker_name}:{getnow().isoformat()}"
+    timestamp_str = getnow().isoformat(timespec="seconds")
     return AuthMessage(
-        body=body, signature=get_signature(bytes(body, encoding="ascii"), private_key)
+        worker_name=worker_name,
+        timestamp_str=timestamp_str,
+        signature=get_signature(
+            bytes(f"{worker_name}.{timestamp_str}", encoding="ascii"), private_key
+        ),
     )

--- a/worker/src/zimfarm_worker/common/requests.py
+++ b/worker/src/zimfarm_worker/common/requests.py
@@ -1,4 +1,3 @@
-import datetime
 from dataclasses import dataclass
 from json import JSONDecodeError
 from typing import Any
@@ -7,16 +6,6 @@ import requests
 
 from zimfarm_worker.common import logger
 from zimfarm_worker.common.constants import REQUESTS_TIMEOUT
-
-
-@dataclass
-class Token:
-    """Access token on successful authentication."""
-
-    access_token: str
-    expires_time: datetime.datetime
-    refresh_token: str
-    token_type: str = "Bearer"
 
 
 @dataclass

--- a/worker/src/zimfarm_worker/common/worker.py
+++ b/worker/src/zimfarm_worker/common/worker.py
@@ -1,18 +1,15 @@
 # vim: ai ts=4 sts=4 et sw=4 nu
 
-import datetime
 import os
 import signal
 import sys
-from dataclasses import dataclass
 from http import HTTPStatus
 from pathlib import Path
 from typing import Any
 
 import docker
-import jwt
 
-from zimfarm_worker.common import getnow, logger
+from zimfarm_worker.common import logger
 from zimfarm_worker.common.constants import (
     DOCKER_CLIENT_TIMEOUT,
     DOCKER_SOCKET,
@@ -24,25 +21,7 @@ from zimfarm_worker.common.cryptography import (
     load_private_key_from_path,
 )
 from zimfarm_worker.common.docker import list_containers
-from zimfarm_worker.common.requests import Response, Token, query_api
-
-
-@dataclass(kw_only=True)
-class JwtPayload:
-    iss: str
-    exp: float
-    iat: float
-    subject: str
-
-
-@dataclass(kw_only=True)
-class WebApiConnection:
-    uri: str
-    access_token: str
-    refresh_token: str
-    jwt_payload: JwtPayload
-    authenticated_on: datetime.datetime
-    authentication_expires_on: datetime.datetime
+from zimfarm_worker.common.requests import Response, query_api
 
 
 class BaseWorker:
@@ -88,35 +67,20 @@ class BaseWorker:
             sys.exit(1)
 
         try:
-            private_key = load_private_key_from_path(PRIVATE_KEY)
+            self.private_key = load_private_key_from_path(PRIVATE_KEY)
         except Exception as exc:
             logger.critical("\tprivate key is not valid RSA")
             logger.exception(exc)
             sys.exit(1)
         else:
-            self.fingerprint: str = get_public_key_fingerprint(private_key.public_key())
+            self.fingerprint: str = get_public_key_fingerprint(
+                self.private_key.public_key()
+            )
 
             logger.info(f"\tprivate key is available and readable ({self.fingerprint})")
 
     def check_auth(self):
-        self.connections: dict[str, WebApiConnection] = {
-            uri: WebApiConnection(
-                uri=uri,
-                access_token="",
-                refresh_token="",
-                jwt_payload=JwtPayload(
-                    iss="",
-                    exp=0,
-                    iat=0,
-                    subject="",
-                ),
-                authenticated_on=datetime.datetime(2019, 1, 1),
-                authentication_expires_on=datetime.datetime(2019, 1, 1),
-            )
-            for uri in self.webapi_uris
-        }
-
-        for uri in self.connections.keys():
+        for uri in self.webapi_uris:
             logger.info(f"testing authentication with {uri}…")
             response = self.query_api(path="/auth/test", method="GET", webapi_uri=uri)
             if response.success:
@@ -153,64 +117,6 @@ class BaseWorker:
         signal.signal(signal.SIGINT, self.exit_gracefully)
         signal.signal(signal.SIGQUIT, self.exit_gracefully)
 
-    def authenticate(self, uri: str, *, force: bool = False):
-        # our access token should grant us access for 60mn
-        if force or self.connections[uri].authentication_expires_on <= getnow():
-            try:
-                private_key = load_private_key_from_path(PRIVATE_KEY)
-                auth_message = generate_auth_message(self.worker_name, private_key)
-                token_response = query_api(
-                    f"{uri}/auth/ssh-authorize",
-                    method="POST",
-                    headers={
-                        "X-SSHAuth-Message": auth_message.body,
-                        "X-SSHAuth-Signature": auth_message.signature,
-                    },
-                    timeout=30,
-                )
-                if not token_response.success:
-                    logger.error(
-                        "failed to authenticate with API: "
-                        f"status_code={token_response.status_code} "
-                        f"mesage={token_response.json.get('message')}"
-                    )
-                    return False
-
-                token = Token(
-                    access_token=token_response.json["access_token"],
-                    expires_time=datetime.datetime.fromisoformat(
-                        token_response.json["expires_time"]
-                    ),
-                    refresh_token=token_response.json["refresh_token"],
-                    token_type=token_response.json["token_type"],
-                )
-
-                self.connections[uri].access_token = token.access_token
-                self.connections[uri].refresh_token = token.refresh_token
-                jwt_payload = jwt.decode(
-                    self.connections[uri].access_token,
-                    algorithms=["HS256"],
-                    options={"verify_signature": False},
-                )
-                self.connections[uri].jwt_payload = JwtPayload(
-                    iss=jwt_payload["iss"],
-                    exp=jwt_payload["exp"],
-                    iat=jwt_payload["iat"],
-                    subject=jwt_payload["subject"],
-                )
-                self.connections[uri].authenticated_on = getnow()
-                self.connections[uri].authentication_expires_on = (
-                    datetime.datetime.fromtimestamp(
-                        self.connections[uri].jwt_payload.exp
-                    )
-                )
-                return True
-            except Exception as exc:
-                logger.error(f"authenticate() failure: {exc}")
-                logger.exception(exc)
-                return False
-        return True
-
     def query_api(
         self,
         *,
@@ -222,18 +128,16 @@ class BaseWorker:
         webapi_uri: str | None = None,
     ) -> Response:
         if not webapi_uri:
-            webapi_uri = next(iter(self.connections.keys()))
+            webapi_uri = next(iter(self.webapi_uris))
 
-        if not self.authenticate(uri=webapi_uri):
-            return Response(
-                status_code=HTTPStatus.UNAUTHORIZED,
-                success=False,
-                json={},
-            )
+        auth_message = generate_auth_message(self.worker_name, self.private_key)
 
         attempts = 0
         headers = headers or {}
-        headers["Authorization"] = f"Bearer {self.connections[webapi_uri].access_token}"
+        headers["Authorization"] = (
+            f"Bearer {auth_message.worker_name}.{auth_message.timestamp_str}."
+            f"{auth_message.signature}"
+        )
         while attempts <= 1:
             response = query_api(
                 url=f"{webapi_uri}{path}",
@@ -246,7 +150,6 @@ class BaseWorker:
 
             # Unauthorised error: attempt to re-auth as scheduler might have restarted?
             if response.status_code == HTTPStatus.UNAUTHORIZED:
-                self.authenticate(uri=webapi_uri, force=True)
                 continue
             else:
                 return response

--- a/worker/src/zimfarm_worker/manager/worker.py
+++ b/worker/src/zimfarm_worker/manager/worker.py
@@ -164,12 +164,11 @@ class WorkerManager(BaseWorker):
         Maintains an ordered iterator so each are called one after another"""
 
         def _get_iter():
-            uris = [conn.uri for conn in self.connections.values()]
             index = 0
             while True:
-                yield uris[index]
+                yield self.webapi_uris[index]
                 index += 1
-                if index >= len(uris):
+                if index >= len(self.webapi_uris):
                     index = 0
 
         if not hasattr(self, "uri_iter"):
@@ -181,7 +180,7 @@ class WorkerManager(BaseWorker):
         self.check_cancellation()  # update our tasks register
 
         # a *poll* is *n* calls to our backend APIs
-        for _ in range(len(self.connections)):
+        for _ in range(len(self.webapi_uris)):
             # dont poll other APIs if we received a task. this will ensure the received
             # task gets to start and assign its resources before requesting more
             if self.poll_api(self.get_next_webapi_uri()):
@@ -242,8 +241,8 @@ class WorkerManager(BaseWorker):
 
     def check_in(self):
         """check_in_at() to all connections"""
-        for connection in self.connections.values():
-            self.check_in_at(connection.uri)
+        for uri in self.webapi_uris:
+            self.check_in_at(uri)
 
     def check_in_at(self, webapi_uri: str):
         """inform backend that we started a manager, sending resources info"""


### PR DESCRIPTION
## Rationale
This PR introduces a new form of bearer tokens. These tokens are generated with a workers' private key and is a drop-in replacement for calls to the `/auth/ssh-authorize` endpoint. The tokens are of the format `{worker_name}.{timestamp_str}.{signature}` where `timestamp_str` is a naive datetime string in isoformat (without milliseconds and other smaller units). 

## Changes
- mark `/auth/ssh-authorize` endpoint as deprecated (new issue to be created to remove it once all worker managers have been updated if PR is approved)
- add new decoder for decoding these SSH tokens. Usually the first decoder to be run as it fails fast and worker calls are likely more important
- refactor dependency `get_jwt_claims_or_none` to incorporate new decoder signature


This closes #1826
