### PR TITLE
Fix permission used to display 'Archive' button in recipe details

### DIFF
--- a/frontend-ui/src/views/RecipeDetailView.vue
+++ b/frontend-ui/src/views/RecipeDetailView.vue
@@ -108,7 +108,7 @@
         </v-tab>
         <v-tab
           base-color="primary"
-          v-if="canDeleteRecipes"
+          v-if="canArchiveRecipes"
           value="archive"
           :to="{
             name: 'recipe-detail-tab',


### PR DESCRIPTION
Users with "only" archive permission (and not delete) should be able to access the archive (or restore) button (kinda obvious).