### PR TITLE
harmonize status display and duration timestamps

### DIFF
--- a/frontend-ui/src/components/PipelineTable.vue
+++ b/frontend-ui/src/components/PipelineTable.vue
@@ -45,54 +45,13 @@
           </router-link>
         </template>
 
-        <template #[`item.requested`]="{ item }">
-          <v-tooltip location="bottom">
-            <template #activator="{ props }">
-              <span v-bind="props">
-                {{ fromNow(getTimestampStringForStatus(item.timestamp, 'requested')) }}
-              </span>
-            </template>
-            <span>{{ formatDt(getTimestampStringForStatus(item.timestamp, 'requested')) }}</span>
-          </v-tooltip>
-        </template>
-
-        <template #[`item.started`]="{ item }">
-          <v-tooltip location="bottom">
-            <template #activator="{ props }">
-              <span v-bind="props" class="text-no-wrap">
-                <router-link :to="{ name: 'task-detail', params: { id: item.id } }">
-                  {{ fromNow(getTimestampStringForStatus(item.timestamp, 'reserved')) }}
-                </router-link>
-              </span>
-            </template>
-            <span>{{ formatDt(getTimestampStringForStatus(item.timestamp, 'reserved')) }}</span>
-          </v-tooltip>
-        </template>
-
-        <template #[`item.completed`]="{ item }">
-          <v-tooltip location="bottom">
-            <template #activator="{ props }">
-              <span v-bind="props" class="text-no-wrap">
-                <router-link :to="{ name: 'task-detail', params: { id: item.id } }">
-                  {{ fromNow(getTimestampStringForStatus(item.timestamp, 'succeeded')) }}
-                </router-link>
-              </span>
-            </template>
-            <span>{{ formatDt(getTimestampStringForStatus(item.timestamp, 'succeeded')) }}</span>
-          </v-tooltip>
-        </template>
-
-        <template #[`item.stopped`]="{ item }">
-          <v-tooltip location="bottom">
-            <template #activator="{ props }">
-              <span v-bind="props" class="text-no-wrap">
-                <router-link :to="{ name: 'task-detail', params: { id: item.id } }">
-                  {{ fromNow(item.updated_at) }}
-                </router-link>
-              </span>
-            </template>
-            <span>{{ formatDt(item.updated_at) }}</span>
-          </v-tooltip>
+        <template #[`item.status`]="{ item }">
+          <StatusDisplay
+            :status="item.status"
+            :timestamp="item.timestamp"
+            :updated-at="item.updated_at"
+            :task-id="item.id"
+          />
         </template>
 
         <template #[`item.resources`]="{ item }">
@@ -158,14 +117,10 @@
         </template>
 
         <template #[`item.cancel`]="{ item }">
-          <code
-            v-if="item.status === 'canceling' || item.status === 'cancel_requested'"
-            class="text-pink-accent-2"
-          >
-            {{ item.status }}
-          </code>
           <CancelTaskButton
-            v-else-if="canCancelTasks"
+            v-if="
+              canCancelTasks && item.status !== 'canceling' && item.status !== 'cancel_requested'
+            "
             :id="item.id"
             :size="smAndDown ? 'x-small' : 'small'"
             @task-canceled="emit('loadData', props.paginator.limit, 0)"
@@ -185,30 +140,17 @@
           }}
         </template>
 
-        <template #[`item.status`]="{ item }">
-          <code class="text-pink-accent-2">{{ item.status }}</code>
-        </template>
-
         <template #[`item.last_run`]="{ item }">
-          <div
+          <StatusDisplay
             v-if="
               (item as TaskLight).recipe_most_recent_task &&
               (item as TaskLight).recipe_most_recent_task?.id != item.id
             "
-            :class="['ga-1', 'd-flex', 'align-center', 'flex-wrap', { 'justify-end': smAndDown }]"
-          >
-            <span>
-              <code :class="statusClass((item as TaskLight).recipe_most_recent_task!.status)">
-                {{ (item as TaskLight).recipe_most_recent_task!.status }} </code
-              >,
-            </span>
-            <TaskLink
-              :id="(item as TaskLight).recipe_most_recent_task!.id"
-              :updatedAt="(item as TaskLight).recipe_most_recent_task!.updated_at"
-              :status="(item as TaskLight).recipe_most_recent_task!.status"
-              :timestamp="(item as TaskLight).recipe_most_recent_task!.timestamp"
-            />
-          </div>
+            :status="(item as TaskLight).recipe_most_recent_task!.status"
+            :timestamp="(item as TaskLight).recipe_most_recent_task!.timestamp"
+            :updated-at="(item as TaskLight).recipe_most_recent_task!.updated_at"
+            :task-id="(item as TaskLight).recipe_most_recent_task!.id"
+          />
         </template>
 
         <template #[`item.requested_by`]="{ item }">
@@ -237,11 +179,12 @@ import DiagnoseTaskDialog from '@/components/DiagnoseTaskDialog.vue'
 import ErrorMessage from '@/components/ErrorMessage.vue'
 import RemoveRequestedTaskButton from '@/components/RemoveRequestedTaskButton.vue'
 import ResourceBadge from '@/components/ResourceBadge.vue'
-import TaskLink from '@/components/TaskLink.vue'
+import StatusDisplay from '@/components/StatusDisplay.vue'
+
 import type { Paginator } from '@/types/base'
 import type { RequestedTaskLight } from '@/types/requestedTasks'
 import type { TaskLight } from '@/types/tasks'
-import { formatDt, formatDurationBetween, fromNow } from '@/utils/format'
+import { formatDurationBetween } from '@/utils/format'
 import { getTimestampStringForStatus } from '@/utils/timestamp'
 import { ref } from 'vue'
 import { useRouter, useRoute } from 'vue-router'
@@ -290,12 +233,6 @@ function onUpdateOptions(options: { page: number; itemsPerPage: number }) {
   if (options.itemsPerPage != props.paginator.limit) {
     emit('limitChanged', options.itemsPerPage)
   }
-}
-
-function statusClass(status: string) {
-  if (status === 'succeeded') return 'recipe-succeeded'
-  else if (['failed', 'canceled', 'cancel_requested'].includes(status)) return 'recipe-failed'
-  else return 'recipe-running'
 }
 
 function diagnoseTask(task: RequestedTaskLight) {

--- a/frontend-ui/src/components/RecipesTable.vue
+++ b/frontend-ui/src/components/RecipesTable.vue
@@ -73,27 +73,14 @@
         </template>
 
         <template #[`item.last_task`]="{ item }">
-          <div
+          <StatusDisplay
             v-if="item.most_recent_task"
-            :class="[
-              'd-flex',
-              'flex-row',
-              'flex wrap',
-              'flex-md-column',
-              'ga-1',
-              { 'justify-end': smAndDown },
-            ]"
-          >
-            <code :class="statusClass(item.most_recent_task.status)">
-              {{ item.most_recent_task.status }}
-            </code>
-            <TaskLink
-              :id="item.most_recent_task.id"
-              :updatedAt="item.most_recent_task.updated_at"
-              :status="item.most_recent_task.status"
-              :timestamp="item.most_recent_task.timestamp"
-            />
-          </div>
+            :status="item.most_recent_task.status"
+            :timestamp="item.most_recent_task.timestamp"
+            :updated-at="item.most_recent_task.updated_at"
+            :task-id="item.most_recent_task.id"
+            :layout="smAndDown ? 'column' : 'row'"
+          />
           <span v-else>-</span>
         </template>
 
@@ -109,7 +96,7 @@
 </template>
 
 <script setup lang="ts">
-import TaskLink from '@/components/TaskLink.vue'
+import StatusDisplay from '@/components/StatusDisplay.vue'
 import type { Paginator } from '@/types/base'
 import type { RecipeLight } from '@/types/recipe'
 import { computed } from 'vue'
@@ -178,12 +165,6 @@ function handleSelectionChange(selection: string[]) {
 
 function clearSelections() {
   emit('selectionChanged', [])
-}
-
-function statusClass(status: string) {
-  if (status === 'succeeded') return 'recipe-succeeded'
-  else if (['failed', 'canceled', 'cancel_requested'].includes(status)) return 'recipe-failed'
-  else return 'recipe-running'
 }
 </script>
 

--- a/frontend-ui/src/components/StatusDisplay.vue
+++ b/frontend-ui/src/components/StatusDisplay.vue
@@ -1,0 +1,87 @@
+<template>
+  <div :class="['d-flex', 'ga-1', layoutClass]">
+    <span>
+      <code :class="statusClass">{{ status }}</code
+      ><template v-if="showTime">,</template>
+    </span>
+    <span v-if="showTime">
+      <v-tooltip v-if="tooltip" :text="formatDt(computedTimestamp)" location="bottom">
+        <template v-slot:activator="{ props: tooltipProps }">
+          <router-link
+            v-if="taskId"
+            v-bind="tooltipProps"
+            :to="{ name: 'task-detail', params: { id: taskId } }"
+            class="text-decoration-none text-no-wrap"
+          >
+            {{ fromNow(computedTimestamp) }}
+          </router-link>
+          <span v-else v-bind="tooltipProps" class="text-no-wrap">
+            {{ fromNow(computedTimestamp) }}
+          </span>
+        </template>
+      </v-tooltip>
+      <router-link
+        v-else-if="taskId"
+        :to="{ name: 'task-detail', params: { id: taskId } }"
+        class="text-decoration-none text-no-wrap"
+      >
+        {{ fromNow(computedTimestamp) }}
+      </router-link>
+      <span v-else class="text-no-wrap">
+        {{ fromNow(computedTimestamp) }}
+      </span>
+    </span>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { formatDt, fromNow } from '@/utils/format'
+import { getTimestampStringForStatus } from '@/utils/timestamp'
+import { computed } from 'vue'
+import { useDisplay } from 'vuetify'
+
+// Props
+interface Props {
+  status: string
+  timestamp?: [string, string][] | null
+  updatedAt?: string | null
+  taskId?: string | null
+  tooltip?: boolean
+  showTime?: boolean
+  layout?: 'row' | 'column'
+  justifyOnSmall?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  timestamp: null,
+  updatedAt: null,
+  taskId: null,
+  tooltip: true,
+  showTime: true,
+  layout: 'row',
+  justifyOnSmall: true,
+})
+
+const { smAndDown } = useDisplay()
+
+// Computed properties
+const layoutClass = computed(() => {
+  const classes = props.layout === 'column' ? 'flex-column' : 'flex-row flex-wrap align-center'
+  return smAndDown.value && props.justifyOnSmall ? `${classes} justify-end` : classes
+})
+
+const computedTimestamp = computed(() => {
+  if (props.timestamp) {
+    return getTimestampStringForStatus(props.timestamp, props.status, props.updatedAt || '')
+  }
+  return props.updatedAt || ''
+})
+
+const statusClass = computed(() => {
+  const status = props.status.toLowerCase()
+  if (status === 'succeeded') return 'text-success'
+  if (['failed', 'canceled', 'cancel_requested', 'canceling'].includes(status))
+    return 'text-pink-accent-2'
+  return 'text-warning'
+})
+</script>

--- a/frontend-ui/src/components/WorkersTable.vue
+++ b/frontend-ui/src/components/WorkersTable.vue
@@ -142,28 +142,23 @@
               >
                 Selfish
               </v-chip>
+
+              <!-- Last seen time -->
+              <span>,</span>
+              <v-tooltip location="bottom">
+                <template #activator="{ props }">
+                  <span v-bind="props" class="text-no-wrap">{{ fromNow(item.last_seen) }}</span>
+                </template>
+                <span>{{ formatDt(item.last_seen) }}</span>
+              </v-tooltip>
             </div>
           </template>
           <template v-else>
-            <!-- Empty cell for tasks -->
-          </template>
-        </template>
-
-        <template #[`item.last_seen`]="{ item }">
-          <template v-if="item.kind === 'worker'">
-            <v-tooltip location="bottom">
-              <template #activator="{ props }">
-                <span v-bind="props" class="text-no-wrap">{{ fromNow(item.last_seen) }}</span>
-              </template>
-              <span>{{ formatDt(item.last_seen) }}</span>
-            </v-tooltip>
-          </template>
-          <template v-else>
-            <TaskLink
-              :id="item.task.id"
-              :updatedAt="item.task.updated_at"
+            <StatusDisplay
               :status="item.task.status"
               :timestamp="item.task.timestamp"
+              :updated-at="item.task.updated_at"
+              :task-id="item.task.id"
             />
           </template>
         </template>
@@ -266,7 +261,7 @@
 <script setup lang="ts">
 import ErrorMessage from '@/components/ErrorMessage.vue'
 import ResourceBadge from '@/components/ResourceBadge.vue'
-import TaskLink from '@/components/TaskLink.vue'
+import StatusDisplay from '@/components/StatusDisplay.vue'
 import type { Paginator } from '@/types/base'
 import type { TaskLight } from '@/types/tasks'
 import type { Worker, DockerImageVersion } from '@/types/workers'

--- a/frontend-ui/src/views/PipelineView.vue
+++ b/frontend-ui/src/views/PipelineView.vue
@@ -55,7 +55,7 @@ const headers = computed(() => {
     case 'todo':
       return [
         { title: 'Recipe', value: 'recipe_name', sortable: false },
-        { title: 'Requested', value: 'requested', sortable: false },
+        { title: 'Status', value: 'status', sortable: false },
         { title: 'By', value: 'requested_by', sortable: false },
         { title: 'Resources', value: 'resources', sortable: false },
         { title: 'Worker', value: 'worker', sortable: false },
@@ -65,26 +65,25 @@ const headers = computed(() => {
     case 'doing':
       return [
         { title: 'Recipe', value: 'recipe_name', sortable: false },
-        { title: 'Started', value: 'started', sortable: false },
+        { title: 'Status', value: 'status', sortable: false },
         { title: 'By', value: 'requested_by', sortable: false },
         { title: 'Resources', value: 'resources', sortable: false },
         { title: 'Worker', value: 'worker', sortable: false },
-        canUnRequestTasks.value ? { title: 'Cancel', value: 'cancel', sortable: false } : null,
+        canCancelTasks.value ? { title: 'Cancel', value: 'cancel', sortable: false } : null,
       ].filter(Boolean) as { title: string; value: string }[]
     case 'done':
       return [
         { title: 'Recipe', value: 'recipe_name', sortable: false },
-        { title: 'Completed', value: 'completed', sortable: false },
+        { title: 'Status', value: 'status', sortable: false },
         { title: 'Worker', value: 'worker', sortable: false },
         { title: 'Duration', value: 'duration', sortable: false },
       ]
     case 'failed':
       return [
         { title: 'Recipe', value: 'recipe_name', sortable: false },
-        { title: 'Stopped', value: 'stopped', sortable: false },
+        { title: 'Status', value: 'status', sortable: false },
         { title: 'Worker', value: 'worker', sortable: false },
         { title: 'Duration', value: 'duration', sortable: false },
-        { title: 'Status', value: 'status', sortable: false },
         { title: 'Last Run', value: 'last_run', sortable: false },
       ]
     default:

--- a/frontend-ui/src/views/RecipeDetailView.vue
+++ b/frontend-ui/src/views/RecipeDetailView.vue
@@ -271,22 +271,14 @@
                     <div class="text-subtitle-2">Last run</div>
                   </v-col>
                   <v-col cols="12" md="8">
-                    <div v-if="lastRun" class="d-flex align-center flex-wrap">
-                      <v-chip
-                        :color="getStatusColor(lastRun.status)"
-                        size="small"
-                        variant="tonal"
-                        class="mr-2"
-                      >
-                        {{ lastRun.status }}
-                      </v-chip>
-                      <TaskLink
-                        :id="lastRun.id"
-                        :updatedAt="lastRun.updated_at"
-                        :status="lastRun.status"
-                        :timestamp="lastRun.timestamp"
-                      />
-                    </div>
+                    <StatusDisplay
+                      v-if="lastRun"
+                      :status="lastRun.status"
+                      :timestamp="lastRun.timestamp"
+                      :updated-at="lastRun.updated_at"
+                      :task-id="lastRun.id"
+                      :justify-on-small="false"
+                    />
                     <div v-else>
                       <v-chip size="small" variant="outlined" color="grey"> None 🙁 </v-chip>
                     </div>
@@ -453,7 +445,6 @@
                       :headers="[
                         { title: 'Worker', value: 'worker' },
                         { title: 'Status', value: 'status' },
-                        { title: 'Task', value: 'task' },
                         { title: 'Total Duration', value: 'total_duration' },
                       ]"
                       :mobile="smAndDown"
@@ -479,20 +470,12 @@
                       </template>
 
                       <template #[`item.status`]="{ item }">
-                        <v-chip :color="getStatusColor(item.status)" size="small" variant="tonal">
-                          {{ item.status }}
-                        </v-chip>
-                      </template>
-
-                      <template #[`item.task`]="{ item }">
-                        <span class="text-no-wrap">
-                          <TaskLink
-                            :id="item.id"
-                            :updatedAt="item.updated_at"
-                            :status="item.status"
-                            :timestamp="item.timestamp"
-                          />
-                        </span>
+                        <StatusDisplay
+                          :status="item.status"
+                          :timestamp="item.timestamp"
+                          :updated-at="item.updated_at"
+                          :task-id="item.id"
+                        />
                       </template>
 
                       <template #[`item.total_duration`]="{ item }">
@@ -786,7 +769,7 @@ import RecipeActionButton from '@/components/RecipeActionButton.vue'
 import RecipeEditor from '@/components/RecipeEditor.vue'
 import RecipeHistory from '@/components/RecipeHistory.vue'
 import RecipesTable from '@/components/RecipesTable.vue'
-import TaskLink from '@/components/TaskLink.vue'
+import StatusDisplay from '@/components/StatusDisplay.vue'
 import type { Config } from '@/config'
 import constants from '@/constants'
 import { useAuthStore } from '@/stores/auth'
@@ -1293,21 +1276,6 @@ const refreshData = async (forceReload: boolean = false, fetchHistory: boolean =
         (await offlinerStore.fetchOfflinerVersions(recipe.value.offliner)) || []
     }
     ready.value = true
-  }
-}
-
-const getStatusColor = (status: string): string => {
-  switch (status) {
-    case 'succeeded':
-      return 'success'
-    case 'failed':
-      return 'error'
-    case 'running':
-      return 'info'
-    case 'pending':
-      return 'warning'
-    default:
-      return 'dark-grey'
   }
 }
 

--- a/frontend-ui/src/views/TaskDetailView.vue
+++ b/frontend-ui/src/views/TaskDetailView.vue
@@ -109,7 +109,13 @@
                     <div class="text-subtitle-2">Status</div>
                   </v-col>
                   <v-col cols="12" md="9">
-                    <code class="text-pink-accent-2">{{ task.status }}</code>
+                    <StatusDisplay
+                      :status="task.status"
+                      :timestamp="task.timestamp"
+                      :updated-at="task.updated_at"
+                      :task-id="task.id"
+                      :justify-on-small="false"
+                    />
                   </v-col>
                 </v-row>
                 <v-divider class="my-2"></v-divider>
@@ -525,7 +531,7 @@ import ErrorMessage from '@/components/ErrorMessage.vue'
 
 import FlagsList from '@/components/FlagsList.vue'
 import ResourceBadge from '@/components/ResourceBadge.vue'
-
+import StatusDisplay from '@/components/StatusDisplay.vue'
 import TaskFileCard from '@/components/TaskFileCard.vue'
 import type { Config } from '@/config'
 import constants from '@/constants'

--- a/frontend-ui/src/views/WorkerDetailView.vue
+++ b/frontend-ui/src/views/WorkerDetailView.vue
@@ -310,7 +310,12 @@
                   </template>
 
                   <template #[`item.resources`]="{ item }">
-                    <div :class="['d-flex', 'flex-row flex-wrap', { 'justify-end': smAndDown }]">
+                    <div
+                      :class="[
+                        'd-flex',
+                        smAndDown ? 'flex-row flex-wrap justify-end ga-1' : 'flex-column',
+                      ]"
+                    >
                       <ResourceBadge
                         kind="cpu"
                         :value="item.config.resources.cpu"
@@ -332,13 +337,13 @@
                     </div>
                   </template>
 
-                  <template #[`item.task`]="{ item }">
-                    <TaskLink
+                  <template #[`item.status`]="{ item }">
+                    <StatusDisplay
                       v-if="item.id && item.updated_at"
-                      :id="item.id"
-                      :updatedAt="item.updated_at"
                       :status="item.status"
                       :timestamp="item.timestamp"
+                      :updated-at="item.updated_at"
+                      :task-id="item.id"
                     />
                     <span v-else class="text-caption">-</span>
                   </template>
@@ -598,8 +603,8 @@ import DiffViewer from '@/components/DiffViewer.vue'
 import ErrorMessage from '@/components/ErrorMessage.vue'
 import ResourceBadge from '@/components/ResourceBadge.vue'
 import SshKeyInput from '@/components/SshKeyInput.vue'
+import StatusDisplay from '@/components/StatusDisplay.vue'
 import SwitchButton from '@/components/SwitchButton.vue'
-import TaskLink from '@/components/TaskLink.vue'
 import type { Config } from '@/config'
 import constants from '@/constants'
 import { useAuthStore } from '@/stores/auth'
@@ -662,7 +667,7 @@ const imageAge = computed(() => {
 const runningTasksHeaders = [
   { title: 'Recipe', value: 'recipe_name' },
   { title: 'Resources', value: 'resources' },
-  { title: 'Task', value: 'task' },
+  { title: 'Status', value: 'status' },
 ]
 
 const hasChanges = computed(() => {

--- a/frontend-ui/src/views/WorkersView.vue
+++ b/frontend-ui/src/views/WorkersView.vue
@@ -152,7 +152,6 @@ const showingAll = ref<boolean>(!getOnlinesOnlyPreference())
 const workerHeaders = [
   { title: 'Name', value: 'name' },
   { title: 'Status', value: 'status' },
-  { title: 'Last seen', value: 'last_seen' },
   { title: 'Resources', value: 'resources' },
   { title: 'Contexts', value: 'contexts' },
 ]


### PR DESCRIPTION
## Rationale
This PR aims to harmonize the way status and duration timestamps are displayed. It introduces a new component `StatusDisplay` that sets the status of the task item along with the timestamp of the status (or default to the time the status was updated at)
<img width="1168" height="837" alt="Screenshot_20260416_161342" src="https://github.com/user-attachments/assets/5a4d8513-2120-4b32-a516-b841e899b7de" />
<img width="1227" height="627" alt="Screenshot_20260416_161330" src="https://github.com/user-attachments/assets/cdadeed7-7a3a-4a8b-a499-5e4074ddc807" />
<img width="1227" height="627" alt="Screenshot_20260416_161320" src="https://github.com/user-attachments/assets/5ffb0d83-d84f-4fb6-846b-107f1d9e2934" />
<img width="1175" height="520" alt="Screenshot_20260416_154145" src="https://github.com/user-attachments/assets/df5fd893-477f-414d-8537-47544808e324" />
<img width="1120" height="280" alt="Screenshot_20260416_154136" src="https://github.com/user-attachments/assets/f124c8d9-0a00-4590-836c-98d9b914f12d" />
<img width="1143" height="352" alt="Screenshot_20260416_154126" src="https://github.com/user-attachments/assets/5dc37ebf-fdd6-45df-9968-62f78325c2e7" />
<img width="1143" height="352" alt="Screenshot_20260416_154122" src="https://github.com/user-attachments/assets/7df531c8-2c87-4ceb-b1ce-a4970b750f36" />


This closes #1697
