### PR TITLE
allow users to input external blob URLs

### DIFF
--- a/backend/maint-scripts/update_offliner_definition_blobs.py
+++ b/backend/maint-scripts/update_offliner_definition_blobs.py
@@ -12,14 +12,18 @@ from zimfarm_backend.db.models import OfflinerDefinition
 from zimfarm_backend.db.offliner_definition import create_offliner_definition_schema
 
 FLAG_MAPPINGS: dict[
-    str, list[dict[str, Literal["image", "css", "html", "illustration"]]]
+    str, list[dict[str, Literal["image", "css", "html", "illustration", "txt"]]]
 ] = {
     "devdocs": [{"logo_format": "image"}],
     "freecodecamp": [{"illustration": "illustration"}],
     "ifixit": [{"icon": "illustration"}],
     "kolibri": [{"favicon": "illustration"}, {"css": "css"}, {"about": "html"}],
     "mindtouch": [{"illustration_url": "illustration"}],
-    "mwoffliner": [{"customZimFavicon": "illustration"}],
+    "mwoffliner": [
+        {"customZimFavicon": "illustration"},
+        {"articleList": "txt"},
+        {"articleListToIgnore": "txt"},
+    ],
     "nautilus": [
         {"main_logo": "image"},
         {"secondary_logo": "image"},
@@ -36,7 +40,9 @@ FLAG_MAPPINGS: dict[
 def update_offliner_definition_flags(
     offliner_id: str,
     spec: OfflinerSpecSchema,
-    flag_mappings: list[dict[str, Literal["image", "css", "html", "illustration"]]],
+    flag_mappings: list[
+        dict[str, Literal["image", "css", "html", "illustration", "txt"]]
+    ],
 ) -> bool:
     """
     Update flags in an offliner definition spec to use blob type with kind.

--- a/backend/maint-scripts/update_offliner_definition_flag.py
+++ b/backend/maint-scripts/update_offliner_definition_flag.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+
+"""
+Script to update an offliner definition's flag property in the database.
+
+EXAMPLES:
+
+1. Update the 'allow_remote_url' property of the 'articleList' flag to true for all
+    versions of an offliner:
+   ./update_offliner_definition_flag.py -o mwoffliner -f articleList \
+        -p allow_remote_url -v true --type boolean
+"""
+
+import argparse
+from copy import deepcopy
+
+import sqlalchemy as sa
+from sqlalchemy.orm.attributes import flag_modified
+
+from zimfarm_backend import logger
+from zimfarm_backend.common.constants import parse_bool
+from zimfarm_backend.db import Session
+from zimfarm_backend.db.models import OfflinerDefinition
+from zimfarm_backend.db.offliner_definition import create_offliner_definition_schema
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Update offliner definition flag properties in the database",
+    )
+
+    parser.add_argument(
+        "-o", "--offliner", required=True, help="Specify which offliner to update"
+    )
+
+    parser.add_argument(
+        "-f",
+        "--flag",
+        required=True,
+        help="Specify the flag to update (e.g., articleList)",
+    )
+
+    parser.add_argument(
+        "-p",
+        "--property",
+        required=True,
+        help="Specify the property to update (e.g., allow_remote_url)",
+    )
+
+    parser.add_argument(
+        "-v", "--value", required=True, help="The new value for the property"
+    )
+
+    parser.add_argument(
+        "-t",
+        "--type",
+        required=True,
+        choices=["string", "boolean", "integer", "float"],
+        help="The type of the new value",
+    )
+
+    args = parser.parse_args()
+
+    # Convert value based on type
+    if args.type == "string":
+        value = args.value
+    elif args.type == "boolean":
+        value = parse_bool(args.value)
+    elif args.type == "integer":
+        value = int(args.value)
+    elif args.type == "float":
+        value = float(args.value)
+    else:
+        raise ValueError(f"Unknown type: {args.type}")
+
+    with Session.begin() as session:
+        definitions = (
+            session.execute(
+                sa.select(OfflinerDefinition).where(
+                    OfflinerDefinition.offliner == args.offliner
+                )
+            )
+            .scalars()
+            .all()
+        )
+        for offliner_definition in definitions:
+            logger.info(
+                f"Processing {offliner_definition.offliner} version "
+                f"{offliner_definition.version}"
+            )
+            flags_dict = deepcopy(offliner_definition.schema["flags"])
+            if args.flag in flags_dict:
+                flags_dict[args.flag][args.property] = value
+                offliner_definition.schema["flags"] = flags_dict
+                flag_modified(offliner_definition, "schema")
+                # Validate that the schema is still valid
+                create_offliner_definition_schema(offliner_definition)
+                logger.info(
+                    f"updated offliner {args.offliner} version "
+                    f"{offliner_definition.version} flag '{args.flag}' property "
+                    f"'{args.property}' to {value}"
+                )
+            else:
+                logger.warning(
+                    f"flag '{args.flag}' not found in offliner {args.offliner} version "
+                    f"{offliner_definition.version}"
+                )
+
+    logger.info("FINISH!")

--- a/backend/src/zimfarm_backend/api/routes/recipes/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/recipes/logic.py
@@ -412,9 +412,7 @@ def update_recipe(
     offliner_definition: OfflinerDefinitionSchema
 
     if (
-        request.offliner
-        and request.offliner
-        != recipe_config.offliner.offliner_id  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
+        request.offliner and request.offliner != recipe_config.offliner.offliner_id  # pyright: ignore[reportAttributeAccessIssue, reportUnknownMemberType]
     ):
         # Case 1: Attempting to change the offliner
         if not request.flags:

--- a/backend/src/zimfarm_backend/common/notifications.py
+++ b/backend/src/zimfarm_backend/common/notifications.py
@@ -40,11 +40,9 @@ jinja_env = Environment(
     autoescape=select_autoescape(["html", "xml", "txt"]),
 )
 jinja_env.filters["short_id"] = lambda value: str(value)[:5]
-jinja_env.filters["format_size"] = (
-    lambda value: humanfriendly.format_size(  # pyright: ignore[reportUnknownMemberType]
-        value,  # pyright: ignore[reportArgumentType]
-        binary=True,
-    )
+jinja_env.filters["format_size"] = lambda value: humanfriendly.format_size(  # pyright: ignore[reportUnknownMemberType]
+    value,  # pyright: ignore[reportArgumentType]
+    binary=True,
 )
 
 

--- a/backend/src/zimfarm_backend/common/schemas/offliners/builder.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/builder.py
@@ -103,7 +103,11 @@ def generate_field_type(offliner: str, flag: FlagSchema, label: str):
     )
     # Additional information to the pydantic field to be used while determining
     # flag details.
-    json_schema_extra: dict[str, Any] = {"kind": flag.kind, "type": flag.type}
+    json_schema_extra: dict[str, Any] = {
+        "kind": flag.kind,
+        "type": flag.type,
+        "allowRemoteUrl": flag.allow_remote_url,
+    }
 
     # Determine the python type to represent the flag
     match flag.type:

--- a/backend/src/zimfarm_backend/common/schemas/offliners/models.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/models.py
@@ -20,6 +20,7 @@ class BaseFlagSchema(BaseModel):
     min_graphemes: int | None = Field(validation_alias="minGraphemes", default=None)
     max_graphemes: int | None = Field(validation_alias="maxGraphemes", default=None)
     pattern: str | None = None
+    allow_remote_url: bool = Field(default=False, validation_alias="allowRemoteUrl")
 
 
 class PreparedBlob(BaseModel):
@@ -84,6 +85,9 @@ class FlagSchema(BaseFlagSchema):
 
         if self.type != "blob" and self.kind:
             raise ValueError("Only blob types should specify a kind")
+
+        if self.allow_remote_url and self.type != "blob":
+            raise ValueError("Only blob types should specify allow_remote_url")
 
         return self
 

--- a/backend/src/zimfarm_backend/common/schemas/offliners/serializer.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/serializer.py
@@ -183,6 +183,7 @@ def schema_to_flags(schema_class: type[BaseModel]) -> list[Flag]:
             kind=json_schema_extra["kind"],
             min_graphemes=json_schema_extra.get("minGraphemes"),
             max_graphemes=json_schema_extra.get("maxGraphemes"),
+            allow_remote_url=json_schema_extra["allowRemoteUrl"],
         )
 
         # Add choices if available

--- a/backend/src/zimfarm_backend/utils/timestamp.py
+++ b/backend/src/zimfarm_backend/utils/timestamp.py
@@ -32,9 +32,7 @@ def get_status_timestamp_expr(
     return cast(
         # select the second element and then the date
         select(
-            literal_column(
-                "elem->1->>'$date'"
-            )  # pyright: ignore[reportUnknownArgumentType]
+            literal_column("elem->1->>'$date'")  # pyright: ignore[reportUnknownArgumentType]
         )
         .select_from(elem)
         .where(literal_column("elem->>0") == status)

--- a/frontend-ui/src/components/BlobEditor.vue
+++ b/frontend-ui/src/components/BlobEditor.vue
@@ -1,54 +1,77 @@
 <template>
   <div>
-    <InlineImageEditor
-      v-if="isImageKind"
-      :model-value="blobEditorContent"
-      :label="label"
-      :required="required"
-      :description="description"
-      v-model:comment="blobComment"
-      :loading="loadingBlobContent || isUploading || isLoadingBlob"
-      :error-message="errorMessage"
-      :preview-error-message="previewErrorMessage"
-      :original-checksum="currentBlobChecksum"
-      :original-comment="originalBlobComment"
-      :original-url="originalUrl"
-      @save="handleImageSave"
-      @clear="handleRemove"
-      @file-selected="handleFileSelected"
-      @url-entered="handleUrlEntered"
-      @use-original-url="handleUseOriginalUrl"
-    />
+    <v-radio-group v-if="allowRemoteUrl" v-model="contentMode" inline hide-details class="mb-2">
+      <v-radio label="Local" value="local"></v-radio>
+      <v-radio label="Remote" value="remote"></v-radio>
+    </v-radio-group>
 
-    <InlineTextEditor
-      v-else
-      :model-value="blobEditorContent"
-      :label="label"
-      :required="required"
-      :description="description"
-      :file-type="textFileType"
-      v-model:comment="blobComment"
-      :loading="loadingBlobContent || isUploading || isLoadingBlob"
-      :error-message="errorMessage"
-      :preview-error-message="previewErrorMessage"
-      :original-checksum="currentBlobChecksum"
-      :original-comment="originalBlobComment"
-      :original-url="originalUrl"
-      @save="handleTextSave"
-      @clear="handleRemove"
-      @file-selected="handleFileSelected"
-      @url-entered="handleUrlEntered"
-      @use-original-url="handleUseOriginalUrl"
-    />
+    <div v-if="contentMode === 'local'">
+      <InlineImageEditor
+        v-if="isImageKind"
+        :model-value="blobEditorContent"
+        :label="label"
+        :required="required"
+        :description="description"
+        v-model:comment="blobComment"
+        :loading="loadingBlobContent || isUploading || isLoadingBlob"
+        :error-message="errorMessage"
+        :preview-error-message="previewErrorMessage"
+        :original-checksum="currentBlobChecksum"
+        :original-comment="originalBlobComment"
+        :original-url="originalUrl"
+        @save="handleImageSave"
+        @clear="handleRemove"
+        @file-selected="handleFileSelected"
+        @url-entered="handleUrlEntered"
+        @use-original-url="handleUseOriginalUrl"
+      />
 
-    <!-- Hidden file input -->
-    <input
-      ref="fileInputRef"
-      type="file"
-      :accept="acceptedTypes"
-      style="display: none"
-      @change="handleFileChange"
-    />
+      <InlineTextEditor
+        v-else
+        :model-value="blobEditorContent"
+        :label="label"
+        :required="required"
+        :description="description"
+        :file-type="textFileType"
+        v-model:comment="blobComment"
+        :loading="loadingBlobContent || isUploading || isLoadingBlob"
+        :error-message="errorMessage"
+        :preview-error-message="previewErrorMessage"
+        :original-checksum="currentBlobChecksum"
+        :original-comment="originalBlobComment"
+        :original-url="originalUrl"
+        @save="handleTextSave"
+        @clear="handleRemove"
+        @file-selected="handleFileSelected"
+        @url-entered="handleUrlEntered"
+        @use-original-url="handleUseOriginalUrl"
+      />
+
+      <!-- Hidden file input -->
+      <input
+        ref="fileInputRef"
+        type="file"
+        :accept="acceptedTypes"
+        style="display: none"
+        @change="handleFileChange"
+      />
+    </div>
+
+    <div v-else>
+      <v-text-field
+        v-model.trim="remoteUrl"
+        :label="label"
+        :required="required"
+        :rules="urlRules"
+        :hint="description || ''"
+        variant="outlined"
+        density="compact"
+        type="url"
+        persistent-hint
+        placeholder="Enter external URL"
+        @update:model-value="handleRemoteUrlUpdate"
+      />
+    </div>
   </div>
 </template>
 
@@ -74,7 +97,8 @@ const IMAGE_KINDS = ['illustration', 'image'] as const
 interface Props {
   modelValue: string | null | undefined
   label?: string
-  kind?: 'image' | 'illustration' | 'css' | 'html' | 'txt'
+  kind?: 'image' | 'illustration' | 'css' | 'html' | 'txt' | string
+  allowRemoteUrl: boolean
   required?: boolean
   description?: string | null
   recipeName: string
@@ -108,6 +132,58 @@ const currentBlobChecksum = ref<string | undefined>(undefined)
 const isUploading = ref(false)
 const isLoadingBlob = ref(false)
 const originalUrl = ref<string | null>(props.modelValue || null)
+
+const contentMode = ref<'local' | 'remote'>('local')
+const remoteUrl = ref<string>('')
+
+const urlRules = [
+  (value: unknown) => {
+    if (props.required && (!value || value == '')) {
+      return 'This field is required.'
+    }
+    if (value && typeof value === 'string' && value !== '') {
+      try {
+        new URL(value)
+        return true
+      } catch {
+        return 'Please enter a valid URL.'
+      }
+    }
+    return true
+  },
+]
+
+const handleRemoteUrlUpdate = (value: string) => {
+  emit('update:modelValue', value)
+}
+
+watch(contentMode, async (newMode) => {
+  if (newMode === 'remote') {
+    if (!remoteUrl.value && props.modelValue) {
+      remoteUrl.value = props.modelValue
+    }
+    emit('update:modelValue', remoteUrl.value)
+  } else {
+    emit('update:modelValue', originalUrl.value)
+
+    const newValue = originalUrl.value
+    if (!newValue) {
+      userInput.value = ''
+      errorMessage.value = ''
+      hasError.value = false
+      blobEditorContent.value = ''
+    } else {
+      if (newValue.startsWith('http://') || newValue.startsWith('https://')) {
+        userInput.value = newValue
+      }
+      if (isImageKind.value) {
+        await loadImageFromUrl(newValue)
+      } else if (isTextKind.value) {
+        await loadTextFromUrl(newValue)
+      }
+    }
+  }
+})
 
 const isTextKind = computed(() => TEXT_KINDS.includes(props.kind as (typeof TEXT_KINDS)[number]))
 const isImageKind = computed(() => IMAGE_KINDS.includes(props.kind as (typeof IMAGE_KINDS)[number]))
@@ -309,6 +385,8 @@ const loadImageFromUrl = async (url: string) => {
     console.error('Failed to load image content:', error)
     previewErrorMessage.value = `Failed to load ${props.kind} for editing (URL: ${url})`
     hasError.value = true
+    // if we cannot load the blob and it supports remote input, force remote input mode
+    if (props.allowRemoteUrl) contentMode.value = 'remote'
   } finally {
     loadingBlobContent.value = false
   }
@@ -338,6 +416,8 @@ const loadTextFromUrl = async (url: string) => {
     console.error('Failed to load text content:', error)
     previewErrorMessage.value = `Failed to load text file for editing (URL: ${url})`
     hasError.value = true
+    // if we cannot load the blob and it supports remote input, force remote input mode
+    if (props.allowRemoteUrl) contentMode.value = 'remote'
   } finally {
     loadingBlobContent.value = false
   }
@@ -493,6 +573,17 @@ async function fetchBlobByUrl(url: string, isText = false): Promise<Blob | strin
 watch(
   () => props.modelValue,
   async (newValue, oldValue) => {
+    if (newValue !== remoteUrl.value) {
+      remoteUrl.value = newValue || ''
+    }
+    if (newValue !== originalUrl.value) {
+      originalUrl.value = newValue || null
+    }
+
+    if (contentMode.value === 'remote') {
+      return
+    }
+
     if (!newValue && oldValue) {
       userInput.value = ''
       errorMessage.value = ''
@@ -502,7 +593,6 @@ watch(
     } else if (newValue && newValue !== oldValue) {
       if (newValue.startsWith('http://') || newValue.startsWith('https://')) {
         userInput.value = newValue
-        originalUrl.value = newValue
       }
       if (isImageKind.value) {
         await loadImageFromUrl(newValue)

--- a/frontend-ui/src/components/RecipeEditor.vue
+++ b/frontend-ui/src/components/RecipeEditor.vue
@@ -490,6 +490,7 @@
             :label="smAndDown ? field.label + (field.required ? ' *' : '') : undefined"
             :kind="field.kind"
             :required="field.required"
+            :allow-remote-url="field.allowRemoteUrl"
             :description="field.description ?? undefined"
             :recipe-name="recipe.name"
             :flag-key="field.key"
@@ -686,6 +687,7 @@ interface FlagField {
   max_graphemes: number | null
   pattern: string | null
   kind?: 'image' | 'illustration' | 'css' | 'html' | 'txt'
+  allowRemoteUrl: boolean
 }
 
 export interface Props {
@@ -1128,6 +1130,7 @@ const flagsFields = computed(() => {
       options,
       step,
       kind: field.kind,
+      allowRemoteUrl: field.allow_remote_url,
     }
   })
 })

--- a/frontend-ui/src/types/offliner.ts
+++ b/frontend-ui/src/types/offliner.ts
@@ -18,6 +18,7 @@ export interface OfflinerDefinition {
   max_graphemes: number | null
   pattern: string | null
   kind?: 'image' | 'illustration' | 'css' | 'html' | 'txt'
+  allow_remote_url: boolean
 }
 
 export interface OfflinerDefinitionResponse {


### PR DESCRIPTION
## Rationale
This PR enhances the blob editor to allow editors to input external blob URLs if the flag in the offliner definition supports it. For such flags, the blob editor can be viewed in local/remote mode with remote allowing the user to input an external URL and `local` for the other modes of input already supported by the blob editor.
<img width="1156" height="745" alt="Screenshot_20260512_165838" src="https://github.com/user-attachments/assets/84ec229c-7904-4db8-b4b0-734d918edacf" />


## Changes
- add property `allow_remote_url` to the flag schema. should only be set for flags that are blob types
- update the maintenance script to modify mwoffliner's `articleListToIgnore` and `articleList` to be txt blobs
- add script to modify any property belonging to any offliner flag. will be used to update both flags by setting their `allow_remote_url` to True.
- force remote mode when we allow remote mode but blob editor fails to load content because default mode is local

This closes #1859 
