### PR TITLE
Fix folder_name sent in CMS notification

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,16 +9,16 @@ repos:
       - id: end-of-file-fixer
       - id: mixed-line-ending
 
+  - repo: https://github.com/psf/black
+    rev: "25.1.0"
+    hooks:
+      - id: black
+
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.11.10
     hooks:
       - id: ruff-check
       - id: ruff-format
-
-  - repo: https://github.com/psf/black
-    rev: "25.1.0"
-    hooks:
-      - id: black
 
   - repo: https://github.com/RobertCraigie/pyright-python
     rev: v1.1.400

--- a/backend/src/zimfarm_backend/background_tasks/send_cms_notifications.py
+++ b/backend/src/zimfarm_backend/background_tasks/send_cms_notifications.py
@@ -174,11 +174,15 @@ def advertise_book_to_cms(session: OrmSession, task: TaskFullSchema, file_name: 
 def get_openzimcms_payload(
     *, file: TaskFileSchema, zimcheck_base_url: str | None, warehouse_path: str
 ) -> dict[str, Any]:
+    # remove leading "/" in warehouse path since CMS expects relative paths
+    folder_name = (
+        warehouse_path[1:] if warehouse_path.startswith("/") else warehouse_path
+    )
     payload = {
         "id": file.info["id"],
         "counter": file.info.get("counter"),
         "article_count": file.info.get("article_count"),
-        "folder_name": warehouse_path,
+        "folder_name": folder_name,
         "filename": file.name,
         "media_count": file.info.get("media_count"),
         "size": file.info.get("size"),


### PR DESCRIPTION
CMS expects `folder_name` to be a relative path, while Zimfarm stores something like `/.hidden/dev` (where CMS expects `.hidden/dev`)