### PR TITLE
add maint-script to restore mwoffliner articleLists from history

### DIFF
--- a/backend/maint-scripts/restore_mwoffliner_article_list.py
+++ b/backend/maint-scripts/restore_mwoffliner_article_list.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+import argparse
+from copy import deepcopy
+
+from sqlalchemy import select
+from sqlalchemy.orm import selectinload
+
+from zimfarm_backend import logger
+from zimfarm_backend.common.constants import API_ENDPOINT
+from zimfarm_backend.common.schemas.models import RecipeConfigSchema
+from zimfarm_backend.db import Session
+from zimfarm_backend.db.account import get_account_by_username
+from zimfarm_backend.db.models import Recipe, RecipeHistory
+from zimfarm_backend.db.offliner import get_offliner
+from zimfarm_backend.db.offliner_definition import (
+    create_offliner_definition_schema,
+    create_offliner_instance,
+)
+from zimfarm_backend.db.recipe import update_recipe
+
+
+def main(*, dry_run: bool = False):
+    with Session() as session:
+        user = get_account_by_username(session, username="maint-scripts")
+        offliner_id = "mwoffliner"
+        offliner = get_offliner(session, offliner_id)
+
+        recipes = (
+            session.execute(
+                select(Recipe)
+                .where(Recipe.config["offliner"]["offliner_id"].astext == offliner_id)
+                .options(selectinload(Recipe.offliner_definition))
+            )
+            .scalars()
+            .all()
+        )
+
+        for recipe in recipes:
+            article_list = recipe.config.get("offliner", {}).get("articleList")
+            if not article_list:
+                logger.info(
+                    f"Recipe '{recipe.name}' does not have an articleList set. "
+                    "Skipping..."
+                )
+                continue
+
+            if not (
+                article_list.startswith(API_ENDPOINT)
+                or article_list.startswith("https://farm.drive.openzim.org")
+            ):
+                logger.info(
+                    f"Recipe '{recipe.name} articleList already set to external URL: "
+                    f"'{article_list}'. Skipping..."
+                )
+                continue
+
+            histories = (
+                session.execute(
+                    select(RecipeHistory)
+                    .where(RecipeHistory.recipe_id == recipe.id)
+                    .order_by(RecipeHistory.created_at.desc())
+                )
+                .scalars()
+                .all()
+            )
+
+            found_old_url = None
+            for history in histories:
+                hist_article_list = history.config.get("offliner", {}).get(
+                    "articleList"
+                )
+                if hist_article_list and not (
+                    hist_article_list.startswith(API_ENDPOINT)
+                    or hist_article_list.startswith("https://farm.drive.openzim.org")
+                ):
+                    found_old_url = hist_article_list
+                    break
+
+            if found_old_url:
+                logger.info(f"Found old articleList for {recipe.name}: {found_old_url}")
+                if dry_run:
+                    logger.info(
+                        f"[dry run]: Changed articleList for {recipe.name} from "
+                        f"{article_list} to {found_old_url}."
+                    )
+                    continue
+
+                offliner_def = create_offliner_definition_schema(
+                    recipe.offliner_definition
+                )
+                new_config = deepcopy(recipe.config)
+                new_config["offliner"]["articleList"] = found_old_url
+
+                recipe_config = RecipeConfigSchema.model_validate(
+                    {
+                        **new_config,
+                        "offliner": create_offliner_instance(
+                            offliner=offliner,
+                            offliner_definition=offliner_def,
+                            data=new_config["offliner"],
+                            skip_validation=True,
+                        ),
+                    },
+                    context={"skip_validation": True},
+                )
+
+                update_recipe(
+                    session=session,
+                    author_id=user.id,
+                    recipe_name=recipe.name,
+                    offliner_definition=offliner_def,
+                    new_recipe_config=recipe_config,
+                    comment="Restore mwoffliner articleList from history",
+                )
+                session.commit()
+                logger.info(
+                    f"Changed articleList for {recipe.name} from "
+                    f"{article_list} to {found_old_url}."
+                )
+            else:
+                logger.warning(f"Could not find old articleList for {recipe.name}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Restore mwoffliner articleList from history"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Do not apply the changes"
+    )
+    args = parser.parse_args()
+    main(dry_run=args.dry_run)


### PR DESCRIPTION
## Rationale
This PR adds a maintenace script to restore mwoffliner `articleList` flag from history. The URL chosen is a URL that doesn't start with 'API_ENDPOINT` env var or `http://farm.drive.openzim.org`. 

Here's a sample output run in `dry run`mode
```bash
root@d9a653b2a07d:/app/maint-scripts# API_ENDPOINT=http://backend:80/v2 python3 restore_mwoffliner_article_list.py --dry-run
[2026-04-23 11:04:01,241: WARNING] Recipe 'wikidex.net_es_all' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,242: WARNING] Recipe 'chabadtext_he_all' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,242: WARNING] Recipe 'wikisource_or' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,242: WARNING] Recipe 'librepathology_en_all' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,242: WARNING] Recipe 'wiktionary_pnb' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,246: INFO] Found old articleList for wikipedia_en_baseball: http://download.openzim.org/wp1/enwiki/projects/Baseball.tsv
[2026-04-23 11:04:01,246: INFO] [dry run]: Changed articleList for wikipedia_en_baseball from http://backend:80/v2/blobs/download/f2d9b220-c1c1-42bd-9474-31741378356d.txt to http://download.openzim.org/wp1/enwiki/projects/Baseball.tsv.
[2026-04-23 11:04:01,248: INFO] Found old articleList for wikipedia_kenya_en_app: https://drive.farm.openzim.org/custom%20apps/kenya_wp.tsv
[2026-04-23 11:04:01,248: INFO] [dry run]: Changed articleList for wikipedia_kenya_en_app from http://backend:80/v2/blobs/download/54306649-d3e0-42cb-91f6-55e60c893f0c.txt to https://drive.farm.openzim.org/custom%20apps/kenya_wp.tsv.
[2026-04-23 11:04:01,250: INFO] Found old articleList for mdwiki_public_full: https://mdwiki.wmcloud.org/nonwiki/lists/mdwikimed.tsv
[2026-04-23 11:04:01,250: INFO] [dry run]: Changed articleList for mdwiki_public_full from http://backend:80/v2/blobs/download/84bd7d9c-605f-43a0-8c43-9c0a4e473c73.txt to https://mdwiki.wmcloud.org/nonwiki/lists/mdwikimed.tsv.
[2026-04-23 11:04:01,250: WARNING] Recipe 'desencyclopedie_fr_all' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,252: INFO] Found old articleList for mdwiki_app_maxi: https://mdwiki.wmcloud.org/nonwiki/lists/mdwikimed.tsv
[2026-04-23 11:04:01,252: INFO] [dry run]: Changed articleList for mdwiki_app_maxi from http://backend:80/v2/blobs/download/87d84c7b-d0a6-4949-9dba-e7668cb8d4e6.txt to https://mdwiki.wmcloud.org/nonwiki/lists/mdwikimed.tsv.
[2026-04-23 11:04:01,252: WARNING] Recipe 'balatrowiki.org_en_all' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,252: WARNING] Recipe 'pg3d.wiki.gg_en_all' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,252: WARNING] Recipe 'vampire.survivors.wiki_en_all' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,252: WARNING] Recipe 'consumerrights.wiki_en_all' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,252: WARNING] Recipe 'wiki.mabinogiworld.com_en_all' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,252: WARNING] Recipe 'wikipedia_lb_all' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,252: WARNING] Recipe 'wikipedia_hu_all' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,252: WARNING] Recipe 'wikisource_it' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,252: INFO] Recipe 'appropedia_en_all articleList already set to external URL: 'https://www.appropedia.org/kiwix.tsv'. Skipping...
[2026-04-23 11:04:01,252: WARNING] Recipe 'wikipedia_ga_all' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,252: WARNING] Recipe 'wikiquote_gu' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,254: INFO] Found old articleList for wikipedia_es_venezuela: http://download.openzim.org/wp1/eswiki/customs/venezuela.tsv
[2026-04-23 11:04:01,254: INFO] [dry run]: Changed articleList for wikipedia_es_venezuela from http://backend:80/v2/blobs/download/22b4c6c0-2ca3-4a8b-b45d-2072c86194cb.txt to http://download.openzim.org/wp1/eswiki/customs/venezuela.tsv.
[2026-04-23 11:04:01,254: WARNING] Recipe 'wikipedia_ro_all' does not have an articleList set. Skipping...
[2026-04-23 11:04:01,256: INFO] Found old articleList for mdwiki_app_mini: https://mdwiki.wmcloud.org/nonwiki/lists/mdwikimed.tsv
[2026-04-23 11:04:01,256: INFO] [dry run]: Changed articleList for mdwiki_app_mini from http://backend:80/v2/blobs/download/e41f971a-e52e-44ef-816b-f3e7a71c6b34.txt to https://mdwiki.wmcloud.org/nonwiki/lists/mdwikimed.tsv.
[
```


This closes #1859