### PR TITLE
hide download button when zim urls is empty

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -132,9 +132,7 @@ class TaskFileSchema(BaseModel):
     check_filename: str | None = None
     check_upload_timestamp: datetime.datetime | None = None
     info: dict[str, Any] = Field(default_factory=dict)
-    zim_urls: list[ZimUrlSchema] = Field(  # pyright: ignore[reportUnknownVariableType]
-        default_factory=list
-    )
+    zim_urls: list[ZimUrlSchema] | None = None
 
 
 class TaskContainerProgressSchema(BaseModel):

--- a/frontend-ui/src/components/TaskFileCard.vue
+++ b/frontend-ui/src/components/TaskFileCard.vue
@@ -126,7 +126,7 @@
 
       <template v-if="file.uploaded_timestamp">
         <ZimUrlButtons v-if="file.zim_urls && file.zim_urls.length > 0" :urls="file.zim_urls" />
-        <v-tooltip v-else location="top">
+        <v-tooltip v-else-if="file.zim_urls == null" location="top">
           <template #activator="{ props: tooltipProps }">
             <v-btn
               v-bind="tooltipProps"

--- a/frontend-ui/src/types/tasks.ts
+++ b/frontend-ui/src/types/tasks.ts
@@ -38,7 +38,7 @@ export interface TaskFile {
   check_filename?: string
   check_upload_timestamp?: string
   info?: TaskFileInfo
-  zim_urls: ZimUrl[]
+  zim_urls: ZimUrl[] | null
 }
 
 export interface TaskResourceUsage {


### PR DESCRIPTION
## Rationale
This PR implements the logic to hide dowload buttons when zim urls is an empty list
## Changes
- make zim urls nullable
- hide download links when zim urls is an empty list. Empty list indicates call wen through to CMS but returned an empty response
- show default download link when zim urls is null. This happens only when `INFORM_CMS` is set to `false` as the call to CMS API never goes through

This closes #1867
