### PR TITLE
use default httpRequest with timeout

### DIFF
--- a/frontend-ui/src/components/BlobDiffViewer.vue
+++ b/frontend-ui/src/components/BlobDiffViewer.vue
@@ -84,6 +84,7 @@ import 'diff2html/bundles/css/diff2html.min.css'
 import { useNotificationStore } from '@/stores/notification'
 import { isTextKind, isImageKind, type BlobKind } from '@/utils/blob'
 import { ColorSchemeType } from 'diff2html/lib/types'
+import httpRequest from '@/utils/httpRequest'
 
 interface Props {
   oldBlobUrl: string | null
@@ -109,11 +110,8 @@ const isText = computed(() => isTextKind(props.kind))
 const isImage = computed(() => isImageKind(props.kind))
 
 const fetchBlobByUrl = async (url: string): Promise<Blob | null> => {
-  const response = await fetch(url)
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`)
-  }
-  return await response.blob()
+  const service = httpRequest({})
+  return await service.get<unknown, Blob>(url, { responseType: 'blob' })
 }
 
 const fetchImageBlob = async (url: string): Promise<string> => {

--- a/frontend-ui/src/components/BlobEditor.vue
+++ b/frontend-ui/src/components/BlobEditor.vue
@@ -53,6 +53,7 @@
 </template>
 
 <script setup lang="ts">
+import httpRequest from '@/utils/httpRequest'
 import { formattedBytesSize } from '@/utils/format'
 import constants from '@/constants'
 import type { Config } from '@/config'
@@ -459,12 +460,8 @@ async function fetchBlobByUrl(url: string, isText = false): Promise<Blob | strin
   errorMessage.value = ''
 
   try {
-    const response = await fetch(url)
-    if (!response.ok) {
-      throw new Error(`Failed to fetch file: ${response.statusText}`)
-    }
-
-    const blob = await response.blob()
+    const service = httpRequest({})
+    const blob = await service.get<unknown, Blob>(url, { responseType: 'blob' })
     const file = new File([blob], 'downloaded-file', { type: blob.type })
     const localChecksum = await computeChecksumFromFile(file)
 

--- a/frontend-ui/src/components/BlobViewer.vue
+++ b/frontend-ui/src/components/BlobViewer.vue
@@ -62,6 +62,7 @@
 </template>
 
 <script setup lang="ts">
+import httpRequest from '@/utils/httpRequest'
 import { computed, ref } from 'vue'
 import { useNotificationStore } from '@/stores/notification'
 import { isTextKind, type BlobKind, type TextKind } from '@/utils/blob'
@@ -85,11 +86,8 @@ const loadingBlobContent = ref(false)
 const isText = computed(() => isTextKind(props.kind))
 
 const fetchBlobByUrl = async (url: string): Promise<Blob | null> => {
-  const response = await fetch(url)
-  if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`)
-  }
-  return await response.blob()
+  const service = httpRequest({})
+  return await service.get<unknown, Blob>(url, { responseType: 'blob' })
 }
 
 const handleViewImage = async () => {

--- a/frontend-ui/src/components/RecipeHistory.vue
+++ b/frontend-ui/src/components/RecipeHistory.vue
@@ -1,6 +1,12 @@
 <template>
   <v-container fluid>
-    <template v-if="history.length > 0">
+    <template v-if="loading && history.length === 0">
+      <div class="d-flex flex-column justify-center align-center pa-8">
+        <v-progress-circular indeterminate color="primary" size="64" />
+        <span class="mt-4">Loading Recipe history...</span>
+      </div>
+    </template>
+    <template v-else-if="history.length > 0">
       <template v-if="!showDiffViewer">
         <v-alert type="info" variant="tonal" :icon="false">
           <template v-slot:prepend>

--- a/frontend-ui/src/stores/auth.ts
+++ b/frontend-ui/src/stores/auth.ts
@@ -289,12 +289,16 @@ export const useAuthStore = defineStore('auth', () => {
     if (!token)
       return httpRequest({
         baseURL: `${config.ZIMFARM_WEBAPI}/${baseURL}`,
+        headers: {
+          'Content-Type': 'application/json',
+        },
       })
 
     return httpRequest({
       baseURL: `${config.ZIMFARM_WEBAPI}/${baseURL}`,
       headers: {
         Authorization: `Bearer ${token.access_token}`,
+        'Content-Type': 'application/json',
       },
     })
   }

--- a/frontend-ui/src/utils/httpRequest.ts
+++ b/frontend-ui/src/utils/httpRequest.ts
@@ -9,7 +9,6 @@ export default function httpRequest(
     timeout: 30000, // timeout of 30 seconds
     headers: {
       ...headers,
-      'Content-Type': 'application/json',
     },
     withCredentials,
     paramsSerializer: {


### PR DESCRIPTION
## Changes
- use httpRequest object (axios wrapper) with timeout to make requests instead of native `fetch` API
- show loading icon while fetching recipe history

This closes #1873