### PR TITLE
add margin to info and detail views

### DIFF
--- a/frontend-ui/src/views/RecipeDetailView.vue
+++ b/frontend-ui/src/views/RecipeDetailView.vue
@@ -153,7 +153,7 @@
         <v-window-item value="details">
           <v-card flat>
             <v-card-text class="pa-0">
-              <div>
+              <div class="ml-4 mr-4 mt-2 mb-2">
                 <v-row no-gutters class="py-2">
                   <v-col cols="12" md="4">
                     <div class="text-subtitle-2">API</div>
@@ -507,7 +507,7 @@
         <v-window-item value="config">
           <v-card flat>
             <v-card-text class="pa-0">
-              <div>
+              <div class="ml-4 mr-4 mt-2 mb-2">
                 <v-row no-gutters class="py-2">
                   <v-col cols="12" md="4">
                     <div class="text-subtitle-2">Offliner</div>

--- a/frontend-ui/src/views/TaskDetailView.vue
+++ b/frontend-ui/src/views/TaskDetailView.vue
@@ -68,7 +68,7 @@
         <v-window-item value="details">
           <v-card flat>
             <v-card-text class="pa-0">
-              <div>
+              <div class="ml-4 mr-4 mt-2 mb-2">
                 <v-row no-gutters class="py-2">
                   <v-col cols="12" md="3">
                     <div class="text-subtitle-2">ID</div>
@@ -234,7 +234,7 @@
         <v-window-item value="debug">
           <v-card flat>
             <v-card-text class="pa-0">
-              <div>
+              <div class="ml-4 mr-4 mt-2 mb-2">
                 <v-row v-if="task.config" no-gutters class="py-2">
                   <v-col cols="12" md="3">
                     <div class="text-subtitle-2">Offliner</div>
@@ -855,7 +855,7 @@ onBeforeUnmount(() => {
 .stdout,
 .stderr {
   max-height: 9rem;
-  overflow: scroll;
+  overflow-y: auto;
   background-color: rgb(var(--v-theme-surface));
   padding: 1rem;
   border-radius: 4px;


### PR DESCRIPTION
## Rationale
<img width="1136" height="518" alt="Screenshot_20260427_095953" src="https://github.com/user-attachments/assets/8a7a9508-8eeb-4688-a0e6-4f840c3d0e1d" />

## Changes
- add a margin to the info/details views of tasks/recipes. side margins are 4 units with top and bottom set to 2 as each row within the component adds a `py-2`.
- remove horizontal scrollbar from scraper stderr and stdout zone since text wraps around

This closes #1875
