### PR TITLE
refactor grapheme string validation for offliner flags

### DIFF
--- a/backend/maint-scripts/update_offliner_definition_graphemes.py
+++ b/backend/maint-scripts/update_offliner_definition_graphemes.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+
+import argparse
+from copy import deepcopy
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm.attributes import flag_modified
+
+from zimfarm_backend import logger
+from zimfarm_backend.db import Session
+from zimfarm_backend.db.models import OfflinerDefinition
+from zimfarm_backend.db.offliner_definition import create_offliner_definition_schema
+
+
+def update_flag(
+    flags_dict: dict[str, Any], *, flag_name: str, old_key: str, new_key: str
+) -> bool:
+    flag_changed = False
+
+    if old_key in flags_dict[flag_name]:
+        flags_dict[flag_name][new_key] = flags_dict[flag_name][old_key]
+        del flags_dict[flag_name][old_key]
+        flag_changed = True
+        if flag_changed:
+            logger.info(
+                f"Schema modified for {offliner_definition.offliner} "
+                f"v{offliner_definition.version} flag '{flag_name}'"
+            )
+
+    return flag_changed
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="""
+Update offliner definition schemas: minLength -> minGraphemes, maxLength -> maxGraphemes
+""",
+    )
+
+    args = parser.parse_args()
+
+    with Session.begin() as session:
+        definitions = session.execute(select(OfflinerDefinition)).scalars().all()
+        for offliner_definition in definitions:
+            logger.info(
+                f"Processing {offliner_definition.offliner} version "
+                f"{offliner_definition.version}"
+            )
+            flags_dict = deepcopy(offliner_definition.schema["flags"])
+
+            offliner_modified = False
+            for flag in flags_dict:
+                update_flag(
+                    flags_dict,
+                    flag_name=flag,
+                    old_key="min_length",
+                    new_key="min_graphemes",
+                )
+
+                update_flag(
+                    flags_dict,
+                    flag_name=flag,
+                    old_key="max_length",
+                    new_key="max_graphemes",
+                )
+
+                update_flag(
+                    flags_dict,
+                    flag_name=flag,
+                    old_key="relaxed_min_length",
+                    new_key="relaxed_min_graphemes",
+                )
+
+                update_flag(
+                    flags_dict,
+                    flag_name=flag,
+                    old_key="relaxed_max_length",
+                    new_key="relaxed_max_graphemes",
+                )
+
+            offliner_definition.schema["flags"] = flags_dict
+            flag_modified(offliner_definition, "schema")
+            # Validate that the schema is still valid
+            create_offliner_definition_schema(offliner_definition)
+            logger.info(
+                f"Schema modified for {offliner_definition.offliner} "
+                f"v{offliner_definition.version}"
+            )
+
+    logger.info("FINISH!")

--- a/backend/src/zimfarm_backend/common/schemas/fields.py
+++ b/backend/src/zimfarm_backend/common/schemas/fields.py
@@ -1,4 +1,5 @@
 from collections.abc import Callable
+from dataclasses import dataclass
 from enum import Enum
 from typing import Annotated, Any
 
@@ -22,14 +23,26 @@ from zimfarm_backend.common.constants import SECRET_STRING_LENGTH
 from zimfarm_backend.common.enums import Platform, WarehousePath
 
 
-class GraphemeStr(str):
-    def __len__(self) -> int:
-        # Count the number of grapheme clusters
-        return len(regex.findall(r"\X", self))
+@dataclass(frozen=True)
+class GraphemeLength:
+    min: int | None = None
+    max: int | None = None
 
+    def __call__(self, v: str, info: ValidationInfo) -> str:
+        context = info.context
+        if context and context.get("skip_validation"):
+            return v
 
-def to_grapheme_str(value: str):
-    return GraphemeStr(value)
+        n = len(regex.findall(r"\X", v))
+        if self.min is not None and n < self.min:
+            raise ValueError(
+                f"String should have at least {self.min} grapheme clusters (got {n})"
+            )
+        if self.max is not None and n > self.max:
+            raise ValueError(
+                f"String should have at most {self.max} grapheme clusters (got {n})"
+            )
+        return v
 
 
 def no_null_char(value: str) -> str:
@@ -46,11 +59,9 @@ def OptionalField(**kwargs: Any) -> Any:  # noqa N802
 
 
 NoNullCharString = Annotated[
-    str, AfterValidator(no_null_char), AfterValidator(to_grapheme_str)
+    str,
+    AfterValidator(no_null_char),
 ]
-
-
-OptionalNoNullCharString = NoNullCharString | None
 
 
 def not_empty(value: str) -> str:
@@ -58,6 +69,8 @@ def not_empty(value: str) -> str:
     if not value.strip():
         raise ValueError("String value cannot be empty")
 
+    # cast value to str else Field validators will use the str len method for
+    # length validation
     return value.strip()
 
 
@@ -109,15 +122,6 @@ def enum_member(
 
 NotEmptyString = Annotated[NoNullCharString, AfterValidator(not_empty)]
 
-OptionalNotEmptyString = NotEmptyString | None
-
-ZIMMetadataString = Annotated[
-    str,
-    AfterValidator(no_null_char),
-    AfterValidator(not_empty),
-    AfterValidator(to_grapheme_str),
-]
-
 
 def show_secrets(value: Any, _: Any, info: SerializationInfo) -> Any:
     """Show secret values in serialization"""
@@ -142,12 +146,8 @@ def skip_validation(
 
 ZIMSecretStr = Annotated[SecretStr, WrapSerializer(show_secrets)]
 
-OptionalZIMSecretStr = ZIMSecretStr | None
 
 Percentage = Annotated[int, Field(ge=1, le=100), WrapValidator(skip_validation)]
-
-
-OptionalPercentage = Percentage | None
 
 
 def validate_secret_url(v: ZIMSecretStr | str, info: ValidationInfo) -> ZIMSecretStr:
@@ -165,72 +165,14 @@ def validate_secret_url(v: ZIMSecretStr | str, info: ValidationInfo) -> ZIMSecre
 
 SecretUrl = Annotated[ZIMSecretStr, AfterValidator(validate_secret_url)]
 
-OptionalSecretUrl = SecretUrl | None
 
 SkipableUrl = Annotated[AnyUrl, WrapValidator(skip_validation)]
-OptionalSkipableUrl = SkipableUrl | None
 
-ZIMLongDescription = Annotated[
-    ZIMMetadataString,
-    Field(min_length=1, max_length=4000),
-    WrapValidator(skip_validation),
-]
-
-OptionalZIMLongDescription = ZIMLongDescription | None
-
-ZIMTitle = Annotated[
-    ZIMMetadataString,
-    Field(min_length=1, max_length=30),
-    WrapValidator(skip_validation),
-]
-
-OptionalZIMTitle = ZIMTitle | None
-
-ZIMDescription = Annotated[
-    ZIMMetadataString,
-    Field(min_length=1, max_length=80),
-    WrapValidator(skip_validation),
-]
-
-OptionalZIMDescription = ZIMDescription | None
-
-ZIMFileName = Annotated[
-    str,
-    Field(
-        pattern=r"^([a-z0-9\-\.]+_)([a-z\-]+_)([a-z0-9\-\.]+_)([a-z0-9\-\.]+_|)([\d]{4}-[\d]{2}|\{period\}).zim$"
-    ),
-    WrapValidator(skip_validation),
-]
-
-OptionalZIMFileName = ZIMFileName | None
-
-SlugString = Annotated[
-    str,
-    Field(
-        pattern=r"^[A-Za-z0-9._-]+$",
-    ),
-    WrapValidator(skip_validation),
-]
-
-OptionalSlugString = SlugString | None
-
-ZIMName = Annotated[
-    str,
-    Field(pattern=r"^([a-z0-9\-\.]+_)([a-z\-]+_)([a-z0-9\-\.]+)$"),
-    WrapValidator(skip_validation),
-]
-
-OptionalZIMName = ZIMName | None
 
 SlackTarget = Annotated[
     str, Field(pattern=r"^[#|@].+$"), WrapValidator(skip_validation)
 ]
 
-OptionalSlackTarget = SlackTarget | None
-
-ZIMPlatformValue = Annotated[int, Field(ge=1), WrapValidator(skip_validation)]
-
-OptionalZIMPlatformValue = ZIMPlatformValue | None
 
 ZIMLangCode = Annotated[
     str,
@@ -239,23 +181,8 @@ ZIMLangCode = Annotated[
     AfterValidator(validate_language_code),
 ]
 
-CommaSeparatedZIMLangCode = Annotated[
-    str,
-    Field(pattern=r"^[a-z]{3}(,[a-z]{3})*$"),
-    AfterValidator(validate_comma_separated_zim_lang_code),
-    WrapValidator(skip_validation),
-]
-
-OptionalCommaSeparatedZIMLangCode = CommaSeparatedZIMLangCode | None
-
-OptionalZIMLangCode = ZIMLangCode | None
-
-ZIMOutputFolder = Annotated[
-    str, Field(pattern=r"^/output$"), WrapValidator(skip_validation)
-]
 
 SkipableBool = Annotated[bool, WrapValidator(skip_validation)]
-OptionalSkipableBool = SkipableBool | None
 
 
 def serialize_color_to_hex(value: Any, _: SerializerFunctionWrapHandler) -> str:
@@ -269,49 +196,31 @@ SkipableColor = Annotated[
     Color, WrapValidator(skip_validation), WrapSerializer(serialize_color_to_hex)
 ]
 
-OptionalZIMOutputFolder = ZIMOutputFolder | None
-
-ZIMProgressFile = Annotated[
-    NotEmptyString,
-    Field(pattern=r"^/output/task_progress\.json$"),
-    WrapValidator(skip_validation),
-]
-
-OptionalZIMProgressFile = ZIMProgressFile | None
 
 ZIMCPU = Annotated[int, Field(ge=0), WrapValidator(skip_validation)]
 
-OptionalZIMCPU = ZIMCPU | None
 
 ZIMMemory = Annotated[int, Field(ge=0), WrapValidator(skip_validation)]
 
-OptionalZIMMemory = ZIMMemory | None
 
 ZIMDisk = Annotated[int, Field(ge=0), WrapValidator(skip_validation)]
 
-OptionalZIMDisk = ZIMDisk | None
 
 SkipField = Annotated[int, Field(ge=0), WrapValidator(skip_validation)]
 
-OptionalSkipField = SkipField | None
 
 LimitFieldMax500 = Annotated[int, Field(ge=1, le=500), WrapValidator(skip_validation)]
 
-OptionalLimitFieldMax500 = LimitFieldMax500 | None
 
 LimitFieldMax200 = Annotated[int, Field(ge=1, le=200), WrapValidator(skip_validation)]
 
-OptionalLimitFieldMax200 = LimitFieldMax200 | None
 
 PriorityField = Annotated[int, Field(ge=1, le=10), WrapValidator(skip_validation)]
 
-OptionalPriorityField = PriorityField | None
 
 WorkerField = Annotated[
     NotEmptyString, Field(min_length=3), WrapValidator(skip_validation)
 ]
-
-OptionalWorkerField = WorkerField | None
 
 
 def validate_recipe_name(name: str, info: ValidationInfo) -> str:
@@ -333,8 +242,6 @@ def validate_recipe_name(name: str, info: ValidationInfo) -> str:
 
 
 RecipeNameField = Annotated[NotEmptyString, AfterValidator(validate_recipe_name)]
-
-OptionalRecipeNameField = RecipeNameField | None
 
 
 def validate_warehouse_path(warehouse_path: str, info: ValidationInfo) -> str:
@@ -360,5 +267,3 @@ def validate_platform_value(platform: str, info: ValidationInfo) -> str:
 
 
 PlatformField = Annotated[str, AfterValidator(validate_platform_value)]
-
-OptionalPlatformField = PlatformField | None

--- a/backend/src/zimfarm_backend/common/schemas/offliners/builder.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/builder.py
@@ -5,6 +5,7 @@ from itertools import chain
 from typing import Annotated, Any, Literal, Optional, cast
 
 from pydantic import (
+    AfterValidator,
     ConfigDict,
     EmailStr,
     Field,
@@ -18,6 +19,7 @@ from zimfarm_backend import logger
 from zimfarm_backend.common.constants import getenv, parse_bool
 from zimfarm_backend.common.schemas import CamelModel, DashModel
 from zimfarm_backend.common.schemas.fields import (
+    GraphemeLength,
     NotEmptyString,
     OptionalField,
     SecretUrl,
@@ -89,36 +91,21 @@ def generate_field_type(offliner: str, flag: FlagSchema, label: str):
     use_relaxed_schema = parse_bool(
         getenv(f"{offliner.upper()}_USE_RELAXED_SCHEMA", default="false")
     )
-    pydantic_field_cls = Field if flag.required else OptionalField
-    pydantic_field = pydantic_field_cls(
-        title=flag.title,
-        description=flag.description,
-        alias=flag.alias,
-        ge=(flag.relaxed_min if flag.relaxed_min and use_relaxed_schema else flag.min),
-        le=(flag.relaxed_max if flag.relaxed_max and use_relaxed_schema else flag.max),
-        pattern=(
-            flag.relaxed_pattern
-            if flag.relaxed_pattern and use_relaxed_schema
-            else flag.pattern
-        ),
-        min_length=(
-            flag.relaxed_min_length
-            if flag.relaxed_min_length and use_relaxed_schema
-            else flag.min_length
-        ),
-        max_length=(
-            flag.relaxed_max_length
-            if flag.relaxed_max_length and use_relaxed_schema
-            else flag.max_length
-        ),
-        # if a field is required and no default is specified, use ellipsis ...
-        # otherwise, it invalidates the required validation
-        default=... if flag.required and flag.default is None else flag.default,
-        frozen=parse_bool(flag.frozen),
-        # Add additional information to the pydantic field to be used while determining
-        # flag details.
-        json_schema_extra={"kind": flag.kind, "type": flag.type},
+    resolved_min_graphemes = (
+        flag.relaxed_min_graphemes
+        if flag.relaxed_min_graphemes and use_relaxed_schema
+        else flag.min_graphemes
     )
+    resolved_max_graphemes = (
+        flag.relaxed_max_graphemes
+        if flag.relaxed_max_graphemes and use_relaxed_schema
+        else flag.max_graphemes
+    )
+    # Additional information to the pydantic field to be used while determining
+    # flag details.
+    json_schema_extra: dict[str, Any] = {"kind": flag.kind, "type": flag.type}
+
+    # Determine the python type to represent the flag
     match flag.type:
         case "string-enum" | "list-of-string-enum":
             # We don't have a type map for string enum types as we don't
@@ -156,6 +143,22 @@ def generate_field_type(offliner: str, flag: FlagSchema, label: str):
                 py_type = base_type if flag.required else Optional[base_type]
         case "string" | "list-of-string":
             base_type = ZIMSecretStr if flag.secret else NotEmptyString
+
+            # Apply the min/max graphemes restraint to the string type
+            if resolved_min_graphemes is not None or resolved_max_graphemes is not None:
+                base_type = Annotated[
+                    base_type,
+                    AfterValidator(
+                        GraphemeLength(
+                            min=resolved_min_graphemes, max=resolved_max_graphemes
+                        )
+                    ),
+                ]
+                if resolved_min_graphemes is not None:
+                    json_schema_extra["minGraphemes"] = resolved_min_graphemes
+                if resolved_max_graphemes is not None:
+                    json_schema_extra["maxGraphemes"] = resolved_max_graphemes
+
             if flag.type == "list-of-string":
                 py_type = (
                     list[base_type] if flag.required else Optional[list[base_type]]
@@ -168,6 +171,25 @@ def generate_field_type(offliner: str, flag: FlagSchema, label: str):
             py_type = (
                 TYPE_MAP[flag.type] if flag.required else Optional[TYPE_MAP[flag.type]]
             )
+
+    pydantic_field_cls = Field if flag.required else OptionalField
+    pydantic_field = pydantic_field_cls(
+        title=flag.title,
+        description=flag.description,
+        alias=flag.alias,
+        ge=(flag.relaxed_min if flag.relaxed_min and use_relaxed_schema else flag.min),
+        le=(flag.relaxed_max if flag.relaxed_max and use_relaxed_schema else flag.max),
+        pattern=(
+            flag.relaxed_pattern
+            if flag.relaxed_pattern and use_relaxed_schema
+            else flag.pattern
+        ),
+        # if a field is required and no default is specified, use ellipsis ...
+        # otherwise, it invalidates the required validation
+        default=... if flag.required and flag.default is None else flag.default,
+        frozen=parse_bool(flag.frozen),
+        json_schema_extra=json_schema_extra,
+    )
 
     # For secret fields, we use the already defined ZIMSecretStr type
     # and it's variants since it supports secret values and masking based on context
@@ -223,14 +245,12 @@ def build_offliner_model(
         for flag, flag_schema in schema.flags.items()
         if flag_schema.custom_validator
     }
-    model_validators: dict[str, Callable[..., Any]] = (
-        {  # pyright: ignore[reportAssignmentType]
-            f"{validator.name}_validator": model_validator(mode="after")(
-                get_model_validator(validator.name)(validator.fields)
-            )
-            for validator in schema.model_validators
-        }
-    )
+    model_validators: dict[str, Callable[..., Any]] = {  # pyright: ignore[reportAssignmentType]
+        f"{validator.name}_validator": model_validator(mode="after")(
+            get_model_validator(validator.name)(validator.fields)
+        )
+        for validator in schema.model_validators
+    }
     return create_model(
         f"{offliner.id}FlagsSchema",
         offliner_id=(Literal[offliner.id], Field(alias="offliner_id")),

--- a/backend/src/zimfarm_backend/common/schemas/offliners/models.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/models.py
@@ -17,8 +17,8 @@ class BaseFlagSchema(BaseModel):
     secret: bool = False
     min: int | None = None
     max: int | None = None
-    min_length: int | None = Field(validation_alias="minLength", default=None)
-    max_length: int | None = Field(validation_alias="maxLength", default=None)
+    min_graphemes: int | None = Field(validation_alias="minGraphemes", default=None)
+    max_graphemes: int | None = Field(validation_alias="maxGraphemes", default=None)
     pattern: str | None = None
 
 
@@ -55,11 +55,11 @@ class FlagSchema(BaseFlagSchema):
     relaxed_pattern: str | None = Field(validation_alias="relaxedPattern", default=None)
     relaxed_min: int | None = Field(validation_alias="relaxedMin", default=None)
     relaxed_max: int | None = Field(validation_alias="relaxedMax", default=None)
-    relaxed_min_length: int | None = Field(
-        validation_alias="relaxedMinLength", default=None
+    relaxed_min_graphemes: int | None = Field(
+        validation_alias="relaxedMinGraphemes", default=None
     )
-    relaxed_max_length: int | None = Field(
-        validation_alias="relaxedMaxLength", default=None
+    relaxed_max_graphemes: int | None = Field(
+        validation_alias="relaxedMaxGraphemes", default=None
     )
     custom_validator: str | None = Field(
         validation_alias="customValidator", default=None

--- a/backend/src/zimfarm_backend/common/schemas/offliners/serializer.py
+++ b/backend/src/zimfarm_backend/common/schemas/offliners/serializer.py
@@ -2,7 +2,7 @@ from enum import Enum
 from types import UnionType
 from typing import Annotated, Any, Union, cast, get_args, get_origin
 
-from annotated_types import Ge, Le, MaxLen, MinLen
+from annotated_types import Ge, Le
 from pydantic import BaseModel, SecretStr
 from pydantic.fields import FieldInfo
 
@@ -181,22 +181,20 @@ def schema_to_flags(schema_class: type[BaseModel]) -> list[Flag]:
             type=json_schema_extra["type"],
             secret=is_secret(field_type),
             kind=json_schema_extra["kind"],
+            min_graphemes=json_schema_extra.get("minGraphemes"),
+            max_graphemes=json_schema_extra.get("maxGraphemes"),
         )
 
         # Add choices if available
         if choices:
             flag_obj.choices = choices
 
-        # retrieve minlength, maxlength, pattern, ge, le, etc from metadata
+        # retrieve minGraphmes, maxGraphemes, pattern, ge, le, etc from metadata
         for metadata in get_field_metadata(field_info):
             if isinstance(metadata, Ge):
                 flag_obj.min = cast(int, metadata.ge)
             if isinstance(metadata, Le):
                 flag_obj.max = cast(int, metadata.le)
-            if isinstance(metadata, MinLen):
-                flag_obj.min_length = metadata.min_length
-            if isinstance(metadata, MaxLen):
-                flag_obj.max_length = metadata.max_length
             # the underlying type that holds the regex for the pattern is an internal
             # pydantic type which is not exported but it exists for a field that sets it
             if hasattr(metadata, "pattern"):

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -176,24 +176,24 @@ def mwoffliner_flags() -> OfflinerSpecSchema:
       "required": false,
       "title": "ZIM Title",
       "description": "Custom ZIM title. Wiki name otherwise.",
-      "minLength": 1,
-      "maxLength": 30
+      "minGraphemes": 1,
+      "maxGraphemes": 30
     },
     "customZimDescription": {
       "type": "string",
       "required": false,
       "title": "ZIM Description",
       "description": "Max length is 80 chars",
-      "minLength": 1,
-      "maxLength": 80
+      "minGraphemes": 1,
+      "maxGraphemes": 80
     },
     "customZimLongDescription": {
       "type": "string",
       "required": false,
       "title": "ZIM Long Description",
       "description": "Max length is 4000 chars",
-      "minLength": 1,
-      "maxLength": 4000
+      "minGraphemes": 1,
+      "maxGraphemes": 4000
     },
     "customZimFavicon": {
       "type": "url",
@@ -537,24 +537,24 @@ def ted_flags() -> OfflinerSpecSchema:
       "required": false,
       "title": "Title",
       "description": "Custom title for your ZIM. Based on selection otherwise",
-      "minLength": 1,
-      "maxLength": 30
+      "minGraphemes": 1,
+      "maxGraphemes": 30
     },
     "description": {
       "type": "string",
       "required": false,
       "title": "Description",
       "description": "Custom description for your ZIM. Based on selection otherwise",
-      "minLength": 1,
-      "maxLength": 80
+      "minGraphemes": 1,
+      "maxGraphemes": 80
     },
     "long_description": {
       "type": "string",
       "required": false,
       "title": "Long description",
       "description": "Custom long description for your ZIM. Based on selection otherwise",
-      "minLength": 1,
-      "maxLength": 4000
+      "minGraphemes": 1,
+      "maxGraphemes": 4000
     },
     "creator": {
       "type": "string",

--- a/backend/tests/test_offliner_serializer.py
+++ b/backend/tests/test_offliner_serializer.py
@@ -1,22 +1,11 @@
 from typing import Any
 
 import pytest
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel
 
 from zimfarm_backend.common.enums import TaskStatus
-from zimfarm_backend.common.schemas.fields import (
-    OptionalNotEmptyString,
-    OptionalSecretUrl,
-    OptionalZIMDescription,
-    OptionalZIMLongDescription,
-    OptionalZIMOutputFolder,
-    OptionalZIMSecretStr,
-    OptionalZIMTitle,
-    SecretUrl,
-)
 from zimfarm_backend.common.schemas.offliners.serializer import (
     get_enum_choices,
-    is_secret,
     schema_to_flags,
 )
 
@@ -33,27 +22,6 @@ def test_get_enum_choices(field_type: Any, expected_choices: list[str]):
     assert len(choices) == len(expected_choices)
     for choice in choices:
         assert choice in expected_choices
-
-
-@pytest.mark.parametrize(
-    "field,is_secret_field",
-    (
-        pytest.param(TaskStatus, False, id="TaskStatus"),
-        pytest.param(SecretStr, True, id="SecretStr"),
-        pytest.param(OptionalZIMOutputFolder, False, id="OptionalZIMOutputFolder"),
-        pytest.param(OptionalZIMSecretStr, True, id="OptionalZIMSecretStr"),
-        pytest.param(OptionalNotEmptyString, False, id="OptionalNotEmptyString"),
-        pytest.param(OptionalZIMDescription, False, id="OptionalZIMDescription"),
-        pytest.param(
-            OptionalZIMLongDescription, False, id="OptionalZIMLongDescription"
-        ),
-        pytest.param(OptionalZIMTitle, False, id="OptionalZIMTitle"),
-        pytest.param(OptionalSecretUrl, True, id="OptionalSecretUrl"),
-        pytest.param(SecretUrl, True, id="SecretUrl"),
-    ),
-)
-def test_is_secret(field: Any, *, is_secret_field: bool):
-    assert is_secret(field) == is_secret_field
 
 
 def test_mw_offliner_schema_to_flags(mwoffliner_schema_cls: type[BaseModel]):
@@ -110,13 +78,13 @@ def test_mw_offliner_schema_to_flags(mwoffliner_schema_cls: type[BaseModel]):
 
         # Validat that restrictions are correctly inferred
         if key in ("customZIMTitle",):
-            assert flag.min_length == 1
-            assert flag.min_length == 30
+            assert flag.min_graphemes == 1
+            assert flag.max_graphemes == 30
         elif key in ("customZIMDescription",):
-            assert flag.min_length == 1
-            assert flag.min_length == 80
+            assert flag.min_graphemes == 1
+            assert flag.max_graphemes == 80
         elif key in ("customZIMLongDescription",):
-            assert flag.min_length == 1
-            assert flag.min_length == 4000
+            assert flag.min_graphemes == 1
+            assert flag.max_graphemes == 4000
         elif key in ("outputDirectory",):
             assert flag.pattern is not None

--- a/backend/tests/test_validators.py
+++ b/backend/tests/test_validators.py
@@ -6,41 +6,17 @@ from typing import Any
 import pydantic
 import pytest
 from _pytest.python_api import RaisesContext
-from pydantic import ValidationError
+from pydantic import ValidationError, create_model
 
 from zimfarm_backend.common.constants import parse_bool
-from zimfarm_backend.common.schemas import BaseModel
+from zimfarm_backend.common.schemas import BaseModel, CamelModel
 from zimfarm_backend.common.schemas.fields import (
-    CommaSeparatedZIMLangCode,
-    GraphemeStr,
     SecretUrl,
     SkipableBool,
     SkipableUrl,
-    ZIMFileName,
-    ZIMLangCode,
-    ZIMName,
-    ZIMTitle,
 )
-
-
-class ZIMFileNameModel(BaseModel):
-    value: ZIMFileName
-
-
-class ZIMNameModel(BaseModel):
-    value: ZIMName
-
-
-class ZIMLanguageCodeModel(BaseModel):
-    value: ZIMLangCode
-
-
-class ZIMTitleModel(BaseModel):
-    value: ZIMTitle
-
-
-class CommaSeparatedZIMLanguageCodeModel(BaseModel):
-    value: CommaSeparatedZIMLangCode
+from zimfarm_backend.common.schemas.offliners.builder import generate_field_type
+from zimfarm_backend.common.schemas.offliners.models import FlagSchema
 
 
 class SkipableBoolModel(BaseModel):
@@ -53,182 +29,6 @@ class SecretUrlModel(BaseModel):
 
 class SkipableUrlModel(BaseModel):
     value: SkipableUrl
-
-
-@pytest.mark.parametrize(
-    "filename,expected",
-    [
-        ("wikipedia_en_all_2024-01.zim", does_not_raise()),
-        ("ted-talks_eng_all_2024-03.zim", does_not_raise()),
-        ("wikipedia_eng_all_{period}.zim", does_not_raise()),
-        ("ted-talks_eng_football_{period}.zim", does_not_raise()),
-        ("wikipedia_en_all_nopic_2024-01.zim", does_not_raise()),  # selection + flavor
-        # Invalid filenames
-        (
-            "wikipedia_eng_all_2024-01",
-            pytest.raises(ValidationError),
-        ),  # Missing .zim extension
-        (
-            "WIKIPEDIA_EN_ALL_2024-01.zim",
-            pytest.raises(ValidationError),
-        ),  # Uppercase letters
-        (
-            "wikipedia_eng_all_2024_01.zim",
-            pytest.raises(ValidationError),
-        ),  # Wrong date format (underscore instead of dash)
-        ("_en_all_2024-01.zim", pytest.raises(ValidationError)),  # Empty first part
-        (
-            "wikipedia__all_2024-01.zim",
-            pytest.raises(ValidationError),
-        ),  # Empty language part
-        ("wikipedia_en_all_.zim", pytest.raises(ValidationError)),  # Empty date part
-        (
-            "wikipedia_en_all_2024-01_.zim",
-            pytest.raises(ValidationError),
-        ),  # Trailing underscore after period
-        (
-            "_wikipedia_en_all_2024-01.zim",
-            pytest.raises(ValidationError),
-        ),  # Leading underscore
-        (
-            "wikipedia en_all_2024-01.zim",
-            pytest.raises(ValidationError),
-        ),  # Space in first part
-        (
-            "wikipedia_en_all 2024-01.zim",
-            pytest.raises(ValidationError),
-        ),  # Space in date part
-    ],
-)
-def test_zimfilename_pattern(filename: str, expected: RaisesContext[Exception]):
-    """Test ZIMFileName pattern validation with various inputs."""
-    with expected:
-        ZIMFileNameModel.model_validate({"value": filename})
-
-
-def test_zimfilename_skips_validation_when_context_set():
-    """Test that ZIMFileName validation is skipped when context is set."""
-    with does_not_raise():
-        ZIMFileNameModel.model_validate(
-            {"value": "invalid_filename"}, context={"skip_validation": True}
-        )
-
-
-@pytest.mark.parametrize(
-    "name,expected",
-    [
-        # Zim name is made of three parts {domain}_{lang}_{selection} with _ as
-        # the separator
-        # Valid ZIM names
-        pytest.param(
-            "android.stackexchange.com_eng_all",
-            does_not_raise(),
-            id="first_part_domain_name",
-        ),
-        pytest.param(
-            "ted-talks_eng_football", does_not_raise(), id="hypen_in_first_part"
-        ),
-        pytest.param(
-            "wikipedia_nds-nl_top", does_not_raise(), id="hypen_in_second_part"
-        ),
-        # Invalid ZIM names
-        pytest.param(
-            "wikipedia_en_all_2024-01", pytest.raises(ValidationError), id="four_parts"
-        ),  # Too many parts (4 instead of 3)
-        pytest.param(
-            "wikipedia_en", pytest.raises(ValidationError), id="two_parts"
-        ),  # Too few parts (2 instead of 3)
-        pytest.param(
-            "WIKIPEDIA_EN_ALL", pytest.raises(ValidationError), id="upper_case_letters"
-        ),  # Uppercase letters
-        pytest.param(
-            "wikipedia EN all",
-            pytest.raises(ValidationError),
-            id="space_separator",
-        ),  # Spaces instead of underscores
-        pytest.param(
-            "wikipedia_en_all_",
-            pytest.raises(ValidationError),
-            id="trailing_underscore",
-        ),  # Trailing underscore
-        pytest.param(
-            "_wikipedia_en_all",
-            pytest.raises(ValidationError),
-            id="leading_underscore",
-        ),  # Leading underscore
-        pytest.param(
-            "wikipedia__all", pytest.raises(ValidationError), id="missing_middle_part"
-        ),  # Empty middle part
-        pytest.param(
-            "wikipedia_en_", pytest.raises(ValidationError), id="empty_last_part"
-        ),  # Empty last part
-        pytest.param(
-            "_en_all",
-            pytest.raises(ValidationError),
-        ),  # Empty first part
-        pytest.param(
-            "wikipedia_en_all.zim",
-            does_not_raise(),
-            id="file_extension_in_name",
-        ),  # File extension not allowed (not sure yet??)
-        pytest.param(
-            "wikipedia@en_all", pytest.raises(ValidationError), id="special_char_at"
-        ),  # Special character @
-        pytest.param(
-            "wikipedia&en_all",
-            pytest.raises(ValidationError),
-            id="special_char_ampersand",
-        ),  # Special character &
-        pytest.param(
-            "wikipedia*en_all",
-            pytest.raises(ValidationError),
-            id="special_char_astersik",
-        ),  # Special character *
-        pytest.param(
-            "", pytest.raises(ValidationError), id="empty_string"
-        ),  # Empty string
-    ],
-)
-def test_zimname_pattern(name: str, expected: RaisesContext[Exception]):
-    """Test ZIMName pattern validation with various inputs."""
-    with expected:
-        ZIMNameModel.model_validate({"value": name})
-
-
-def test_zimname_skips_validation_when_context_set():
-    """Test that ZIMName validation is skipped when context is set."""
-    with does_not_raise():
-        ZIMNameModel.model_validate(
-            {"value": "invalid_name"}, context={"skip_validation": True}
-        )
-
-
-@pytest.mark.parametrize(
-    "language_code,expected",
-    [
-        ("eng", does_not_raise()),
-        ("fra", does_not_raise()),
-        ("jpn", does_not_raise()),
-        ("jp", pytest.raises(ValidationError)),
-        ("en", pytest.raises(ValidationError)),
-        ("invalid", pytest.raises(ValidationError)),
-    ],
-)
-def test_language_code_validator(
-    language_code: str,
-    expected: RaisesContext[Exception],
-):
-    """Test language code validator with various inputs."""
-    with expected:
-        ZIMLanguageCodeModel.model_validate({"value": language_code})
-
-
-def test_language_code_validator_skips_validation_when_context_set():
-    """Test that language code validator is skipped when context is set."""
-    with does_not_raise():
-        ZIMLanguageCodeModel.model_validate(
-            {"value": "invalid"}, context={"skip_validation": True}
-        )
 
 
 @pytest.mark.parametrize(
@@ -409,144 +209,6 @@ def test_ted_flags_schema_links(
 def test_parse_bool(value: Any, *, expected: bool):
     """Test parse_bool function with various inputs."""
     assert parse_bool(value) == expected
-
-
-@pytest.mark.parametrize(
-    "string,expected_length",
-    [
-        ("hello", 5),
-        ("世界", 2),
-        ("🌍", 1),
-        ("👨‍👩‍👧‍👦", 1),
-        ("👨‍👩‍👧‍👦👨‍👩‍👧‍👦", 2),
-        ("👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦", 3),
-    ],
-)
-def test_grapheme_str(string: str, expected_length: int):
-    assert len(GraphemeStr(string)) == expected_length
-
-
-@pytest.mark.parametrize(
-    "string,expected",
-    [
-        ("hello", does_not_raise()),
-        ("世界", does_not_raise()),
-        ("🌍" * 30, does_not_raise()),
-        ("👨‍👩‍👧‍👦" * 30, does_not_raise()),
-        ("👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦", does_not_raise()),
-        # Test strings longer than 30 characters that should fail
-        ("This is a very long title that should fail", pytest.raises(ValidationError)),
-        ("ThisIsALongTitleWithoutSpacesThatShouldFail", pytest.raises(ValidationError)),
-        ("A string with exactly 31 characters!", pytest.raises(ValidationError)),
-        (
-            "Another string that is way too long to be a valid ZIM title",
-            pytest.raises(ValidationError),
-        ),
-        ("👨‍👩‍👧‍👦" * 31, pytest.raises(ValidationError)),  # Long string of emojis
-        (
-            "世界" * 20,
-            pytest.raises(ValidationError),
-        ),  # Long string of Chinese characters
-    ],
-)
-def test_zimtitle_string(string: str, expected: RaisesContext[Exception]):
-    with expected:
-        ZIMTitleModel.model_validate({"value": string})
-
-
-@pytest.mark.parametrize(
-    "string",
-    [
-        ("hello"),
-        ("世界"),
-        ("🌍"),
-        ("👨‍👩‍👧‍👦"),
-        ("👨‍👩‍👧‍👦👨‍👩‍👧‍👦👨‍👩‍👧‍👦"),
-        ("This is a very long title that should fail"),
-        ("ThisIsALongTitleWithoutSpacesThatShouldFail"),
-        ("A string with exactly 31 characters!"),
-        ("Another string that is way too long to be a valid ZIM title",),
-        ("👨‍👩‍👧‍👦" * 31),
-        ("世界" * 20,),
-    ],
-)
-def test_zimtitle_string_does_not_raise(string: str):
-    with does_not_raise():
-        ZIMTitleModel.model_validate(
-            {"value": string}, context={"skip_validation": True}
-        )
-
-
-@pytest.mark.parametrize(
-    "languages,expected",
-    [
-        pytest.param("eng", does_not_raise(), id="single-valid-language-code"),
-        pytest.param("eng,fra,jpn", does_not_raise(), id="multiple-valid-languages"),
-        pytest.param(
-            "en,fr,jp",
-            pytest.raises(ValidationError),
-            id="multiple-invalid-language-codes",
-        ),
-        pytest.param(
-            "en",
-            pytest.raises(ValidationError),
-            id="single-invalid-language-code",
-        ),
-        pytest.param(
-            "eng,",
-            pytest.raises(ValidationError),
-            id="valid-language-code-with-trailing-comma",
-        ),
-        pytest.param(
-            "eng,,",
-            pytest.raises(ValidationError),
-            id="valid-language-code-with-double-trailing-comma",
-        ),
-        pytest.param(
-            "eng,fr,jpn",
-            pytest.raises(ValidationError),
-            id="multiple-valid-languages-with-one-invalid",
-        ),
-    ],
-)
-def test_comma_separated_zim_language_code_validator(
-    languages: str, expected: RaisesContext[Exception]
-):
-    with expected:
-        CommaSeparatedZIMLanguageCodeModel.model_validate({"value": languages})
-
-
-@pytest.mark.parametrize(
-    "languages,expected",
-    [
-        pytest.param("eng", does_not_raise(), id="single-valid-language-code"),
-        pytest.param("eng,fra,jpn", does_not_raise(), id="multiple-valid-languages"),
-        pytest.param(
-            "en,fr,jp", does_not_raise(), id="multiple-invalid-language-codes"
-        ),
-        pytest.param("en", does_not_raise(), id="single-invalid-language-code"),
-        pytest.param(
-            "eng,", does_not_raise(), id="valid-language-code-with-trailing-comma"
-        ),
-        pytest.param(
-            "eng,,",
-            does_not_raise(),
-            id="valid-language-code-with-double-trailing-comma",
-        ),
-        pytest.param(
-            "eng,fr,jpn",
-            does_not_raise(),
-            id="multiple-valid-languages-with-one-invalid",
-        ),
-    ],
-)
-def test_comma_separated_zim_language_code_validator_skips_validation_when_context_set(
-    languages: str, expected: RaisesContext[Exception]
-):
-    with expected:
-        CommaSeparatedZIMLanguageCodeModel.model_validate(
-            {"value": languages}, context={"skip_validation": True}
-        )
 
 
 @pytest.mark.parametrize(
@@ -732,4 +394,64 @@ def test_skipable_url_model_skip_validation(
     with expected:
         SecretUrlModel.model_validate(
             {"value": value}, context={"skip_validation": True}
+        )
+
+
+@pytest.mark.parametrize(
+    "grapheme,skip_validation,expected",
+    [
+        pytest.param("é" * 30, False, does_not_raise()),
+        pytest.param("é" * 40, False, pytest.raises(ValidationError)),
+        pytest.param("é" * 40, True, does_not_raise()),
+    ],
+)
+def test_grapheme_length_validation_on_strings(
+    *, grapheme: str, skip_validation: bool, expected: RaisesContext[Exception]
+):
+    """Test that grapheme validation is applied to string flags."""
+    field = generate_field_type(
+        "mwoffliner",
+        FlagSchema(
+            type="string",
+            label="ZIM Title",
+            description="Custom ZIM title. Wiki name otherwise.",
+            min_graphemes=1,
+            max_graphemes=30,
+        ),
+        label="title",
+    )
+    model = create_model("mwofflinerFlagsSchema", __base__=CamelModel, title=field)
+    with expected:
+        model.model_validate(
+            {"title": grapheme}, context={"skip_validation": skip_validation}
+        )
+
+
+@pytest.mark.parametrize(
+    "grapheme,skip_validation,expected",
+    [
+        pytest.param(["é" * 30, "é" * 25], False, pytest.raises(ValidationError)),
+        pytest.param(["é" * 40, "é" * 25], False, pytest.raises(ValidationError)),
+        pytest.param(["é" * 40, "é" * 25], True, does_not_raise()),
+    ],
+)
+def test_grapheme_length_validation_on_list_of_strings(
+    *, grapheme: str, skip_validation: bool, expected: RaisesContext[Exception]
+):
+    """Test that grapheme validation is applied to the inner string in list of string flag"""
+    field = generate_field_type(
+        "mwoffliner",
+        FlagSchema(
+            type="string",
+            label="ZIM Title",
+            description="Custom ZIM title. Wiki name otherwise.",
+            min_graphemes=1,
+            max_graphemes=30,
+        ),
+        label="title",
+    )
+    model = create_model("mwofflinerFlagsSchema", __base__=CamelModel, title=field)
+    with expected:
+        model.model_validate(
+            {"title": grapheme}, context={"skip_validation": skip_validation}
         )

--- a/frontend-ui/src/components/RecipeEditor.vue
+++ b/frontend-ui/src/components/RecipeEditor.vue
@@ -480,8 +480,8 @@
             :hint="field.description ?? undefined"
             persistent-hint
           >
-            <template v-if="field.max_length" #counter>
-              {{ getGraphemeCount(editFlags[field.dataKey]) }}/{{ field.max_length }}
+            <template v-if="field.max_graphemes" #counter>
+              {{ getGraphemeCount(editFlags[field.dataKey]) }}/{{ field.max_graphemes }}
             </template>
           </v-textarea>
           <BlobEditor
@@ -509,8 +509,8 @@
             :hint="field.description ?? undefined"
             persistent-hint
           >
-            <template v-if="field.max_length" #counter>
-              {{ getGraphemeCount(editFlags[field.dataKey]) }}/{{ field.max_length }}
+            <template v-if="field.max_graphemes" #counter>
+              {{ getGraphemeCount(editFlags[field.dataKey]) }}/{{ field.max_graphemes }}
             </template>
           </v-text-field>
           <div v-if="showYoutubeLinks && isIdentField(field)" class="mt-1">
@@ -682,8 +682,8 @@ interface FlagField {
   step?: number | null
   min: number | null
   max: number | null
-  min_length: number | null
-  max_length: number | null
+  min_graphemes: number | null
+  max_graphemes: number | null
   pattern: string | null
   kind?: 'image' | 'illustration' | 'css' | 'html' | 'txt'
 }
@@ -1120,8 +1120,8 @@ const flagsFields = computed(() => {
       description: field.description,
       min: field.min,
       max: field.max,
-      min_length: field.min_length,
-      max_length: field.max_length,
+      min_graphemes: field.min_graphemes,
+      max_graphemes: field.max_graphemes,
       pattern: field.pattern,
       placeholder: 'Not set',
       component,
@@ -1246,17 +1246,17 @@ const getFieldRules = (field: FlagField) => {
     })
   }
 
-  // Add validation for min, max, min_length, and pattern constraints
+  // Add validation for min, max, min_graphemes, and pattern constraints
   const shouldValidate = (value: unknown) => {
     return value !== null && value !== undefined && value !== ''
   }
 
   // Min length validation
-  if (field.min_length !== null) {
+  if (field.min_graphemes !== null) {
     rules.push((value: unknown) => {
       if (shouldValidate(value) && typeof value === 'string') {
-        if (value.split(byGrapheme).length < field.min_length!) {
-          return `Minimum length is ${field.min_length} characters`
+        if (value.split(byGrapheme).length < field.min_graphemes!) {
+          return `Minimum length is ${field.min_graphemes} characters`
         }
       }
       return true
@@ -1264,11 +1264,11 @@ const getFieldRules = (field: FlagField) => {
   }
 
   // Max length validation
-  if (field.max_length !== null) {
+  if (field.max_graphemes !== null) {
     rules.push((value: unknown) => {
       if (shouldValidate(value) && typeof value === 'string') {
-        if (value.split(byGrapheme).length > field.max_length!) {
-          return `Maximum length is ${field.max_length} characters`
+        if (value.split(byGrapheme).length > field.max_graphemes!) {
+          return `Maximum length is ${field.max_graphemes} characters`
         }
       }
       return true
@@ -1340,8 +1340,8 @@ const truncateToMaxGraphemes = (value: string, maxLength: number): string => {
 
 const handleInputWithGraphemeLimit = (field: FlagField, value: string) => {
   const trimmedValue = value?.trim() || value
-  if (field.max_length && typeof trimmedValue === 'string') {
-    const truncatedValue = truncateToMaxGraphemes(trimmedValue, field.max_length)
+  if (field.max_graphemes && typeof trimmedValue === 'string') {
+    const truncatedValue = truncateToMaxGraphemes(trimmedValue, field.max_graphemes)
     editFlags.value[field.dataKey] = truncatedValue
   } else {
     editFlags.value[field.dataKey] = trimmedValue

--- a/frontend-ui/src/types/offliner.ts
+++ b/frontend-ui/src/types/offliner.ts
@@ -14,8 +14,8 @@ export interface OfflinerDefinition {
   type: string
   min: number | null
   max: number | null
-  min_length: number | null
-  max_length: number | null
+  min_graphemes: number | null
+  max_graphemes: number | null
   pattern: string | null
   kind?: 'image' | 'illustration' | 'css' | 'html' | 'txt'
 }


### PR DESCRIPTION
## Rationale
The `NotEmptyString` is the base str class used for building up most of the types of the different offliner fields. However, even though we initially recast it to `GraphemeStr` which has a custom `__len__`, pydantic min/max length validation still do not use this hook. See https://github.com/pydantic/pydantic/discussions/13131#discussioncomment-16785225 for more information. 

The solution is to inject the grapheme string validation function while building the flags and still maintain the base class str annotation for type-checkers. However, min/max length are no longer done by pydantic via the `Field` constructor.

## Changes
- remove different types which were defined when the offliners were still defined in one file per offliner type
- add grapheme string validation as a validator function
- rename max_length, min_length, relaxed_min_length and relaxed_max_length to each end with `_graphemes`
- add maintenace script to rename the fields for the flags in the database


This fixes #1881