### PR TITLE
Fix instructions regarding Docker FS usage

### DIFF
--- a/worker/README.md
+++ b/worker/README.md
@@ -69,20 +69,29 @@ We do not mind about one or two unexpected Internet or machine downtimes per yea
 
 ### Docker configuration
 
-Default docker configuration stores its internal data into `/var/lib/docker` (Linux). While the data produced by the Zimfarm are not stored in this folder (but in the `ZIMFARM_ROOT` you'll define later), it's important to note that docker container logs are stored there.
+_Note_: folders/files below are for Linux machines. Same principles applies to windows with different folders/files.
 
-Logs are kept only for the duration of the task/container so you should not worry about those piling up.
+Default docker configuration stores its internal data into `/var/lib/docker`. Since Docker 29, default containerd configuration stores its internal data into `/var/lib/containerd`. While the data produced by the Zimfarm are not stored in this folder (but in the `ZIMFARM_ROOT` you'll define later), it's important to note that docker and containerd data are stored there.
+
+Docker data is typically its logs. Logs are kept only for the duration of the task/container so you should not worry about those piling up.
 
 Still, under certain circumstances, we enable verbose mode on scrapers and that can lead to logs files up to **20GB+** large.
 
 Keep this information in mind when you configure the disk space you want zimfarm to use as those are not managed by the zimfarm and thus not accounted for.
 
-Additionally, if your partition scheme isn't compatible with such sizes on `/var/lib`, change the data folder of the docker daemon in `/etc/docker/daemon.json` (you'll probably have to create it) and restart docker.
+Additionally, if your partition scheme isn't compatible with such sizes on `/var/lib`, you can alter docker and containerd configuration.
+
+Change docker data folder in `/etc/docker/daemon.json` (you'll probably have to create it) and restart docker.
 
 ```json
 {
-  "data-root": "/not/var/lib/docker"
+  "data-root": "/data/docker-data-root" # set folder of your choice, must be fully empty / available for Docker
 }
+```
+
+Change containerd data folder in `/etc/containerd/config.toml`, by adding following line
+```toml
+root = "/data/containerd-root" # set folder of your choice, must be fully empty / available for containerd
 ```
 
 ### Create a Zimfarm folder


### PR DESCRIPTION
Since Docker 29, the containerd image store is the default storage backend. This change impacts the storage of images and so on, which are now stored in `/var/lib/containerd`, instead of `/var/lib/docker/overlay2` used by the now-legacy graph driver.

I hence propose we rewrite installation instructions since image size is a significant contributor to disk usage on Zimfarm workers. I've made some small cosmetic arrangement in few phrases around it.