### PR TITLE
expose recipe id in response and accept id in route parameters

### DIFF
--- a/backend/maint-scripts/relaunch_failed_recipes.py
+++ b/backend/maint-scripts/relaunch_failed_recipes.py
@@ -95,7 +95,7 @@ def relaunch_failed_recipes(session: OrmSession, start_date: str):
 
         result = request_task(
             session=session,
-            recipe_name=recipe_name,
+            recipe_identifier=recipe_name,
             requested_by=get_account_by_username(session, username="maint-scripts").id,
         )
         if result.requested_task:

--- a/backend/maint-scripts/restore_mwoffliner_article_list.py
+++ b/backend/maint-scripts/restore_mwoffliner_article_list.py
@@ -107,7 +107,7 @@ def main(*, dry_run: bool = False):
                 update_recipe(
                     session=session,
                     author_id=user.id,
-                    recipe_name=recipe.name,
+                    recipe_identifier=recipe.name,
                     offliner_definition=offliner_def,
                     new_recipe_config=recipe_config,
                     comment="Restore mwoffliner articleList from history",

--- a/backend/maint-scripts/update_scraper_version.py
+++ b/backend/maint-scripts/update_scraper_version.py
@@ -162,7 +162,7 @@ def update_recipes(
             session,
             offliner_definition=offliner_definition,
             author_id=get_account_by_username(session, username="maint-scripts").id,
-            recipe_name=recipe.name,
+            recipe_identifier=recipe.name,
             new_recipe_config=recipe_config,
             comment="updates made via update_scraper_version",
         )

--- a/backend/src/zimfarm_backend/api/routes/blobs/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/blobs/logic.py
@@ -44,17 +44,17 @@ router = APIRouter(prefix="/blobs", tags=["blobs"])
 
 
 @router.post(
-    "/{recipe_name}",
+    "/{recipe_identifier}",
     dependencies=[Depends(require_permission(namespace="recipes", name="create"))],
 )
 def create_blob(
-    recipe_name: Annotated[NotEmptyString, Path()],
+    recipe_identifier: Annotated[NotEmptyString, Path()],
     request: CreateBlobRequest,
     session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> BlobSchema:
     "Create a blob for recipe"
 
-    recipe = get_recipe(session, recipe_name=recipe_name)
+    recipe = get_recipe(session, recipe_identifier)
 
     if request.data.startswith("data:"):
         _, encoded_data = request.data.split(",", 1)
@@ -101,11 +101,11 @@ def create_blob(
 
 
 @router.get(
-    "/{recipe_name}",
+    "/{recipe_identifier}",
     dependencies=[Depends(require_permission(namespace="recipes", name="read"))],
 )
 def get_blobs(
-    recipe_name: Annotated[NotEmptyString, Path()],
+    recipe_identifier: Annotated[NotEmptyString, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
     params: Annotated[BlobsGetSchema, Query()],
 ):
@@ -114,7 +114,7 @@ def get_blobs(
         session,
         skip=params.skip,
         limit=params.limit,
-        recipe_name=recipe_name,
+        recipe_identifier=recipe_identifier,
     )
     return ListResponse(
         items=result.blobs,
@@ -184,16 +184,16 @@ def delete_blob(
 
 
 @router.get(
-    "/{recipe_name}/{flag_name}/{checksum}",
+    "/{recipe_identifier}/{flag_name}/{checksum}",
     dependencies=[Depends(require_permission(namespace="recipes", name="read"))],
 )
 def get_blob(
-    recipe_name: Annotated[NotEmptyString, Path()],
+    recipe_identifier: Annotated[NotEmptyString, Path()],
     flag_name: Annotated[NotEmptyString, Path()],
     checksum: Annotated[NotEmptyString, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> BlobSchema:
-    recipe = get_recipe(session, recipe_name=recipe_name)
+    recipe = get_recipe(session, recipe_identifier)
     return db_get_blob(
         session, recipe_id=recipe.id, flag_name=flag_name, checksum=checksum
     )

--- a/backend/src/zimfarm_backend/api/routes/recipes/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/recipes/logic.py
@@ -272,22 +272,23 @@ def restore_archived_recipes(
 ) -> Response:
     db_restore_recipes(
         session,
-        recipe_names=request.recipe_names,
+        recipe_identifiers=request.recipe_names
+        or [str(recipe_id) for recipe_id in request.recipe_ids],
         actor_id=current_account.id,
         comment=request.comment,
     )
     return Response(status_code=HTTPStatus.NO_CONTENT)
 
 
-@router.get("/{recipe_name}")
+@router.get("/{recipe_identifier}")
 def get_recipe(
-    recipe_name: Annotated[NotEmptyString, Path()],
+    recipe_identifier: Annotated[NotEmptyString, Path()],
     session: OrmSession = Depends(gen_dbsession),
     current_account: Account | None = Depends(get_current_account_or_none),
     *,
     hide_secrets: Annotated[bool | None, Query()] = True,
 ) -> JSONResponse:
-    db_recipe = db_get_recipe(session, recipe_name=recipe_name)
+    db_recipe = db_get_recipe(session, recipe_identifier)
 
     if current_account is None and db_recipe.archived:
         raise UnauthorizedError(
@@ -342,13 +343,13 @@ def get_recipe(
     )
 
 
-@router.get("/{recipe_name}/similar")
+@router.get("/{recipe_identifier}/similar")
 def get_similar_recipe(
-    recipe_name: Annotated[NotEmptyString, Path()],
+    recipe_identifier: Annotated[NotEmptyString, Path()],
     params: Annotated[RecipesGetSchema, Query()],
     session: OrmSession = Depends(gen_dbsession),
 ) -> ListResponse[RecipeLightSchema]:
-    recipe = db_get_recipe(session, recipe_name=recipe_name)
+    recipe = db_get_recipe(session, recipe_identifier)
     results = db_get_recipes(
         session,
         skip=params.skip,
@@ -372,16 +373,16 @@ def get_similar_recipe(
 
 
 @router.patch(
-    "/{recipe_name}",
+    "/{recipe_identifier}",
     dependencies=[Depends(require_permission(namespace="recipes", name="update"))],
 )
 def update_recipe(
-    recipe_name: Annotated[NotEmptyString, Path()],
+    recipe_identifier: Annotated[NotEmptyString, Path()],
     request: RecipeUpdateSchema,
     session: OrmSession = Depends(gen_dbsession),
     current_account: Account = Depends(get_current_account),
 ) -> JSONResponse:
-    db_recipe = db_get_recipe(session, recipe_name=recipe_name)
+    db_recipe = db_get_recipe(session, recipe_identifier)
     if db_recipe.archived:
         raise BadRequestError("Cannot update an archived recipe")
     offliner = get_offliner(session, db_recipe.config["offliner"]["offliner_id"])
@@ -559,7 +560,7 @@ def update_recipe(
 
     recipe = db_update_recipe(
         session,
-        recipe_name=recipe_name,
+        recipe_identifier=recipe_identifier,
         author_id=current_account.id,
         comment=request.comment,
         new_recipe_config=new_recipe_config,
@@ -589,25 +590,25 @@ def update_recipe(
 
 
 @router.delete(
-    "/{recipe_name}",
+    "/{recipe_identifier}",
     dependencies=[Depends(require_permission(namespace="recipes", name="delete"))],
 )
 def delete_recipe(
-    recipe_name: Annotated[NotEmptyString, Path()],
+    recipe_identifier: Annotated[NotEmptyString, Path()],
     session: OrmSession = Depends(gen_dbsession),
 ) -> Response:
     """Delete a recipe"""
-    db_delete_recipe(session, recipe_name=recipe_name)
+    db_delete_recipe(session, recipe_identifier)
     return Response(status_code=HTTPStatus.NO_CONTENT)
 
 
-@router.get("/{recipe_name}/image-names")
+@router.get("/{recipe_identifier}/image-names")
 def get_recipe_image_names(
-    recipe_name: Annotated[NotEmptyString, Path()],
+    recipe_identifier: Annotated[NotEmptyString, Path()],
     hub_name: Annotated[str, Query()],
     session: OrmSession = Depends(gen_dbsession),
 ) -> ListResponse[Any]:
-    db_get_recipe(session, recipe_name=recipe_name)
+    db_get_recipe(session, recipe_identifier)
     try:
         tags = get_recipe_image_tags(hub_name)
     except requests.HTTPError as exc:
@@ -631,16 +632,16 @@ def get_recipe_image_names(
 
 
 @router.post(
-    "/{recipe_name}/clone",
+    "/{recipe_identifier}/clone",
     dependencies=[Depends(require_permission(namespace="recipes", name="create"))],
 )
 def clone_recipe(
-    recipe_name: Annotated[NotEmptyString, Path()],
+    recipe_identifier: Annotated[NotEmptyString, Path()],
     request: CloneSchema,
     session: OrmSession = Depends(gen_dbsession),
     current_account: Account = Depends(get_current_account),
 ) -> RecipeCreateResponseSchema:
-    recipe = db_get_recipe(session, recipe_name=recipe_name)
+    recipe = db_get_recipe(session, recipe_identifier)
     if recipe.archived:
         raise BadRequestError("You cannot clone an archived recipe.")
 
@@ -696,7 +697,7 @@ def clone_recipe(
     except ValidationError:
         db_update_recipe(
             session,
-            recipe_name=new_recipe.name,
+            recipe_identifier=new_recipe.name,
             author_id=current_account.id,
             is_valid=False,
             offliner_definition=create_offliner_definition_schema(
@@ -710,11 +711,11 @@ def clone_recipe(
 
 
 @router.patch(
-    "/{recipe_name}/archive",
+    "/{recipe_identifier}/archive",
     dependencies=[Depends(require_permission(namespace="recipes", name="archive"))],
 )
 def archive_recipe(
-    recipe_name: Annotated[NotEmptyString, Path()],
+    recipe_identifier: Annotated[NotEmptyString, Path()],
     request: ToggleArchiveStatusSchema,
     session: OrmSession = Depends(gen_dbsession),
     current_account: Account = Depends(get_current_account),
@@ -722,23 +723,23 @@ def archive_recipe(
     """Archive a recipe"""
     db_toggle_archive_status(
         session,
-        recipe_name=recipe_name,
+        recipe_identifier=recipe_identifier,
         archived=True,
         actor_id=current_account.id,
         comment=request.comment,
     )
     return JSONResponse(
-        content={"message": f"Recipe '{recipe_name}' has been archived"},
+        content={"message": f"Recipe '{recipe_identifier}' has been archived"},
         status_code=HTTPStatus.OK,
     )
 
 
 @router.patch(
-    "/{recipe_name}/restore",
+    "/{recipe_identifier}/restore",
     dependencies=[Depends(require_permission(namespace="recipes", name="archive"))],
 )
 def restore_archived_recipe(
-    recipe_name: Annotated[NotEmptyString, Path()],
+    recipe_identifier: Annotated[NotEmptyString, Path()],
     request: ToggleArchiveStatusSchema,
     session: OrmSession = Depends(gen_dbsession),
     current_account: Account = Depends(get_current_account),
@@ -746,26 +747,26 @@ def restore_archived_recipe(
     """Restore an archived recipe"""
     db_toggle_archive_status(
         session,
-        recipe_name=recipe_name,
+        recipe_identifier=recipe_identifier,
         archived=False,
         actor_id=current_account.id,
         comment=request.comment,
     )
     return JSONResponse(
-        content={"message": f"Recipe '{recipe_name}' has been restored"},
+        content={"message": f"Recipe '{recipe_identifier}' has been restored"},
         status_code=HTTPStatus.OK,
     )
 
 
 @router.get(
-    "/{recipe_name}/validate",
+    "/{recipe_identifier}/validate",
     dependencies=[Depends(require_permission(namespace="recipes", name="update"))],
 )
 def validate_recipe(
-    recipe_name: Annotated[NotEmptyString, Path()],
+    recipe_identifier: Annotated[NotEmptyString, Path()],
     session: Annotated[OrmSession, Depends(gen_dbsession)],
 ) -> JSONResponse:
-    recipe = db_get_recipe(session, recipe_name=recipe_name)
+    recipe = db_get_recipe(session, recipe_identifier)
     offliner = get_offliner(session, recipe.config["offliner"]["offliner_id"])
 
     try:
@@ -777,16 +778,16 @@ def validate_recipe(
 
 
 @router.get(
-    "/{recipe_name}/history",
+    "/{recipe_identifier}/history",
     dependencies=[Depends(require_permission(namespace="recipes", name="secrets"))],
 )
 def get_recipe_history(
-    recipe_name: Annotated[NotEmptyString, Path()],
+    recipe_identifier: Annotated[NotEmptyString, Path()],
     session: OrmSession = Depends(gen_dbsession),
     skip: Annotated[SkipField, Query()] = 0,
     limit: Annotated[LimitFieldMax200, Query()] = 200,
 ) -> ListResponse[RecipeHistorySchema]:
-    recipe = db_get_recipe(session, recipe_name=recipe_name)
+    recipe = db_get_recipe(session, recipe_identifier)
 
     results = db_get_recipe_history(
         session, recipe_id=recipe.id, skip=skip, limit=limit
@@ -803,26 +804,26 @@ def get_recipe_history(
 
 
 @router.get(
-    "/{recipe_name}/history/{history_id}",
+    "/{recipe_identifier}/history/{history_id}",
     dependencies=[Depends(require_permission(namespace="recipes", name="secrets"))],
 )
 def get_recipe_history_entry(
-    recipe_name: Annotated[NotEmptyString, Path()],
+    recipe_identifier: Annotated[NotEmptyString, Path()],
     history_id: Annotated[UUID, Path()],
     session: OrmSession = Depends(gen_dbsession),
 ) -> RecipeHistorySchema:
     history_entry = db_get_recipe_history_entry(
-        session, recipe_name=recipe_name, history_id=history_id
+        session, recipe_identifier=recipe_identifier, history_id=history_id
     )
     return create_recipe_history_schema(history_entry)
 
 
 @router.patch(
-    "/{recipe_name}/revert/{history_id}",
+    "/{recipe_identifier}/revert/{history_id}",
     dependencies=[Depends(require_permission(namespace="recipes", name="update"))],
 )
 def revert_recipe(
-    recipe_name: Annotated[NotEmptyString, Path()],
+    recipe_identifier: Annotated[NotEmptyString, Path()],
     history_id: Annotated[UUID, Path()],
     request: RevertRecipeSchema,
     session: OrmSession = Depends(gen_dbsession),
@@ -831,12 +832,12 @@ def revert_recipe(
     """Revert a recipe to a previous history."""
     db_revert_recipe(
         session,
-        recipe_name=recipe_name,
+        recipe_identifier=recipe_identifier,
         history_id=history_id,
         author_id=current_account.id,
         comment=request.comment,
     )
     return JSONResponse(
-        content={"message": f"Recipe '{recipe_name}' has been restored"},
+        content={"message": f"Recipe '{recipe_identifier}' has been restored"},
         status_code=HTTPStatus.OK,
     )

--- a/backend/src/zimfarm_backend/api/routes/recipes/models.py
+++ b/backend/src/zimfarm_backend/api/routes/recipes/models.py
@@ -81,6 +81,7 @@ class CloneSchema(BaseModel):
 
 class RestoreRecipesSchema(BaseModel):
     recipe_names: list[RecipeNameField] = Field(default_factory=list)
+    recipe_ids: list[UUID] = Field(default_factory=list)  # pyright: ignore[reportUnknownVariableType]
     comment: str | None = None
 
 

--- a/backend/src/zimfarm_backend/api/routes/requested_tasks/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/requested_tasks/logic.py
@@ -108,16 +108,16 @@ def create_request_task(
 
     requested_tasks: list[RequestedTaskFullSchema] = []
     errors: dict[str, str] = {}
-    for recipe_name in new_requested_task.recipe_names:
+    for recipe_identifier in new_requested_task.recipe_names:
         result = request_task(
             session,
-            recipe_name=recipe_name,
+            recipe_identifier=recipe_identifier,
             requested_by=current_account.id,
             worker_name=new_requested_task.worker,
             priority=new_requested_task.priority or 0,
         )
         if result.error:
-            errors[recipe_name] = result.error
+            errors[recipe_identifier] = result.error
 
         if result.requested_task:
             requested_tasks.append(result.requested_task)

--- a/backend/src/zimfarm_backend/api/routes/requested_tasks/models.py
+++ b/backend/src/zimfarm_backend/api/routes/requested_tasks/models.py
@@ -8,7 +8,6 @@ from zimfarm_backend.common.schemas.fields import (
     LimitFieldMax200,
     NotEmptyString,
     PriorityField,
-    RecipeNameField,
     SkipField,
     WorkerField,
     ZIMDisk,
@@ -32,7 +31,7 @@ class RequestedTaskSchema(BaseModel):
 
 
 class NewRequestedTaskSchema(BaseModel):
-    recipe_names: list[RecipeNameField] = Field(default_factory=list)
+    recipe_names: list[NotEmptyString] = Field(default_factory=list)
     priority: PriorityField | None = None
     worker: WorkerField | None = None
 

--- a/backend/src/zimfarm_backend/api/routes/tasks/logic.py
+++ b/backend/src/zimfarm_backend/api/routes/tasks/logic.py
@@ -62,7 +62,7 @@ def get_tasks(
         skip=params.skip,
         limit=params.limit,
         status=params.status,
-        recipe_name=params.recipe_name,
+        recipe_identifier=params.recipe_name or params.recipe_id,
         sort_criteria=params.sort_criteria,
         offliner=params.offliner,
         fetch_most_recent_tasks=params.fetch_most_recent_tasks,

--- a/backend/src/zimfarm_backend/api/routes/tasks/models.py
+++ b/backend/src/zimfarm_backend/api/routes/tasks/models.py
@@ -17,6 +17,7 @@ class TasksGetSchema(BaseModel):
     limit: LimitFieldMax200 = 20
     status: list[TaskStatus] | None = None
     recipe_name: NotEmptyString | None = None
+    recipe_id: NotEmptyString | None = None
     sort_criteria: Literal["done", "doing", "failed", "updated_at"] = "updated_at"
     offliner: NotEmptyString | None = None
     fetch_most_recent_tasks: bool = False

--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -266,6 +266,7 @@ class RecipeLightSchema(BaseModel):
     Schema for reading a recipe model with some fields
     """
 
+    id: UUID
     name: str
     category: str
     most_recent_task: MostRecentTaskSchema | None
@@ -323,6 +324,7 @@ class RecipeFullSchema(BaseModel):
     Schema for reading a recipe model with all fields
     """
 
+    id: UUID
     language: LanguageSchema
     durations: list[RecipeDurationSchema] = Field(exclude=True)
     name: str

--- a/backend/src/zimfarm_backend/common/utils.py
+++ b/backend/src/zimfarm_backend/common/utils.py
@@ -207,7 +207,7 @@ def save_event(
         recipe.most_recent_task = task
 
     if code == TaskStatus.scraper_completed and recipe:
-        update_recipe_duration(session, recipe_name=recipe.name)
+        update_recipe_duration(session, recipe_identifier=recipe.name)
 
 
 def task_requested_event_handler(

--- a/backend/src/zimfarm_backend/db/blob.py
+++ b/backend/src/zimfarm_backend/db/blob.py
@@ -5,6 +5,7 @@ from sqlalchemy import delete, func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.orm import Session as OrmSession
 
+from zimfarm_backend.common import is_valid_uuid
 from zimfarm_backend.common.schemas import BaseModel
 from zimfarm_backend.common.schemas.orms import BlobSchema, CreateBlobSchema
 from zimfarm_backend.db.exceptions import RecordDoesNotExistError
@@ -19,20 +20,22 @@ class BlobListResult(BaseModel):
 def get_blobs(
     session: OrmSession,
     *,
-    recipe_name: str,
+    recipe_identifier: str,
     skip: int,
     limit: int,
 ) -> BlobListResult:
     """Get a list of blobs for the recipe"""
+    if is_valid_uuid(recipe_identifier):
+        where_clause = Recipe.id == recipe_identifier
+    else:
+        where_clause = Recipe.name == recipe_identifier
     query = (
         select(
             func.count().over().label("nb_records"),
             Blob,
         )
         .join(Recipe, Blob.recipe_id == Recipe.id)
-        .where(
-            Recipe.name == recipe_name,
-        )
+        .where(where_clause)
         .offset(skip)
         .limit(limit)
         .order_by(Blob.created_at.desc())

--- a/backend/src/zimfarm_backend/db/recipe.py
+++ b/backend/src/zimfarm_backend/db/recipe.py
@@ -10,7 +10,7 @@ from sqlalchemy.orm import Session as OrmSession
 from sqlalchemy.orm import selectinload
 
 from zimfarm_backend import logger
-from zimfarm_backend.common import constants, getnow
+from zimfarm_backend.common import constants, getnow, is_valid_uuid
 from zimfarm_backend.common.enums import (
     RecipeCategory,
     RecipePeriodicity,
@@ -89,19 +89,23 @@ def count_enabled_recipes(session: OrmSession, recipe_names: list[str]) -> int:
     )
 
 
-def get_recipe_or_none(session: OrmSession, *, recipe_name: str) -> Recipe | None:
-    """Get a recipe for the given recipe name if possible else None"""
+def get_recipe_or_none(session: OrmSession, recipe_identifier: str) -> Recipe | None:
+    """Get a recipe for the by id or name if possible else None"""
+    if is_valid_uuid(recipe_identifier):
+        where_clause = Recipe.id == recipe_identifier
+    else:
+        where_clause = Recipe.name == recipe_identifier
     return session.scalars(
         select(Recipe)
-        .where(Recipe.name == recipe_name)
+        .where(where_clause)
         .options(selectinload(Recipe.offliner_definition))
     ).one_or_none()
 
 
-def get_recipe(session: OrmSession, *, recipe_name: str) -> Recipe:
+def get_recipe(session: OrmSession, recipe_identifier: str) -> Recipe:
     """Get a recipe for the given recipe name if possible else raise an exception"""
-    if (recipe := get_recipe_or_none(session, recipe_name=recipe_name)) is None:
-        raise RecordDoesNotExistError(f"Recipe with name {recipe_name} does not exist")
+    if (recipe := get_recipe_or_none(session, recipe_identifier)) is None:
+        raise RecordDoesNotExistError(f"Recipe {recipe_identifier} does not exist")
     return recipe
 
 
@@ -126,12 +130,12 @@ def get_duration_for_recipe(recipe: Recipe, worker_name: str) -> RecipeDurationS
 
 
 def get_recipe_duration(
-    session: OrmSession, *, recipe_name: str | None, worker_name: str
+    session: OrmSession, *, recipe_identifier: str | None, worker_name: str
 ) -> RecipeDurationSchema:
     """get duration for a recipe and worker (or default one)"""
-    if recipe_name is None:
+    if recipe_identifier is None:
         return DEFAULT_RECIPE_DURATION
-    recipe = get_recipe_or_none(session, recipe_name=recipe_name)
+    recipe = get_recipe_or_none(session, recipe_identifier)
     if recipe is None:
         return DEFAULT_RECIPE_DURATION
     return get_duration_for_recipe(recipe, worker_name)
@@ -140,10 +144,10 @@ def get_recipe_duration(
 def update_recipe_duration(
     session: OrmSession,
     *,
-    recipe_name: str,
+    recipe_identifier: str,
 ):
     """Update the duration for a recipe and worker"""
-    recipe = get_recipe(session, recipe_name=recipe_name)
+    recipe = get_recipe(session, recipe_identifier)
     # retrieve tasks that completed the resources intensive part
     # we don't mind to retrieve all of them because they are regularly purged
     tasks = session.execute(
@@ -245,6 +249,7 @@ def get_recipes(
     stmt = (
         select(
             func.count().over().label("total_records"),
+            Recipe.id.label("recipe_id"),
             Recipe.name.label("recipe_name"),
             Recipe.category,
             Recipe.enabled,
@@ -291,6 +296,7 @@ def get_recipes(
 
     for (
         nb_records,
+        recipe_id,
         recipe_name,
         category,
         enabled,
@@ -317,6 +323,7 @@ def get_recipes(
         results.nb_records = nb_records
         results.recipes.append(
             RecipeLightSchema(
+                id=recipe_id,
                 name=recipe_name,
                 category=category,
                 enabled=enabled,
@@ -442,6 +449,7 @@ def create_recipe_full_schema(
             context={"skip_validation": skip_validation},
         )
     return RecipeFullSchema(
+        id=recipe.id,
         language=language,
         durations=[
             RecipeDurationSchema(
@@ -511,7 +519,7 @@ def toggle_archive_status(
     session: OrmSession,
     *,
     actor_id: UUID,
-    recipe_name: str,
+    recipe_identifier: str,
     archived: bool,
     comment: str | None = None,
 ) -> Recipe:
@@ -521,10 +529,10 @@ def toggle_archive_status(
 
     # Since we are toggling the archive status, the recipe in question must
     # be the opposite of the current archive status
-    recipe = get_recipe(session, recipe_name=recipe_name)
+    recipe = get_recipe(session, recipe_identifier)
     if recipe.archived == archived:
         raise RecordAlreadyExistsError(
-            f"Recipe with name {recipe_name} already has archive status {archived}"
+            f"Recipe  {recipe_identifier} already has archive status {archived}"
         )
     recipe.archived = archived
     history_entry = RecipeHistory(
@@ -583,7 +591,7 @@ def update_recipe(
     session: OrmSession,
     *,
     author_id: UUID,
-    recipe_name: str,
+    recipe_identifier: str,
     offliner_definition: OfflinerDefinitionSchema,
     new_recipe_config: RecipeConfigSchema | None = None,
     language: LanguageSchema | None = None,
@@ -598,10 +606,10 @@ def update_recipe(
     notification: RecipeNotificationSchema | None = None,
 ) -> Recipe:
     """Update a recipe with the given values that are set."""
-    recipe = get_recipe(session, recipe_name=recipe_name)
+    recipe = get_recipe(session, recipe_identifier)
 
     if recipe.archived:
-        raise RecordDoesNotExistError(f"Recipe with name {recipe_name} is archived")
+        raise RecordDoesNotExistError(f"Recipe  {recipe_identifier} is archived")
 
     if new_recipe_config:
         recipe.config = new_recipe_config.model_dump(
@@ -648,9 +656,9 @@ def update_recipe(
     return recipe
 
 
-def delete_recipe(session: OrmSession, *, recipe_name: str) -> None:
+def delete_recipe(session: OrmSession, recipe_identifier: str) -> None:
     """Delete a recipe"""
-    recipe = get_recipe(session, recipe_name=recipe_name)
+    recipe = get_recipe(session, recipe_identifier)
     # first unset most recent task to avoid circular dependency
     recipe.most_recent_task = None
     session.delete(recipe)
@@ -701,10 +709,10 @@ def get_recipe_history(
 
 
 def get_recipe_history_entry_or_none(
-    session: OrmSession, *, recipe_name: str, history_id: UUID
+    session: OrmSession, *, recipe_identifier: str, history_id: UUID
 ) -> RecipeHistory | None:
     """Get a recipe's history entry or None if it does not exist"""
-    recipe = get_recipe(session, recipe_name=recipe_name)
+    recipe = get_recipe(session, recipe_identifier)
     return session.scalars(
         select(RecipeHistory).where(
             RecipeHistory.id == history_id, RecipeHistory.recipe_id == recipe.id
@@ -713,15 +721,16 @@ def get_recipe_history_entry_or_none(
 
 
 def get_recipe_history_entry(
-    session: OrmSession, *, recipe_name: str, history_id: UUID
+    session: OrmSession, *, recipe_identifier: str, history_id: UUID
 ) -> RecipeHistory:
     """Get a recipe's history entry"""
     if history_entry := get_recipe_history_entry_or_none(
-        session, recipe_name=recipe_name, history_id=history_id
+        session, recipe_identifier=recipe_identifier, history_id=history_id
     ):
         return history_entry
     raise RecordDoesNotExistError(
-        f"Recipe '{recipe_name}' does not have a history entry with id {history_id}"
+        f"Recipe '{recipe_identifier}' does not have a history entry with id "
+        f"{history_id}"
     )
 
 
@@ -729,15 +738,15 @@ def restore_recipes(
     session: OrmSession,
     *,
     actor_id: UUID,
-    recipe_names: list[str],
+    recipe_identifiers: list[str],
     comment: str | None = None,
 ) -> None:
     """Restore a list of archived recipes"""
-    for recipe_name in recipe_names:
+    for recipe_identifier in recipe_identifiers:
         toggle_archive_status(
             session,
             actor_id=actor_id,
-            recipe_name=recipe_name,
+            recipe_identifier=recipe_identifier,
             archived=False,
             comment=comment,
         )
@@ -746,18 +755,18 @@ def restore_recipes(
 def revert_recipe(
     session: OrmSession,
     *,
-    recipe_name: str,
+    recipe_identifier: str,
     history_id: UUID,
     author_id: UUID,
     comment: str | None = None,
 ) -> Recipe:
     """Revert the recipe configuration and settings to those defined in history_id"""
-    recipe = get_recipe(session, recipe_name=recipe_name)
+    recipe = get_recipe(session, recipe_identifier)
     if recipe.archived:
-        raise RecordDoesNotExistError(f"Recipe with name {recipe_name} is archived")
+        raise RecordDoesNotExistError(f"Recipe {recipe_identifier} is archived")
 
     history_entry = get_recipe_history_entry(
-        session, recipe_name=recipe_name, history_id=history_id
+        session, recipe_identifier=recipe_identifier, history_id=history_id
     )
     if history_entry.offliner_definition_version is None:
         raise ValueError(

--- a/backend/src/zimfarm_backend/db/requested_task.py
+++ b/backend/src/zimfarm_backend/db/requested_task.py
@@ -8,7 +8,7 @@ from sqlalchemy.orm import Session as OrmSession
 from sqlalchemy.orm import selectinload
 
 from zimfarm_backend import logger
-from zimfarm_backend.common import getnow, to_naive_utc
+from zimfarm_backend.common import getnow, is_valid_uuid, to_naive_utc
 from zimfarm_backend.common.constants import (
     ARTIFACTS_EXPIRATION,
     ARTIFACTS_UPLOAD_URI,
@@ -196,12 +196,17 @@ def _create_new_requested_task(
 
 
 def _validate_recipe_request_uniqueness(
-    session: OrmSession, *, recipe_name: str, worker_name: str | None
+    session: OrmSession, *, recipe_identifier: str, worker_name: str | None
 ):
+    if is_valid_uuid(recipe_identifier):
+        recipe_where_clause = Recipe.id == recipe_identifier
+    else:
+        recipe_where_clause = Recipe.name == recipe_identifier
+
     query = (
         select(RequestedTask, Recipe)
         .join(Recipe, RequestedTask.recipe)
-        .where(Recipe.name == recipe_name)
+        .where(recipe_where_clause)
     )
     if worker_name is not None:
         query = query.join(Worker, RequestedTask.worker).where(
@@ -209,18 +214,18 @@ def _validate_recipe_request_uniqueness(
         )
 
     if count_from_stmt(session, query) > 0:
-        return f"Recipe '{recipe_name}' already requested"
+        return f"Recipe '{recipe_identifier}' already requested"
     return None
 
 
 def _validate_recipe_state(
-    session: OrmSession, recipe_name: str
+    session: OrmSession, recipe_identifier: str
 ) -> tuple[Recipe | None, str | None]:
-    recipe = get_recipe_or_none(session, recipe_name=recipe_name)
+    recipe = get_recipe_or_none(session, recipe_identifier)
     if recipe is None or not recipe.enabled:
-        return None, f"Recipe '{recipe_name}' not found or disabled"
+        return None, f"Recipe '{recipe_identifier}' not found or disabled"
     if recipe.archived:
-        return None, f"Recipe '{recipe_name}' is archived"
+        return None, f"Recipe '{recipe_identifier}' is archived"
     return recipe, None
 
 
@@ -284,7 +289,7 @@ def _validate_worker_resources(
 def request_task(
     session: OrmSession,
     *,
-    recipe_name: str,
+    recipe_identifier: str,
     requested_by: UUID,
     worker_name: str | None = None,
     priority: int = 0,
@@ -297,11 +302,11 @@ def request_task(
     """
 
     if error := _validate_recipe_request_uniqueness(
-        session, recipe_name=recipe_name, worker_name=worker_name
+        session, recipe_identifier=recipe_identifier, worker_name=worker_name
     ):
         return RequestTaskResult(requested_task=None, error=error)
 
-    recipe, error = _validate_recipe_state(session, recipe_name)
+    recipe, error = _validate_recipe_state(session, recipe_identifier)
     if recipe is None:
         return RequestTaskResult(requested_task=None, error=error)
 
@@ -497,7 +502,7 @@ def create_requested_task_with_duration(
         context=task.context,
         duration=get_recipe_duration(
             session,
-            recipe_name=task.recipe.name if task.recipe else None,
+            recipe_identifier=task.recipe.name if task.recipe else None,
             worker_name=worker.name,
         ),
         updated_at=task.updated_at,

--- a/backend/src/zimfarm_backend/db/tasks.py
+++ b/backend/src/zimfarm_backend/db/tasks.py
@@ -2,13 +2,13 @@ import datetime
 from typing import Any, Literal, cast
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import func, literal, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Bundle, selectinload
 from sqlalchemy.orm import Session as OrmSession
 
-from zimfarm_backend.common import getnow
+from zimfarm_backend.common import getnow, is_valid_uuid
 from zimfarm_backend.common.constants import parse_bool
 from zimfarm_backend.common.enums import TaskStatus
 from zimfarm_backend.common.schemas import BaseModel
@@ -170,7 +170,7 @@ def get_tasks(
     skip: int,
     limit: int,
     status: list[TaskStatus] | None = None,
-    recipe_name: str | None = None,
+    recipe_identifier: str | None = None,
     sort_criteria: Literal["updated_at", "doing", "done", "failed"] = "updated_at",
     offliner: str | None = None,
     fetch_most_recent_tasks: bool = False,
@@ -189,6 +189,16 @@ def get_tasks(
             order_by = Task.updated_at.desc()
         case _:
             order_by = Task.updated_at.desc()
+
+    if recipe_identifier is not None:
+        if is_valid_uuid(recipe_identifier):
+            recipe_where_clause = Recipe.id == recipe_identifier
+        else:
+            recipe_where_clause = Recipe.name == recipe_identifier
+    else:
+        # if no recipe identifier, then we don't filter by that column and just set it
+        # it to true so every row passes the condition
+        recipe_where_clause = literal(True)
 
     status = status or list(TaskStatus)
     stmt = (  # pyright: ignore[reportUnknownVariableType]
@@ -214,7 +224,7 @@ def get_tasks(
         .join(Worker, Task.worker, isouter=True)
         .join(Recipe, Task.recipe, isouter=True)
         .where(
-            (Recipe.name == recipe_name) | (recipe_name is None),
+            recipe_where_clause,
             (Recipe.config["offliner"]["offliner_id"].astext == offliner)
             | (offliner is None),
             (Task.status.in_(status)),
@@ -405,7 +415,7 @@ def compute_task_eta(session: OrmSession, task: Task) -> dict[str, Any]:
     now = getnow()
     duration = get_recipe_duration(
         session,
-        recipe_name=task.recipe.name if task.recipe else None,
+        recipe_identifier=task.recipe.name if task.recipe else None,
         worker_name=task.worker.name,
     )
     elapsed = now - get_timestamp_for_status(

--- a/backend/src/zimfarm_backend/utils/scheduling.py
+++ b/backend/src/zimfarm_backend/utils/scheduling.py
@@ -72,7 +72,7 @@ def request_tasks_using_recipe(session: OrmSession):
                     try:
                         result = request_task(
                             session=session,
-                            recipe_name=recipe.name,
+                            recipe_identifier=recipe.name,
                             requested_by=get_account_by_identifier(
                                 session, account_identifier=requester
                             ).id,

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1045,7 +1045,7 @@ def create_requested_task(
             else recipe_config
         )
 
-        recipe = get_recipe_or_none(dbsession, recipe_name=recipe_name)
+        recipe = get_recipe_or_none(dbsession, recipe_name)
         if recipe is None:
             recipe = create_recipe(name=recipe_name, recipe_config=recipe_config)
 

--- a/backend/tests/db/test_blob.py
+++ b/backend/tests/db/test_blob.py
@@ -155,7 +155,9 @@ def test_get_blobs(
         )
     dbsession.add(recipe)
     dbsession.flush()
-    results = get_blobs(dbsession, skip=skip, limit=limit, recipe_name=recipe.name)
+    results = get_blobs(
+        dbsession, skip=skip, limit=limit, recipe_identifier=recipe.name
+    )
     assert len(results.blobs) == expected_nb_records
     assert len(results.blobs) <= limit
 
@@ -174,5 +176,7 @@ def test_get_blobs_wrong_recipe_name(
     )
     dbsession.add(recipe)
     dbsession.flush()
-    results = get_blobs(dbsession, skip=0, limit=10, recipe_name=recipe.name + "wrong")
+    results = get_blobs(
+        dbsession, skip=0, limit=10, recipe_identifier=recipe.name + "wrong"
+    )
     assert len(results.blobs) == 0

--- a/backend/tests/db/test_language.py
+++ b/backend/tests/db/test_language.py
@@ -191,7 +191,7 @@ def test_get_recipe_with_invalid_language_from_db(
     dbsession.add(recipe)
     dbsession.flush()
     # assert we can read recipes with invalid codes from db
-    recipe = get_recipe(dbsession, recipe_name="test1")
+    recipe = get_recipe(dbsession, "test1")
     assert recipe.language_code == code
     recipe_schema = create_recipe_full_schema(recipe, mwoffliner)
     # for unknown languages, the code and name should be the same

--- a/backend/tests/db/test_recipe.py
+++ b/backend/tests/db/test_recipe.py
@@ -63,21 +63,22 @@ from zimfarm_backend.db.recipe import (
 
 def test_get_recipe_or_none(dbsession: OrmSession):
     """Test that get_recipe_or_none returns None if the recipe does not exist"""
-    recipe = get_recipe_or_none(dbsession, recipe_name="nonexistent")
+    recipe = get_recipe_or_none(dbsession, "nonexistent")
     assert recipe is None
 
 
 def test_get_recipe_not_found(dbsession: OrmSession):
     """Test that get_recipe raises an exception if the recipe does not exist"""
     with pytest.raises(RecordDoesNotExistError):
-        get_recipe(dbsession, recipe_name="nonexistent")
+        get_recipe(dbsession, "nonexistent")
 
 
 def test_get_recipe(dbsession: OrmSession, recipe: Recipe):
     """Test that get_recipe returns the recipe if it exists"""
-    db_recipe = get_recipe(dbsession, recipe_name=recipe.name)
+    db_recipe = get_recipe(dbsession, str(recipe.id))
     assert db_recipe is not None
     assert db_recipe.name == recipe.name
+    assert db_recipe.id == recipe.id
 
 
 @pytest.mark.parametrize(
@@ -98,7 +99,7 @@ def test_count_enabled_recipes(
 def test_get_recipe_duration_default(dbsession: OrmSession, worker: Worker):
     """Test that returns default duration when no specific duration exists"""
     duration = get_recipe_duration(
-        dbsession, recipe_name="nonexistent", worker_name=worker.name
+        dbsession, recipe_identifier="nonexistent", worker_name=worker.name
     )
     assert duration.value > 0
     assert duration.worker_name is None
@@ -113,7 +114,7 @@ def test_get_recipe_duration_with_worker(
     """Returns worker-specific duration when recipe exists"""
     recipe = create_recipe(worker=worker)
     duration = get_recipe_duration(
-        dbsession, recipe_name=recipe.name, worker_name=worker.name
+        dbsession, recipe_identifier=str(recipe.id), worker_name=worker.name
     )
     assert duration.value == recipe.durations[0].value
     assert duration.worker_name is not None
@@ -229,7 +230,7 @@ def test_update_recipe(
         update_recipe(
             dbsession,
             author_id=account.id,
-            recipe_name=old_recipe.name,
+            recipe_identifier=str(old_recipe.id),
             new_recipe_config=new_recipe_config,
             name=old_recipe.name + "_updated",
             offliner_definition=mwoffliner_definition,
@@ -245,13 +246,14 @@ def test_update_recipe(
 def test_delete_recipe(dbsession: OrmSession, create_recipe: Callable[..., Recipe]):
     """Test that delete_recipe deletes a recipe"""
     recipe = create_recipe()
-    delete_recipe(dbsession, recipe_name=recipe.name)
-    assert get_recipe_or_none(dbsession, recipe_name=recipe.name) is None
+    recipe_id = recipe.id
+    delete_recipe(dbsession, str(recipe.id))
+    assert get_recipe_or_none(dbsession, str(recipe_id)) is None
     # assert that there is no recipe history entry
     assert (
         count_from_stmt(
             dbsession,
-            select(RecipeHistory).where(RecipeHistory.recipe_id == recipe.id),
+            select(RecipeHistory).where(RecipeHistory.recipe_id == recipe_id),
         )
         == 0
     )
@@ -260,7 +262,7 @@ def test_delete_recipe(dbsession: OrmSession, create_recipe: Callable[..., Recip
 def test_delete_recipe_not_found(dbsession: OrmSession):
     """Test that delete_recipe raises an exception if the recipe does not exist"""
     with pytest.raises(RecordDoesNotExistError):
-        delete_recipe(dbsession, recipe_name="nonexistent")
+        delete_recipe(dbsession, "nonexistent")
 
 
 @pytest.mark.parametrize(
@@ -366,7 +368,7 @@ def test_update_recipe_duration_no_tasks(
     """Test that update_recipe_duration does nothing when no matching tasks exist"""
     recipe = create_recipe(name="test_recipe")
 
-    update_recipe_duration(dbsession, recipe_name=recipe.name)
+    update_recipe_duration(dbsession, recipe_identifier=recipe.name)
 
     assert len(recipe.durations) == 1
     assert recipe.durations[0].default is True
@@ -400,11 +402,11 @@ def test_update_recipe_duration_with_completed_tasks(
     dbsession.add(task)
     dbsession.flush()
 
-    update_recipe_duration(dbsession, recipe_name=recipe.name)
+    update_recipe_duration(dbsession, recipe_identifier=str(recipe.id))
 
     # Expire the recipe to force a reload of the recipe
     dbsession.expire(recipe)
-    updated_recipe = get_recipe(dbsession, recipe_name=recipe.name)
+    updated_recipe = get_recipe(dbsession, recipe.name)
 
     assert len(updated_recipe.durations) == 2  # Default + worker-specific
 
@@ -446,11 +448,11 @@ def test_update_recipe_duration_with_failed_tasks(
     dbsession.add(task)
     dbsession.flush()
 
-    update_recipe_duration(dbsession, recipe_name=recipe.name)
+    update_recipe_duration(dbsession, recipe_identifier=recipe.name)
 
     # Expire the recipe to force a reload of the recipe
     dbsession.expire(recipe)
-    updated_recipe = get_recipe(dbsession, recipe_name=recipe.name)
+    updated_recipe = get_recipe(dbsession, recipe.name)
 
     # Verify no new durations were created (only the default remains)
     assert len(updated_recipe.durations) == 1
@@ -501,10 +503,10 @@ def test_update_recipe_duration_multiple_workers(
     dbsession.add_all([task1, task2])
     dbsession.flush()
 
-    update_recipe_duration(dbsession, recipe_name=recipe.name)
+    update_recipe_duration(dbsession, recipe_identifier=recipe.name)
 
     dbsession.expire(recipe)
-    updated_recipe = get_recipe(dbsession, recipe_name=recipe.name)
+    updated_recipe = get_recipe(dbsession, recipe.name)
 
     assert len(updated_recipe.durations) == 3  # Default + 2 worker-specific
 
@@ -523,7 +525,7 @@ def test_get_recipe_history_entry_or_none_not_found(
     dbsession: OrmSession, recipe: Recipe
 ):
     history_entry = get_recipe_history_entry_or_none(
-        dbsession, recipe_name=recipe.name, history_id=uuid4()
+        dbsession, recipe_identifier=recipe.name, history_id=uuid4()
     )
     assert history_entry is None
 
@@ -531,7 +533,7 @@ def test_get_recipe_history_entry_or_none_not_found(
 def test_get_recipe_history_entry_or_none(dbsession: OrmSession, recipe: Recipe):
     history_entry = get_recipe_history_entry_or_none(
         dbsession,
-        recipe_name=recipe.name,
+        recipe_identifier=recipe.name,
         history_id=recipe.history_entries[0].id,
     )
     assert history_entry is not None
@@ -541,7 +543,7 @@ def test_get_recipe_history_entry(dbsession: OrmSession, recipe: Recipe):
     with pytest.raises(RecordDoesNotExistError):
         get_recipe_history_entry(
             dbsession,
-            recipe_name=recipe.name,
+            recipe_identifier=recipe.name,
             history_id=uuid4(),
         )
 
@@ -569,7 +571,7 @@ def test_toggle_recipe_archive_status(
         recipe = create_recipe(archived=archived)
         toggle_archive_status(
             dbsession,
-            recipe_name=recipe.name,
+            recipe_identifier=recipe.name,
             archived=new_archive_status,
             actor_id=account.id,
         )
@@ -596,7 +598,7 @@ def test_restore_recipes(
     create_recipe(name="testrecipe", archived=True)
 
     with expected:
-        restore_recipes(dbsession, recipe_names=recipe_names, actor_id=account.id)
+        restore_recipes(dbsession, recipe_identifiers=recipe_names, actor_id=account.id)
 
 
 def test_revert_recipe_archived_recipe(
@@ -613,7 +615,7 @@ def test_revert_recipe_archived_recipe(
     ):
         revert_recipe(
             dbsession,
-            recipe_name="archived_recipe",
+            recipe_identifier="archived_recipe",
             history_id=history_id,
             author_id=account.id,
         )
@@ -637,7 +639,7 @@ def test_revert_recipe_no_offliner_definition_version(
     ):
         revert_recipe(
             dbsession,
-            recipe_name="test_recipe",
+            recipe_identifier="test_recipe",
             history_id=history_entry.id,
             author_id=account.id,
         )
@@ -703,7 +705,7 @@ def test_revert_recipe_all_fields(
     update_recipe(
         dbsession,
         author_id=account.id,
-        recipe_name="test_recipe",
+        recipe_identifier="test_recipe",
         new_recipe_config=new_recipe_config,
         offliner_definition=mwoffliner_definition,
         tags=["tag3", "tag4"],
@@ -719,7 +721,7 @@ def test_revert_recipe_all_fields(
         ),
     )
 
-    updated_recipe = get_recipe(dbsession, recipe_name="test_recipe")
+    updated_recipe = get_recipe(dbsession, "test_recipe")
 
     assert updated_recipe.config != initial_config
     assert updated_recipe.tags != initial_tags
@@ -731,7 +733,7 @@ def test_revert_recipe_all_fields(
 
     reverted_recipe = revert_recipe(
         dbsession,
-        recipe_name="test_recipe",
+        recipe_identifier="test_recipe",
         history_id=initial_history_id,
         author_id=account.id,
     )

--- a/backend/tests/db/test_requested_task.py
+++ b/backend/tests/db/test_requested_task.py
@@ -51,7 +51,7 @@ def test_request_task_nonexistent_recipe(dbsession: OrmSession, worker: Worker):
     """Test that request_task returns None for non-existent recipe"""
     result = request_task(
         session=dbsession,
-        recipe_name="nonexistent",
+        recipe_identifier="nonexistent",
         requested_by=uuid4(),
         worker_name=worker.name,
     )
@@ -62,7 +62,7 @@ def test_request_task_nonexistent_worker(dbsession: OrmSession, recipe: Recipe):
     """Test that request_task returns None for non-existent worker"""
     result = request_task(
         session=dbsession,
-        recipe_name=recipe.name,
+        recipe_identifier=recipe.name,
         requested_by=uuid4(),
         worker_name="nonexistent",
     )
@@ -79,7 +79,7 @@ def test_request_task_disabled_recipe(
 
     result = request_task(
         session=dbsession,
-        recipe_name=recipe.name,
+        recipe_identifier=recipe.name,
         requested_by=uuid4(),
         worker_name=worker.name,
     )
@@ -96,7 +96,7 @@ def test_request_task_archived_recipe(
 
     result = request_task(
         session=dbsession,
-        recipe_name=recipe.name,
+        recipe_identifier=recipe.name,
         requested_by=uuid4(),
         worker_name=worker.name,
     )
@@ -117,7 +117,7 @@ def test_request_task_already_requested(
     )
     result = request_task(
         session=dbsession,
-        recipe_name=recipe.name,
+        recipe_identifier=recipe.name,
         requested_by=uuid4(),
         worker_name=worker.name,
     )
@@ -325,7 +325,7 @@ def test_request_task_for_worker(
     requested_by = create_account(username="testuser")
     result = request_task(
         session=dbsession,
-        recipe_name=recipe.name,
+        recipe_identifier=recipe.name,
         requested_by=requested_by.id,
         worker_name=worker.name,
     )

--- a/backend/tests/db/test_task.py
+++ b/backend/tests/db/test_task.py
@@ -105,7 +105,7 @@ def test_get_tasks(
         skip=skip,
         limit=limit,
         status=status,
-        recipe_name=recipe_name,
+        recipe_identifier=recipe_name,
         offliner=offliner,
     )
     assert result.nb_records == expected_nb_records

--- a/backend/tests/routes/test_recipes.py
+++ b/backend/tests/routes/test_recipes.py
@@ -370,7 +370,7 @@ def test_create_recipe_with_permssions(
     assert response.status_code == expected_status_code
     if response.status_code == HTTPStatus.OK:
         # assert top-level scalar attributes of the recipe with the payload
-        recipe = get_recipe(dbsession, recipe_name="test_recipe")
+        recipe = get_recipe(dbsession, "test_recipe")
         assert recipe.language_code == "eng"
         assert recipe.tags == ["important"]
         assert recipe.enabled is True
@@ -462,6 +462,7 @@ def test_get_recipe(
         headers={"Authorization": f"Bearer {access_token}"},
     )
     data = response.json()
+    assert "id" in data
     assert "config" in data
     assert "offliner" in data["config"]
     assert "mwPassword" in data["config"]["offliner"]
@@ -504,6 +505,7 @@ def test_get_obsolete_recipe(
     )
     assert response.status_code == HTTPStatus.OK
     recipe_data = response.json()
+    assert "id" in recipe_data
     assert "config" in recipe_data
     assert "offliner" in recipe_data["config"]
     assert "mwUrl" in recipe_data["config"]["offliner"]
@@ -679,8 +681,9 @@ def test_update_recipe(
     dbsession.add(recipe)
     dbsession.flush()
 
+    recipe_identifier = recipe.id if hash(str(payload)) % 2 == 0 else recipe.name
     response = client.patch(
-        f"/v2/recipes/{recipe.name}",
+        f"/v2/recipes/{recipe_identifier}",
         headers={"Authorization": f"Bearer {access_token}"},
         json=payload,
     )
@@ -713,7 +716,7 @@ def test_delete_recipe(
     dbsession.flush()
 
     response = client.delete(
-        f"/v2/recipes/{recipe.name}",
+        f"/v2/recipes/{recipe.id}",
         headers={"Authorization": f"Bearer {access_token}"},
     )
     assert response.status_code == expected_status_code
@@ -770,7 +773,7 @@ def test_clone_recipe(
     dbsession.flush()
 
     response = client.post(
-        f"/v2/recipes/{recipe.name}/clone",
+        f"/v2/recipes/{recipe.id}/clone",
         headers={"Authorization": f"Bearer {access_token}"},
         json={"name": "test_recipe_clone"},
     )
@@ -780,7 +783,7 @@ def test_clone_recipe(
     assert data["id"] is not None
     assert str(data["id"]) != str(recipe.id)
 
-    new_recipe = get_recipe(dbsession, recipe_name="test_recipe_clone")
+    new_recipe = get_recipe(dbsession, "test_recipe_clone")
     assert new_recipe.is_valid == expected_validity_status
 
 
@@ -829,7 +832,7 @@ def test_validate_recipe(
     dbsession.flush()
 
     response = client.get(
-        f"/v2/recipes/{recipe.name}/validate",
+        f"/v2/recipes/{recipe.id}/validate",
         headers={"Authorization": f"Bearer {access_token}"},
     )
     assert response.status_code == expected_status_code
@@ -1126,7 +1129,7 @@ def test_get_recipe_history_pagination(
         update_recipe(
             session=dbsession,
             author_id=account.id,
-            recipe_name=recipe.name,
+            recipe_identifier=recipe.name,
             comment=f"test_comment_{i}",
             tags=[*recipe.tags, f"test_tag_{i}"],
             offliner_definition=create_offliner_definition_schema(
@@ -1256,7 +1259,7 @@ def test_archive_recipe(
     recipe = create_recipe(name="test_recipe")
 
     response = client.patch(
-        f"/v2/recipes/{recipe.name}/archive",
+        f"/v2/recipes/{recipe.id}/archive",
         headers={"Authorization": f"Bearer {access_token}"},
         json={},
     )
@@ -1330,7 +1333,7 @@ def test_revert_recipe_history(
     update_recipe(
         dbsession,
         author_id=account.id,
-        recipe_name="test_recipe",
+        recipe_identifier="test_recipe",
         offliner_definition=mwoffliner_definition,
         tags=["tag3", "tag4"],
         category=RecipeCategory.other,


### PR DESCRIPTION
## Rationale
This API enhances the API by returning the recipe id in the endpoints that return a recipe details. Accordingly, it accepts the recipe id as a route parameter and not just the recipe name

This closes #1914