### PR TITLE
hide links for requested tasks

### DIFF
--- a/frontend-ui/src/components/PipelineTable.vue
+++ b/frontend-ui/src/components/PipelineTable.vue
@@ -50,7 +50,7 @@
             :status="item.status"
             :timestamp="item.timestamp"
             :updated-at="item.updated_at"
-            :task-id="item.id"
+            :task-id="isRequestedTasks ? null : item.id"
           />
         </template>
 
@@ -205,6 +205,7 @@ const props = defineProps<{
   tasks: TaskLight[] | RequestedTaskLight[] // the tasks to display
   paginator: Paginator // the paginator
   errors: string[] // the errors to display
+  isRequestedTasks?: boolean
 }>()
 
 const emit = defineEmits<{

--- a/frontend-ui/src/views/PipelineView.vue
+++ b/frontend-ui/src/views/PipelineView.vue
@@ -16,6 +16,7 @@
     :canRequestTasks="canRequestTasks"
     :canUnRequestTasks="canUnRequestTasks"
     :canCancelTasks="canCancelTasks"
+    :isRequestedTasks="currentFilter === 'todo'"
     @limit-changed="handleLimitChange"
     @load-data="loadData"
   />


### PR DESCRIPTION
## Rationale

https://github.com/openzim/zimfarm/pull/1854 introduced a common way for display status and timestamp information. However, it only includes a task link if a task id is supplied. This PR removes links for requested tasks which are shown in the todo tab of the pipeline view as they shouldn't have tasks.

This fixes #1926 