### PR TITLE
Add maps platform

### DIFF
--- a/backend/src/zimfarm_backend/common/enums.py
+++ b/backend/src/zimfarm_backend/common/enums.py
@@ -254,6 +254,7 @@ class Platform(StrEnum):
     libretexts = "libretexts"
     phet = "phet"
     gutenberg = "gutenberg"
+    maps = "maps"
 
     @classmethod
     def all(cls) -> list["Platform"]:
@@ -268,6 +269,7 @@ class Platform(StrEnum):
             cls.libretexts,
             cls.phet,
             cls.gutenberg,
+            cls.maps,
         ]
 
     @classmethod

--- a/worker/src/zimfarm_worker/common/constants.py
+++ b/worker/src/zimfarm_worker/common/constants.py
@@ -182,6 +182,7 @@ ALL_PLATFORMS = [
     "libretexts",
     "gutenberg",
     "phet",
+    "maps",
 ]
 PLATFORMS_TASKS: dict[str, int] = {}
 for platform in ALL_PLATFORMS:


### PR DESCRIPTION
## Rationale

We need a new `maps` platform so that we do not start more than one `maps` task at a time on the Zimfarm, this causes problems of throttling / overwhelming on upstream.