### PR TITLE
sync navbar entries with active route name

### DIFF
--- a/frontend-ui/src/App.vue
+++ b/frontend-ui/src/App.vue
@@ -53,7 +53,7 @@ const navigationItems = computed<NavigationItem[]>(() => [
     show: true,
   },
   {
-    name: 'recipes-list',
+    name: 'recipes',
     label: 'Recipes',
     route: 'recipes',
     icon: 'mdi-book-open-variant',
@@ -69,7 +69,7 @@ const navigationItems = computed<NavigationItem[]>(() => [
     show: true,
   },
   {
-    name: 'users-list',
+    name: 'users',
     label: 'Users',
     route: 'users',
     icon: 'mdi-account-group',

--- a/frontend-ui/src/components/NavBar.vue
+++ b/frontend-ui/src/components/NavBar.vue
@@ -14,7 +14,7 @@
     </v-app-bar-title>
     <v-spacer class="d-flex"></v-spacer>
     <!-- Navigation Links -->
-    <v-tabs class="d-none d-md-flex" color="white" slider-color="white">
+    <v-tabs class="d-none d-md-flex" color="white" slider-color="white" :model-value="activeTab">
       <v-tab
         v-for="item in visibleNavigationItems"
         :key="item.name"
@@ -63,6 +63,7 @@
         :disabled="item.disabled"
         :prepend-icon="item.icon"
         :to="{ name: item.name }"
+        :active="activeTab == item.name"
       >
         <v-list-item-title>{{ item.label }}</v-list-item-title>
       </v-list-item>
@@ -84,6 +85,8 @@ import Loading from '@/components/Loading.vue'
 import UserButton from '@/components/UserButton.vue'
 import type { AuthProviderType } from '@/types/auth'
 import { computed, ref } from 'vue'
+
+import { useRoute } from 'vue-router'
 
 // Props
 export interface NavigationItem {
@@ -110,11 +113,26 @@ defineEmits<{
   'sign-out': []
 }>()
 
+const route = useRoute()
+
 // Reactive data
 const drawer = ref(false)
 
 const visibleNavigationItems = computed(() => {
   return props.navigationItems.filter((item) => item.show)
+})
+
+const activeTab = computed(() => {
+  let currentRouteName = route.name as string
+  if (route.meta?.parentNavigation) {
+    currentRouteName = route.meta.parentNavigation as string
+  }
+
+  const isInNavigation = visibleNavigationItems.value.some(
+    (item) => item.show && item.name == currentRouteName,
+  )
+
+  return isInNavigation ? currentRouteName : undefined
 })
 </script>
 

--- a/frontend-ui/src/router/index.ts
+++ b/frontend-ui/src/router/index.ts
@@ -23,6 +23,7 @@ const routes = [
     props: true,
     meta: {
       title: (to: RouteLocationNormalized) => `Zimfarm | Worker • ${to.params.workerName}`,
+      parentNavigation: 'workers',
     },
   },
   {
@@ -32,6 +33,7 @@ const routes = [
     props: true,
     meta: {
       title: (to: RouteLocationNormalized) => `Zimfarm | Worker • ${to.params.workerName}`,
+      parentNavigation: 'workers',
     },
   },
   {
@@ -77,6 +79,7 @@ const routes = [
     props: true,
     meta: {
       title: (to: RouteLocationNormalized) => `Zimfarm | Task • ${to.params.id}`,
+      parentNavigation: 'pipeline',
     },
   },
 
@@ -87,6 +90,7 @@ const routes = [
     props: true,
     meta: {
       title: (to: RouteLocationNormalized) => `Zimfarm | Task • ${to.params.id}`,
+      parentNavigation: 'pipeline',
     },
   },
 
@@ -97,6 +101,7 @@ const routes = [
     props: true,
     meta: {
       title: (to: RouteLocationNormalized) => `Zimfarm | Recipe • ${to.params.recipeName}`,
+      parentNavigation: 'recipes',
     },
   },
   {
@@ -106,11 +111,12 @@ const routes = [
     props: true,
     meta: {
       title: (to: RouteLocationNormalized) => `Zimfarm | Recipe • ${to.params.recipeName}`,
+      parentNavigation: 'recipes',
     },
   },
   {
     path: '/recipes',
-    name: 'recipes-list',
+    name: 'recipes',
     component: RecipesView,
     meta: { title: 'Zimfarm | Recipes' },
   },
@@ -118,7 +124,7 @@ const routes = [
     path: '/recipes/archives',
     name: 'archived-recipes',
     component: ArchivedRecipesView,
-    meta: { title: 'Zimfarm | Archived Recipes' },
+    meta: { title: 'Zimfarm | Archived Recipes', parentNavigation: 'recipes' },
   },
   {
     path: '/users/:userId',
@@ -127,6 +133,7 @@ const routes = [
     props: true,
     meta: {
       title: (to: RouteLocationNormalized) => `Zimfarm | User • ${to.params.userId}`,
+      parentNavigation: 'users',
     },
   },
   {
@@ -136,11 +143,12 @@ const routes = [
     props: true,
     meta: {
       title: (to: RouteLocationNormalized) => `Zimfarm | User • ${to.params.userId}`,
+      parentNavigation: 'users',
     },
   },
   {
     path: '/users',
-    name: 'users-list',
+    name: 'users',
     component: UsersView,
     meta: { title: 'Zimfarm | Users' },
   },

--- a/frontend-ui/src/views/RecipeDetailView.vue
+++ b/frontend-ui/src/views/RecipeDetailView.vue
@@ -1192,7 +1192,7 @@ const deleteRecipe = async () => {
   const response = await recipeStore.deleteRecipe(props.recipeName)
   if (response) {
     notificationStore.showSuccess(`Recipe <code>${props.recipeName}</code> has been deleted.`)
-    router.push({ name: 'recipes-list' })
+    router.push({ name: 'recipes' })
   } else {
     for (const error of recipeStore.errors) {
       notificationStore.showError(error)

--- a/frontend-ui/src/views/RecipesView.vue
+++ b/frontend-ui/src/views/RecipesView.vue
@@ -4,7 +4,7 @@
   <div>
     <RecipesBaseView
       :archived="false"
-      :route-name="'recipes-list'"
+      :route-name="'recipes'"
       :can-request-tasks="canRequestTasks"
       @filters-updated="handleFiltersUpdated"
     >

--- a/frontend-ui/src/views/UserView.vue
+++ b/frontend-ui/src/views/UserView.vue
@@ -368,7 +368,7 @@ const deleteUser = async () => {
   const success = await userStore.deleteUser(props.userId)
   if (success) {
     notificationStore.showSuccess(`User account ${user.value?.display_name} has been deleted.`)
-    router.push({ name: 'users-list' })
+    router.push({ name: 'users' })
   } else {
     for (const error of userStore.errors) {
       notificationStore.showError(error)


### PR DESCRIPTION
## Rationale
<img width="1373" height="593" alt="Screenshot_20260619_102720" src="https://github.com/user-attachments/assets/b4537757-1444-43cb-abd0-720a2afcfd1b" />
<img width="1674" height="639" alt="Screenshot_20260619_102700" src="https://github.com/user-attachments/assets/804a2309-b242-4b4a-ba02-833f5decb512" />
<img width="1590" height="512" alt="Screenshot_20260619_102642" src="https://github.com/user-attachments/assets/16236da6-c8e2-477d-a6a7-31ddda1e34f3" />


## Changes
- add `parentNavigation` metadata to route items to detect which navbar to highlight when we visit the route
