### PR TITLE
use zimcheck urls if supplied by CMS

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -105,7 +105,7 @@ class TaskLightSchema(BaseTaskSchema):
 class ZimUrlSchema(BaseModel):
     """Schema for a single zim URL"""
 
-    kind: Literal["view", "download"]
+    kind: Literal["view", "download", "zimcheck"]
     url: AnyUrl
     collection: str
 

--- a/frontend-ui/src/components/TaskFileCard.vue
+++ b/frontend-ui/src/components/TaskFileCard.vue
@@ -89,7 +89,7 @@
               </template>
             </v-tooltip>
             <v-btn
-              v-if="file.check_filename"
+              v-if="checksUrl"
               variant="text"
               size="x-small"
               class="ml-1 pa-0"
@@ -150,7 +150,7 @@
 import FileInfoTable from '@/components/FileInfoTable.vue'
 import ZimUrlButtons from '@/components/ZimUrlButtons.vue'
 import { TaskStatus } from '@/types/base'
-import type { Task, TaskFile } from '@/types/tasks'
+import type { Task, TaskFile, ZimUrl } from '@/types/tasks'
 import { formatDt, formatDurationBetween, formattedBytesSize } from '@/utils/format'
 import { checkUrl } from '@/utils/offliner'
 import { getTimestampStringForStatus } from '@/utils/timestamp'
@@ -191,8 +191,12 @@ const uploadDurationTime = computed(() => {
 })
 
 const checksUrl = computed(() => {
-  if (!props.file.check_filename) return ''
-  return checkUrl(props.task, props.file.check_filename)
+  if (props.file.zim_urls == null) {
+    // Fall back to old behaviour when zim_urls is not available
+    if (!props.file.check_filename) return ''
+    return checkUrl(props.task, props.file.check_filename)
+  }
+  return props.file.zim_urls?.find((url: ZimUrl) => url.kind === 'zimcheck')?.url
 })
 
 const fallbackDownloadUrl = computed(() => {

--- a/frontend-ui/src/components/ZimUrlButtons.vue
+++ b/frontend-ui/src/components/ZimUrlButtons.vue
@@ -2,8 +2,8 @@
   <div v-if="loading" class="d-flex align-center">
     <v-progress-circular indeterminate size="20" width="2" />
   </div>
-  <div v-else-if="urls && urls.length > 0" class="d-inline-flex align-center">
-    <v-tooltip v-for="url in urls" :key="`${url.kind}-${url.collection}`" location="bottom">
+  <div v-else-if="displayUrls && displayUrls.length > 0" class="d-inline-flex align-center">
+    <v-tooltip v-for="url in displayUrls" :key="`${url.kind}-${url.collection}`" location="bottom">
       <template #activator="{ props: tooltipProps }">
         <v-btn
           v-bind="tooltipProps"
@@ -22,9 +22,10 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from 'vue'
 import type { ZimUrl } from '@/types/tasks'
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     urls?: ZimUrl[]
     loading?: boolean
@@ -35,5 +36,9 @@ withDefaults(
     loading: false,
     compact: false,
   },
+)
+
+const displayUrls = computed(
+  () => props.urls?.filter((url) => url.kind === 'view' || url.kind === 'download') ?? [],
 )
 </script>

--- a/frontend-ui/src/types/tasks.ts
+++ b/frontend-ui/src/types/tasks.ts
@@ -12,7 +12,7 @@ export interface TaskEvent {
 }
 
 export interface ZimUrl {
-  kind: 'view' | 'download'
+  kind: 'view' | 'download' | 'zimcheck'
   url: string
   collection: string
 }


### PR DESCRIPTION
## Rationale
CMS is now in charge of deleting zimcheck results from S3 (https://github.com/openzim/cms/pull/355). So, when zimfarm is configured to inform CMS, it needs to rely on CMS to know if zimcheck urls are still valid.

## Changes
- use zimcheck URL provided by CMS if zimfarm is configured to inform CMS, otherwise, default to old behaviour of building the URL using zimcheck filename

This closes #1972 