### PR TITLE
exclude archived recipes from scheduling

### DIFF
--- a/backend/src/zimfarm_backend/utils/scheduling.py
+++ b/backend/src/zimfarm_backend/utils/scheduling.py
@@ -44,6 +44,7 @@ def request_tasks_using_recipe(session: OrmSession):
         for recipe in session.execute(
             sa.select(dbm.Recipe).where(
                 dbm.Recipe.enabled,
+                dbm.Recipe.archived.is_(False),
                 dbm.Recipe.periodicity == period,
                 ~sa.exists().where(dbm.RequestedTask.recipe_id == dbm.Recipe.id),
             )


### PR DESCRIPTION
## Changes
- exclude archived recipes from periodic scheduler list of recipes to request tasks for

This fixes #1978 