### PR TITLE
update zim-tools to 3.8.0

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -223,7 +223,7 @@ services:
       monitor_parent:
         condition: service_started
 
-    command: worker-manager --webapi-uri 'http://backend:80/v2' --name test_worker
+    command: worker-manager --webapi-uri 'http://backend:80/v2' --name test-worker
     environment:
       - DEBUG=true
       - TASK_WORKER_IMAGE=zf_task_worker

--- a/worker/src/zimfarm_worker/common/constants.py
+++ b/worker/src/zimfarm_worker/common/constants.py
@@ -41,7 +41,7 @@ DNSCACHE_IMAGE = getenv(
 UPLOADER_IMAGE = getenv(
     "UPLOADER_IMAGE", default="ghcr.io/openzim/zimfarm-uploader:latest"
 )
-CHECKER_IMAGE = getenv("CHECKER_IMAGE", default="ghcr.io/openzim/zim-tools:3.7.0-1")
+CHECKER_IMAGE = getenv("CHECKER_IMAGE", default="ghcr.io/openzim/zim-tools:3.8.0")
 MONITOR_IMAGE = getenv(
     "MONITOR_IMAGE", default="ghcr.io/openzim/zimfarm-monitor-child:latest"
 )


### PR DESCRIPTION
## Changes
- update zim-tools checker image to 3.8.0
- use alphanumeric characters only in worker name as API now requires that

This closes #1993
