### PR TITLE
show paused recipes and requested tasks in tasks pipeline

### DIFF
--- a/backend/src/zimfarm_backend/common/schemas/orms.py
+++ b/backend/src/zimfarm_backend/common/schemas/orms.py
@@ -73,6 +73,8 @@ class MostRecentTaskSchema(BaseModel):
     status: str
     updated_at: MadeAwareDateTime
     timestamp: list[tuple[str, datetime.datetime]]
+    # whether this is a requested task instead of a task
+    is_requested: bool = False
 
 
 class BaseTaskSchema(BaseModel):
@@ -99,6 +101,7 @@ class TaskLightSchema(BaseTaskSchema):
     """
 
     config: ConfigWithOnlyResourcesSchema
+    recipe_enabled: bool | None = None
     recipe_most_recent_task: MostRecentTaskSchema | None = None
 
 

--- a/backend/src/zimfarm_backend/db/tasks.py
+++ b/backend/src/zimfarm_backend/db/tasks.py
@@ -38,6 +38,7 @@ from zimfarm_backend.db.models import (
     File,
     OfflinerDefinition,
     Recipe,
+    RequestedTask,
     Task,
     Worker,
 )
@@ -219,6 +220,7 @@ def get_tasks(
             Account.display_name.label("requested_by"),
             Recipe.name.label("recipe_name"),
             Recipe.id.label("recipe_id"),
+            Recipe.enabled.label("recipe_enabled"),
             Worker.name.label("worker_name"),
         )
         .join(Account, Task.requested_by)
@@ -249,6 +251,7 @@ def get_tasks(
         requested_by,
         _recipe_name,
         _recipe_id,
+        _recipe_enabled,
         worker_name,
     ) in session.execute(
         stmt  # pyright: ignore[reportUnknownArgumentType]
@@ -273,6 +276,7 @@ def get_tasks(
                 requested_by=requested_by,
                 recipe_name=_recipe_name,
                 recipe_id=_recipe_id,
+                recipe_enabled=_recipe_enabled,
                 worker_name=worker_name,
             )
         )
@@ -307,6 +311,32 @@ def get_tasks(
                             status=task_status,
                             updated_at=task_updated_at,
                             timestamp=task_timestamp,
+                        )
+
+            # a requested task is always more recent than any task of the recipe,
+            # and there is at most one of them per recipe
+            requested_stmt = select(
+                RequestedTask.recipe_id,
+                RequestedTask.id,
+                RequestedTask.status,
+                RequestedTask.updated_at,
+                RequestedTask.timestamp,
+            ).where(RequestedTask.recipe_id.in_(list(recipe_ids)))
+            for (
+                schedule_id,
+                requested_task_id,
+                requested_task_status,
+                requested_task_updated_at,
+                requested_task_timestamp,
+            ) in session.execute(requested_stmt).all():
+                for task in results.tasks:
+                    if schedule_id == task.recipe_id:
+                        task.recipe_most_recent_task = MostRecentTaskSchema(
+                            id=requested_task_id,
+                            status=requested_task_status,
+                            updated_at=requested_task_updated_at,
+                            timestamp=requested_task_timestamp,
+                            is_requested=True,
                         )
 
     return results

--- a/backend/tests/routes/test_task.py
+++ b/backend/tests/routes/test_task.py
@@ -54,6 +54,7 @@ def test_get_tasks(
     assert len(data["items"]) == 5
 
     for item in data["items"]:
+        assert item["recipe_enabled"] is True
         most_recent_task = item["recipe_most_recent_task"]
         if fetch_most_recent_tasks == "true":
             assert most_recent_task is not None
@@ -61,8 +62,49 @@ def test_get_tasks(
             assert "status" in most_recent_task
             assert "timestamp" in most_recent_task
             assert "updated_at" in most_recent_task
+            assert most_recent_task["is_requested"] is False
         else:
             assert most_recent_task is None
+
+
+def test_get_tasks_of_disabled_recipe_with_requested_task(
+    dbsession: OrmSession,
+    client: TestClient,
+    access_token: str,
+    create_task: Callable[..., Task],
+    create_recipe: Callable[..., Recipe],
+    create_requested_task: Callable[..., RequestedTask],
+):
+    """Test that tasks report whether their recipe is disabled and its last run"""
+    recipe = create_recipe(name="disabled_recipe", enabled=False)
+    task = create_task(recipe_name="disabled_recipe")
+    recipe.most_recent_task = task
+    dbsession.add(recipe)
+    dbsession.flush()
+
+    response = client.get(
+        "/v2/tasks?recipe_name=disabled_recipe&fetch_most_recent_tasks=true",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == HTTPStatus.OK
+    items = response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["recipe_enabled"] is False
+    assert items[0]["recipe_most_recent_task"]["id"] == str(task.id)
+    assert items[0]["recipe_most_recent_task"]["is_requested"] is False
+
+    # a requested task is more recent than the most recent task of the recipe
+    requested_task = create_requested_task(recipe_name="disabled_recipe")
+
+    response = client.get(
+        "/v2/tasks?recipe_name=disabled_recipe&fetch_most_recent_tasks=true",
+        headers={"Authorization": f"Bearer {access_token}"},
+    )
+    assert response.status_code == HTTPStatus.OK
+    items = response.json()["items"]
+    assert len(items) == 1
+    assert items[0]["recipe_most_recent_task"]["id"] == str(requested_task.id)
+    assert items[0]["recipe_most_recent_task"]["is_requested"] is True
 
 
 @pytest.mark.parametrize("hide_secrets", ["true", "false"])

--- a/frontend-ui/src/components/PipelineTable.vue
+++ b/frontend-ui/src/components/PipelineTable.vue
@@ -42,6 +42,14 @@
             :to="{ name: 'recipe-detail', params: { recipeName: item.recipe_name } }"
           >
             {{ item.recipe_name }}
+            <v-icon
+              v-if="(item as TaskLight).recipe_enabled === false"
+              size="small"
+              color="orange"
+              class="ml-1"
+            >
+              mdi-pause
+            </v-icon>
           </router-link>
         </template>
 
@@ -149,7 +157,11 @@
             :status="(item as TaskLight).recipe_most_recent_task!.status"
             :timestamp="(item as TaskLight).recipe_most_recent_task!.timestamp"
             :updated-at="(item as TaskLight).recipe_most_recent_task!.updated_at"
-            :task-id="(item as TaskLight).recipe_most_recent_task!.id"
+            :task-id="
+              (item as TaskLight).recipe_most_recent_task!.is_requested
+                ? null
+                : (item as TaskLight).recipe_most_recent_task!.id
+            "
           />
         </template>
 

--- a/frontend-ui/src/types/base.ts
+++ b/frontend-ui/src/types/base.ts
@@ -67,6 +67,7 @@ export interface MostRecentTask {
   status: string
   updated_at: string
   timestamp: [string, string][] // [status, datetime] tuples
+  is_requested?: boolean // whether this is a requested task instead of a task
 }
 export enum TaskStatus {
   requested = 'requested',

--- a/frontend-ui/src/types/tasks.ts
+++ b/frontend-ui/src/types/tasks.ts
@@ -3,6 +3,7 @@ import type { ExpandedRecipeConfig, RecipeNotification } from '@/types/recipe'
 
 export interface TaskLight extends BaseTask {
   config: ConfigWithOnlyResources
+  recipe_enabled?: boolean | null
   recipe_most_recent_task?: MostRecentTask | null
 }
 


### PR DESCRIPTION
## Rationale

The failed tasks tab is used to check that every failed task has been handled, but two things it needs are missing. A paused recipe looks exactly like an enabled one, and the "Last run" column only looks at tasks, so a recipe that has already been requested again still shows its old failed run.

Fixes #1944

## Changes

`get_tasks` now returns `recipe_enabled` for each task, and when `fetch_most_recent_tasks` is set it replaces the recipe most recent task with its requested task when there is one. A recipe can have at most one requested task at a time (unique constraint on `requested_task.recipe_id`), so the requested task simply wins and there is no ordering to decide. It carries `is_requested` so the table shows it as plain text instead of linking to a task page that does not exist yet.

The pipeline table shows the same pause icon next to the recipe name as the recipe list does. Both parts are covered in `tests/routes/test_task.py`.