### PR TITLE
respect http schemes in s3 upload urls

### DIFF
--- a/backend/src/zimfarm_backend/common/upload.py
+++ b/backend/src/zimfarm_backend/common/upload.py
@@ -106,9 +106,19 @@ def generate_http_upload_url(uri: str, filename: str) -> str:
     url = urllib.parse.urlparse(uri)
     scheme = url.scheme
 
+    def get_url_scheme(url: urllib.parse.ParseResult) -> str:
+        if url.scheme.startswith("s3"):
+            if url.scheme.startswith("s3+https"):
+                return "https"
+            elif url.scheme.startswith("s3+http"):
+                return "http"
+        return "https"
+
     # If scheme is not http or https, convert to https
     if scheme not in ["http", "https"]:
-        url = urllib.parse.urlparse(uri.replace(url.scheme + ":", "https:"))
+        url = urllib.parse.urlparse(
+            uri.replace(url.scheme + ":", get_url_scheme(url) + ":")
+        )
 
     # Handle S3 scheme
     if scheme in ["s3", "s3+http", "s3+https"]:

--- a/backend/tests/test_upload.py
+++ b/backend/tests/test_upload.py
@@ -325,6 +325,12 @@ def test_build_task_upload_uris_no_secrets_in_uri():
             id="s3+https-uri-with-bucket",
         ),
         pytest.param(
+            "s3+http://s3.example.com/path?bucketName=my-bucket",
+            "file.zim",
+            "http://s3.example.com/path/my-bucket/file.zim",
+            id="s3+http-uri-with-bucket",
+        ),
+        pytest.param(
             "s3://s3.us-east-1.example.com/?bucketName=zim-bucket&token=secret",
             "wikipedia_en_all.zim",
             "https://s3.us-east-1.example.com/zim-bucket/wikipedia_en_all.zim",

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -88,7 +88,7 @@ services:
       INFORM_CMS: false
       ZIM_UPLOAD_URI: sftp://uploader@receiver:22/zim/
       LOGS_UPLOAD_URI: s3+http://minio:9000/?keyId=minio_key&secretAccessKey=minio_secret&bucketName=zimfarm-logs
-      ZIMCHECK_UPLOAD_URI: s3+http://minio:9000/?keyId=minio_key&secretAccessKey=minio_secret&bucketName=zimfarm-zimchecks
+      ZIMCHECK_RESULTS_UPLOAD_URI: s3+http://minio:9000/?keyId=minio_key&secretAccessKey=minio_secret&bucketName=zimfarm-zimchecks
       ARTIFACTS_UPLOAD_URI: s3+http://minio:9000/?keyId=minio_key&secretAccessKey=minio_secret&bucketName=zimfarm-artifacts
       ZIMCHECK_OPTION: --all
       INIT_USERNAME: admin


### PR DESCRIPTION
## Rationale
CMS dev environment now interacts end to end with zimfarm (https://github.com/openzim/cms/pull/469) but it sets it's s3 urls for zimcheck to start with `s3+http` because it's local minio cannot be accessed via https. This PR enhances the logic to transform upload urls to respect the underlying scheme of the upload URL. This prevents http errors that would arise trying when trying to download zimcheck files

## Changes
- respect http schems in s3 urls
- update zimcheck results upload url env in background tasks service (docker-compose)
