### PR TITLE
Rework slightly OAuth OIDC

### DIFF
--- a/INTEGRATORS_GUIDE.md
+++ b/INTEGRATORS_GUIDE.md
@@ -113,7 +113,6 @@ be injected at runtime so the browser can read it. This is typically done via th
 - `ZIMFARM_ZIM_DOWNLOAD_URL`: The URL of the server where the ZIMs are stored
 - `MONITORING_URL`: The URL of the [Netdata server](https://www.netdata.cloud/) where
   monitoring statistics are stored
-- `OAUTH_CLIENT_ID`: Oauth client ID for authentication (currently backed by [Ory.sh](https://www.ory.com/))
 
 See the `dev/frontend-ui/public/config.json` for some reasonable defaults of these variables.
 
@@ -313,25 +312,57 @@ and other resources.
 
 ### Authentication Methods
 
+#### Backend
+
 The backend supports multiple authentication modes, controlled by the `AUTH_MODES`
-environment variable (comma-separated list):
+environment variable (comma-separated list, possible to activate as many modes as required):
 
 - **`local`**: Traditional username/password authentication.
 - **`oauth-oidc`**: OpenID Connect authentication flow.
-- **`oauth-session`**: OAuth session-based authentication.
+- **`oauth-session`**: OAuth session-based authentication (the frontend transform a cookie-based session on identity provider into a JWT, which is then sent to the API).
 
-Both `oauth-oidc` and `oauth-session` are backed by [Ory.sh](https://www.ory.com/)
+Both `oauth-oidc` and `oauth-session` are backed by [Ory.sh](https://www.ory.com/) ATM.
 
-When integrating with an external identity provider (like Kiwix SSO), configure:
+When `oauth-oidc` and/or `oauth-session` are activated, you need to configure:
 
 - `OAUTH_JWKS_URI`: The JWKS endpoint for token verification
 - `OAUTH_ISSUER`: The OAuth issuer URL
-- `OAUTH_OIDC_CLIENT_ID`: Your OAuth client identifier
-- `CREATE_NEW_OAUTH_ACCOUNT`: Set to `"true"` to automatically create viewer accounts
-  for new OAuth users on first login
+- `OAUTH_CREATE_NEW_ACCOUNT`: Set to `"true"` to automatically create accounts whenever a new valid JWT is presented to the backend ; new account while have `VIEWER` role (no more permission than when not authenticated) ; this is convenient to then let admins grant proper role to this user through the UI
 
-Users authenticated via OAuth are identified by their `idp_sub` (identity provider subject ID).
+For `oauth-oidc` you also need to configure:
+- `OAUTH_OIDC_AUDIENCE`: The audience the JWT received by the API must contain
+- `OAUTH_OIDC_LOGIN_REQUIRE_2FA`: Set to "False" if users can be logged-in without 2FA (default: True)
+
+And for `oauth-session` you also need to configure:
+- `OAUTH_SESSION_AUDIENCE`: The audience the JWT received by the API must contain
+- `OAUTH_SESSION_LOGIN_REQUIRE_2FA`: Set to "False" if users can be logged-in without 2FA (default: True)
+
+OAuth identities are matched by the `sub` JWT claim which must match the value in `idp_sub` (identity provider subject ID) DB column.
 Local users authenticate with username/password and workers authenticate using SSH keys.
+
+OAuth supports both humans and machine-to-machine identities. Humans are detected by the fact that the JWT misses the `client_id` claim (occurs in OAuth session) or has the `profile` value in `scp` claim (occurs in OAuth OIDC). Machines JWTs are expected to have the `sub` equal to the `client_id` (this is enforced in the backend).
+
+Enforcement of 2FA is of-course possible only on human identities, not on machine-to-machine.
+
+#### Frontend
+
+The frontedn supports two authentication modes, controlled by the `LOGIN_MODES`
+setting (comma-separated list, possible to activate as many modes as required):
+
+- **`local`**: Username/password authentication towards Zimfarm API
+- **`oauth`**: External authentication to an IdP provider
+
+Both modes can be active, letting user decides how we wanna authenticate.
+
+When `oauth` mode is activated, it is necessary to choose between session flows (exchange IdP session for a JWT) and OIDC flows (standard OIDC exchanges) and designate :
+
+- **`OAUTH_MODE`**: either `session` or `oidc`
+- **`OAUTH_BASE_URL`**: base URL to the IdP, e.g. `https://ory.login.kiwix.org`
+
+When `oidc` mode is activated, you also need to configure:
+
+- **`OAUTH_CLIENT_ID`**: the frontend client ID
+- **`OAUTH_AUDIENCE`**: the audience to sign JWT for, i.e. the backend client ID
 
 ### Roles & Permissions
 

--- a/backend/src/zimfarm_backend/api/constants.py
+++ b/backend/src/zimfarm_backend/api/constants.py
@@ -23,18 +23,18 @@ OAUTH_JWKS_URI = getenv(
     default="https://ory.login.kiwix.org/.well-known/jwks.json",
 )
 OAUTH_ISSUER = getenv("OAUTH_ISSUER", default="https://ory.login.kiwix.org")
-OAUTH_OIDC_CLIENT_ID = getenv(
-    "OAUTH_OIDC_CLIENT_ID", default="38302485-7f3d-4e88-b1b3-ec02fb92ec8c"
+OAUTH_OIDC_AUDIENCE = getenv(
+    "OAUTH_OIDC_AUDIENCE", default="38302485-7f3d-4e88-b1b3-ec02fb92ec8c"
 )
 OAUTH_OIDC_LOGIN_REQUIRE_2FA = parse_bool(
     getenv("OAUTH_OIDC_LOGIN_REQUIRE_2FA", default="true")
 )
-OAUTH_SESSION_AUDIENCE_ID = getenv(
-    "OAUTH_SESSION_AUDIENCE_ID", default="bada4130-5143-4524-a0bb-0d69671beee2"
+OAUTH_SESSION_AUDIENCE = getenv(
+    "OAUTH_SESSION_AUDIENCE", default="bada4130-5143-4524-a0bb-0d69671beee2"
 )
 OAUTH_SESSION_LOGIN_REQUIRE_2FA = parse_bool(
     getenv("OAUTH_SESSION_LOGIN_REQUIRE_2FA", default="true")
 )
-CREATE_NEW_OAUTH_ACCOUNT = parse_bool(
-    getenv("CREATE_NEW_OAUTH_ACCOUNT", default="true")
+OAUTH_CREATE_NEW_ACCOUNT = parse_bool(
+    getenv("OAUTH_CREATE_NEW_ACCOUNT", default="true")
 )

--- a/backend/src/zimfarm_backend/api/routes/dependencies.py
+++ b/backend/src/zimfarm_backend/api/routes/dependencies.py
@@ -6,7 +6,7 @@ from jwt import exceptions as jwt_exceptions
 from sqlalchemy.orm import Session as OrmSession
 
 from zimfarm_backend.api.constants import (
-    CREATE_NEW_OAUTH_ACCOUNT,
+    OAUTH_CREATE_NEW_ACCOUNT,
 )
 from zimfarm_backend.api.routes.http_errors import ForbiddenError, UnauthorizedError
 from zimfarm_backend.api.token import JWTClaims, token_decoder
@@ -74,17 +74,11 @@ def get_current_account_or_none_with_session(
         if claims is None:
             return None
         account = get_account_by_id_or_none(session, account_id=claims.sub)
-        # If this is a kiwix token, we create a new account account
-        if account is None and CREATE_NEW_OAUTH_ACCOUNT:
-            if not claims.name:
-                raise UnauthorizedError(
-                    "Logged in user is unknown in Zimfarm and it is impossible to "
-                    "automatically create a new user because token is missing profile "
-                    "scope."
-                )
+        # If this is token for a new account, consider creating it
+        if account is None and OAUTH_CREATE_NEW_ACCOUNT:
             create_account(
                 session,
-                display_name=claims.name,
+                display_name=claims.name or str(claims.sub),
                 role=RoleEnum.VIEWER,
                 idp_sub=claims.sub,
             )

--- a/backend/src/zimfarm_backend/api/token.py
+++ b/backend/src/zimfarm_backend/api/token.py
@@ -3,7 +3,7 @@ import base64
 import binascii
 import datetime
 import uuid
-from typing import NamedTuple
+from typing import Any, NamedTuple
 
 import jwt
 from jwt import PyJWKClient
@@ -20,9 +20,9 @@ from zimfarm_backend.api.constants import (
     JWT_TOKEN_ISSUER,
     OAUTH_ISSUER,
     OAUTH_JWKS_URI,
-    OAUTH_OIDC_CLIENT_ID,
+    OAUTH_OIDC_AUDIENCE,
     OAUTH_OIDC_LOGIN_REQUIRE_2FA,
-    OAUTH_SESSION_AUDIENCE_ID,
+    OAUTH_SESSION_AUDIENCE,
     OAUTH_SESSION_LOGIN_REQUIRE_2FA,
 )
 from zimfarm_backend.common import getnow
@@ -46,6 +46,28 @@ class JWTClaims(BaseModel):
     iat: datetime.datetime
     sub: uuid.UUID = Field(alias="subject")
     name: str | None = Field(exclude=True, default=None)
+
+
+def oauth_token_is_from_human(decoded_token: dict[str, Any]) -> bool:
+    # detect if token is coming from a human or from a machine
+
+    # session JWT from humans have no "client_id" claim
+    # OIDC JWT from humans have "openid" in their "scp" claim
+    is_human = not decoded_token.get("client_id") or "openid" in decoded_token.get(
+        "scp", []
+    )
+
+    # check machine requirements are met (sub == client_id)
+    if not is_human:
+        sub = decoded_token.get("sub")
+        client_id = decoded_token.get("client_id")
+        if not client_id:
+            raise ValueError("Oauth client ID should not be empty for a machine.")
+        if client_id != sub:
+            raise ValueError(
+                "Oauth client ID does not match sub, while it should for a machine."
+            )
+    return is_human
 
 
 class TokenDecoder(abc.ABC):
@@ -226,38 +248,26 @@ class OAuthOIDCTokenDecoder(TokenDecoder):
             signing_key.key,
             algorithms=[signing_key.algorithm_name],
             issuer=OAUTH_ISSUER,
-            audience=OAUTH_OIDC_CLIENT_ID,
+            audience=OAUTH_OIDC_AUDIENCE,
             options={
                 "require": ["exp", "iat", "iss", "sub", "aud"],
             },
         )
 
+        # Check for 2FA requirement for human accounts.
         if (
-            client_id := decoded_token.get("client_id")
-        ) and client_id != decoded_token.get("sub"):
-            raise ValueError("Oauth client ID does not match.")
-
-        # Check for 2FA requirement only if client_id is not present in the token
-        # as those come from oauth2 clients and not real accounts.
-        # Ensure the account logged in with two authentication factors. As per Ory docs,
-        # "password", "code"  and "oidc" are categorized as first methods of login while
-        # "totp", "webauthn" and "lookup_secret" are second authentication methods
-        # https://www.ory.com/docs/kratos/mfa/overview#authenticator-assurance-level-aal
-        amr = set(decoded_token.get("amr", []))
-        if (
-            not decoded_token.get("client_id")
+            oauth_token_is_from_human(decoded_token)
             and OAUTH_OIDC_LOGIN_REQUIRE_2FA
-            and not (
-                {"password", "oidc", "code"} & amr
-                and {"webauthn", "lookup_secrets", "totp"} & amr
-            )
+            and decoded_token.get("ext", {}).get("kiwix-aal") != "aal2"
         ):
             raise ValueError(
                 "2FA authentication is mandatory on Zimfarm but it looks like you only "
                 "have one setup on Ory. Please, configure a second one on Ory at "
                 f"{OAUTH_ISSUER}/settings"
             )
-        return JWTClaims.model_validate(decoded_token)
+        claims = JWTClaims.model_validate(decoded_token)
+        claims.name = decoded_token.get("ext", {}).get("kiwix-name")
+        return claims
 
     @property
     def name(self) -> str:
@@ -279,9 +289,9 @@ class OAuthOIDCTokenDecoder(TokenDecoder):
         except Exception:
             return False
 
-        if payload.get(
-            "iss"
-        ) != OAUTH_ISSUER or OAUTH_OIDC_CLIENT_ID not in payload.get("aud", []):
+        if payload.get("iss") != OAUTH_ISSUER or OAUTH_OIDC_AUDIENCE not in payload.get(
+            "aud", []
+        ):
             return False
 
         return True
@@ -313,21 +323,15 @@ class OAuthSessionTokenDecoder(TokenDecoder):
             signing_key.key,
             algorithms=[signing_key.algorithm_name],
             issuer=OAUTH_ISSUER,
-            audience=OAUTH_SESSION_AUDIENCE_ID,
+            audience=OAUTH_SESSION_AUDIENCE,
             options={
                 "require": ["exp", "iat", "iss", "sub", "aud"],
             },
         )
 
+        # Check for 2FA requirement for human accounts.
         if (
-            client_id := decoded_token.get("client_id")
-        ) and client_id != decoded_token.get("sub"):
-            raise ValueError("Oauth client ID does not match.")
-
-        # Check for 2FA requirement only if client_id is not present in the token
-        # as those come from oauth2 clients and not real accounts
-        if (
-            not decoded_token.get("client_id")
+            oauth_token_is_from_human(decoded_token)
             and OAUTH_SESSION_LOGIN_REQUIRE_2FA
             and decoded_token.get("aal") != "aal2"
         ):
@@ -360,7 +364,7 @@ class OAuthSessionTokenDecoder(TokenDecoder):
 
         if payload.get(
             "iss"
-        ) != OAUTH_ISSUER or OAUTH_SESSION_AUDIENCE_ID not in payload.get("aud", []):
+        ) != OAUTH_ISSUER or OAUTH_SESSION_AUDIENCE not in payload.get("aud", []):
             return False
         return True
 

--- a/backend/tests/test_token_decoder.py
+++ b/backend/tests/test_token_decoder.py
@@ -3,8 +3,9 @@
 import base64
 import datetime
 from collections.abc import Callable
-from unittest.mock import MagicMock, patch
-from uuid import UUID
+from typing import Any
+from unittest.mock import patch
+from uuid import UUID, uuid4
 
 import jwt
 import pytest
@@ -27,9 +28,10 @@ FIRST_FACTOR_METHODS = ["password", "oidc"]
 SECOND_FACTOR_METHODS = ["webauthn", "lookup_secrets", "totp"]
 TEST_ISSUER = "https://foo.acme.org"
 TEST_CLIENT_ID = "d87a31d2-874e-44c4-9dc2-63fad523bf1b"
+TEST_AUDIENCE = "04e22317-4036-4b6c-9d27-a14c607dce08"
 
 
-def create_test_jwt_token(
+def create_test_jwt(
     issuer: str = TEST_ISSUER,
     client_id: str = TEST_CLIENT_ID,
     subject: str | None = None,
@@ -52,147 +54,134 @@ def create_test_jwt_token(
     return jwt.encode(payload, "test-secret", algorithm="HS256")
 
 
-def create_test_session_jwt_token(
+def get_test_session_jwt_payload(
     issuer: str = TEST_ISSUER,
-    audience_id: str = TEST_CLIENT_ID,
+    audience: str = TEST_AUDIENCE,
     subject: str | None = None,
     exp_delta: datetime.timedelta = datetime.timedelta(hours=1),
     aal: str | None = "aal2",
-) -> str:
+    name: str | None = "Test Account",
+    client_id: str | None = None,
+) -> dict[str, Any]:
     """Create a test JWT token for session authentication."""
     if subject is None:
         subject = str(UUID(int=0))
 
     now = getnow()
-    payload = {
+    payload: dict[str, Any] = {
         "iss": issuer,
         "sub": subject,
         "iat": int(now.timestamp()),
         "exp": int((now + exp_delta).timestamp()),
-        "aud": [audience_id],
-        "name": "Test Account",
+        "aud": [audience],
     }
+    if name:
+        payload["name"] = name
+    if client_id:
+        payload["client_id"] = client_id
     if aal:
         payload["aal"] = aal
 
+    return payload
+
+
+def get_test_oidc_jwt_payload(
+    issuer: str = TEST_ISSUER,
+    audience: str = TEST_AUDIENCE,
+    client_id: str = TEST_CLIENT_ID,
+    subject: str | None = None,
+    exp_delta: datetime.timedelta = datetime.timedelta(hours=1),
+    aal: str | None = "aal2",
+    name: str | None = "Test Account",
+) -> dict[str, Any]:
+
+    if subject is None:
+        subject = str(UUID(int=0))
+
+    now = getnow()
+
+    payload: dict[str, Any] = {
+        "iss": issuer,
+        "sub": subject,
+        "iat": int(now.timestamp()),
+        "exp": int((now + exp_delta).timestamp()),
+        "aud": [audience],
+        "client_id": client_id,
+        "ext": {},
+    }
+    if name:
+        # we are dealing with a human, it has an scp claim and kiwix-name ext claim
+        payload["ext"]["kiwix-name"] = name
+        payload["scp"] = ["openid", "offline"]
+    if aal:
+        payload["ext"]["kiwix-aal"] = aal
+
+    return payload
+
+
+def create_jwt_from_payload(payload: dict[str, Any]) -> str:
+    """Create a test JWT token from payload."""
     # Create a test token (unsigned for testing purposes)
     return jwt.encode(payload, "test-secret", algorithm="HS256")
 
 
-def test_verify_oidc_access_token_expired_token(
-    monkeypatch: pytest.MonkeyPatch,
-):
+def test_verify_oidc_jwt_expired():
     """Test that expired tokens raise ValueError."""
-    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
-    monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_OIDC_CLIENT_ID",
-        TEST_CLIENT_ID,
-    )
 
-    test_token = create_test_jwt_token()
-
-    mock_signing_key = MagicMock()
-    mock_signing_key.key = "test-key"
-
+    test_token = create_jwt_from_payload(get_test_oidc_jwt_payload())
     decoder = OAuthOIDCTokenDecoder()
 
     with (
-        patch.object(
-            decoder._jwks_client,
-            "get_signing_key_from_jwt",
-        ) as mock_get_key,
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
         patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
     ):
-        mock_get_key.return_value = mock_signing_key
         mock_decode.side_effect = jwt.ExpiredSignatureError("Token has expired")
 
         with pytest.raises(jwt.ExpiredSignatureError, match="Token has expired"):
             decoder.decode(test_token)
 
 
-def test_verify_oidc_access_token_with_2fa_enabled_and_valid_amr(
+def test_verify_oidc_jwt_with_2fa_enabled_and_two_factors(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Test successful verification when 2FA is enabled and account has both factors."""
-    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
-    monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_OIDC_CLIENT_ID",
-        TEST_CLIENT_ID,
-    )
     monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_OIDC_LOGIN_REQUIRE_2FA", True)
 
-    test_token = create_test_jwt_token()
-
-    # Mock the PyJWKClient and jwt.decode
-    mock_signing_key = MagicMock()
-    mock_signing_key.key = "test-key"
-
-    decoded_payload = {
-        "iss": TEST_ISSUER,
-        "sub": str(UUID(int=0)),
-        "aud": [TEST_CLIENT_ID],
-        "name": "Test Account",
-        "iat": int(getnow().timestamp()),
-        "exp": int((getnow() + datetime.timedelta(hours=1)).timestamp()),
-        "amr": ["password", "totp"],  # Both first and second factor
-    }
+    test_payload = get_test_oidc_jwt_payload()
+    test_token = create_jwt_from_payload(test_payload)
 
     decoder = OAuthOIDCTokenDecoder()
 
     with (
-        patch.object(
-            decoder._jwks_client,
-            "get_signing_key_from_jwt",
-        ) as mock_get_key,
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
         patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
     ):
-        mock_get_key.return_value = mock_signing_key
-        mock_decode.return_value = decoded_payload
+        mock_decode.return_value = test_payload
 
         result = decoder.decode(test_token)
 
-        assert result.iss == decoded_payload["iss"]
-        assert str(result.sub) == decoded_payload["sub"]
-        assert result.name == decoded_payload["name"]
+        assert result.iss == test_payload["iss"]
+        assert str(result.sub) == test_payload["sub"]
+        assert result.name == test_payload["ext"]["kiwix-name"]
 
 
-def test_verify_oidc_access_token_with_2fa_enabled_only_first_factor(
+def test_verify_oidc_jwt_with_2fa_enabled_and_only_first_factor(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Test verification fails when 2FA is enabled but only first factor is present."""
-    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
-    monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_OIDC_CLIENT_ID",
-        TEST_CLIENT_ID,
-    )
     monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_OIDC_LOGIN_REQUIRE_2FA", True)
 
-    test_token = create_test_jwt_token()
+    test_token = create_test_jwt()
 
-    mock_signing_key = MagicMock()
-    mock_signing_key.key = "test-key"
-
-    decoded_payload = {
-        "iss": TEST_ISSUER,
-        "sub": str(UUID(int=0)),
-        "aud": [TEST_CLIENT_ID],
-        "name": "Test Account",
-        "iat": int(getnow().timestamp()),
-        "exp": int((getnow() + datetime.timedelta(hours=1)).timestamp()),
-        "amr": ["password"],  # Only first factor
-    }
-
+    test_payload = get_test_oidc_jwt_payload(aal="aal1")
+    test_token = create_jwt_from_payload(test_payload)
     decoder = OAuthOIDCTokenDecoder()
 
     with (
-        patch.object(
-            decoder._jwks_client,
-            "get_signing_key_from_jwt",
-        ) as mock_get_key,
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
         patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
     ):
-        mock_get_key.return_value = mock_signing_key
-        mock_decode.return_value = decoded_payload
+        mock_decode.return_value = test_payload
 
         with pytest.raises(
             ValueError, match="2FA authentication is mandatory on Zimfarm"
@@ -200,172 +189,207 @@ def test_verify_oidc_access_token_with_2fa_enabled_only_first_factor(
             decoder.decode(test_token)
 
 
-def test_verify_kiwix_access_token_with_2fa_disabled_only_first_factor(
+def test_verify_oidc_jwt_with_2fa_enabled_and_missing_aal(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test verification fails when 2FA is enabled but aal info is missing."""
+    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_OIDC_LOGIN_REQUIRE_2FA", True)
+
+    test_token = create_test_jwt()
+
+    test_payload = get_test_oidc_jwt_payload(aal=None)
+    test_token = create_jwt_from_payload(test_payload)
+
+    decoder = OAuthOIDCTokenDecoder()
+
+    with (
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
+        patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
+    ):
+        mock_decode.return_value = test_payload
+
+        with pytest.raises(
+            ValueError, match="2FA authentication is mandatory on Zimfarm"
+        ):
+            decoder.decode(test_token)
+
+
+def test_verify_oidc_jwt_with_2fa_disabled_and_only_first_factor(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """
     Test that verification succeeds when 2FA is disabled even with only first factor
     """
-    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
-    monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_OIDC_CLIENT_ID",
-        TEST_CLIENT_ID,
-    )
     monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_OIDC_LOGIN_REQUIRE_2FA", False)
 
-    test_token = create_test_jwt_token()
-
-    mock_signing_key = MagicMock()
-    mock_signing_key.key = "test-key"
-
-    decoded_payload = {
-        "iss": TEST_ISSUER,
-        "sub": str(UUID(int=0)),
-        "aud": [TEST_CLIENT_ID],
-        "name": "Test Account",
-        "iat": int(getnow().timestamp()),
-        "exp": int((getnow() + datetime.timedelta(hours=1)).timestamp()),
-        "amr": ["password"],  # Only first factor, but 2FA is disabled
-    }
+    test_payload = get_test_oidc_jwt_payload(aal="aal1")
+    test_token = create_jwt_from_payload(test_payload)
 
     decoder = OAuthOIDCTokenDecoder()
 
     with (
-        patch.object(
-            decoder._jwks_client,
-            "get_signing_key_from_jwt",
-        ) as mock_get_key,
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
         patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
     ):
-        mock_get_key.return_value = mock_signing_key
-        mock_decode.return_value = decoded_payload
+        mock_decode.return_value = test_payload
 
         result = decoder.decode(test_token)
 
-        # The decoder returns a JWTClaims object, not the raw payload
-        assert result.iss == decoded_payload["iss"]
-        assert str(result.sub) == decoded_payload["sub"]
-        assert result.name == decoded_payload["name"]
+        assert result.iss == test_payload["iss"]
+        assert str(result.sub) == test_payload["sub"]
+        assert result.name == test_payload["ext"]["kiwix-name"]
 
 
-def test_verify_session_access_token_expired_token(
+def test_verify_oidc_jwt_with_2fa_disabled_and_missing_aal(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    """Test that expired session tokens raise ValueError."""
-    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
+    """
+    Test that verification succeeds when 2FA is disabled and aal is missing
+    """
+    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_OIDC_LOGIN_REQUIRE_2FA", False)
+
+    test_payload = get_test_oidc_jwt_payload(aal=None)
+    test_token = create_jwt_from_payload(test_payload)
+
+    decoder = OAuthOIDCTokenDecoder()
+
+    with (
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
+        patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
+    ):
+        mock_decode.return_value = test_payload
+
+        result = decoder.decode(test_token)
+
+        assert result.iss == test_payload["iss"]
+        assert str(result.sub) == test_payload["sub"]
+        assert result.name == test_payload["ext"]["kiwix-name"]
+
+
+def test_verify_oidc_jwt_from_machine_requires_no_2fa(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Test that verification succeeds when 2FA is enabled but token comes from a machine
+    """
     monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE_ID",
-        TEST_CLIENT_ID,
+        "zimfarm_backend.api.token.OAUTH_SESSION_LOGIN_REQUIRE_2FA", True
     )
 
-    test_token = create_test_session_jwt_token()
-
-    mock_signing_key = MagicMock()
-    mock_signing_key.key = "test-key"
+    test_payload = get_test_oidc_jwt_payload(
+        aal=None, name=None, client_id=TEST_CLIENT_ID, subject=TEST_CLIENT_ID
+    )
+    test_token = create_jwt_from_payload(test_payload)
 
     decoder = OAuthSessionTokenDecoder()
 
     with (
-        patch.object(
-            decoder._jwks_client,
-            "get_signing_key_from_jwt",
-        ) as mock_get_key,
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
         patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
     ):
-        mock_get_key.return_value = mock_signing_key
+        mock_decode.return_value = test_payload
+
+        result = decoder.decode(test_token)
+
+        # The decoder returns a JWTClaims object, not the raw payload
+        assert result.iss == test_payload["iss"]
+        assert str(result.sub) == test_payload["sub"]
+        assert not result.name
+
+
+def test_verify_oidc_jwt_from_machine_matches_sub(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Test that verification fails when token comes from a machine and client_id doesn't
+    match sub
+    """
+    monkeypatch.setattr(
+        "zimfarm_backend.api.token.OAUTH_SESSION_LOGIN_REQUIRE_2FA", False
+    )
+
+    test_payload = get_test_oidc_jwt_payload(
+        aal=None, name=None, client_id=TEST_CLIENT_ID, subject=str(uuid4())
+    )
+    test_token = create_jwt_from_payload(test_payload)
+
+    decoder = OAuthSessionTokenDecoder()
+
+    with (
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
+        patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
+    ):
+        mock_decode.return_value = test_payload
+
+        with pytest.raises(
+            ValueError,
+            match="Oauth client ID does not match sub, while it should for a machine",
+        ):
+            decoder.decode(test_token)
+
+
+def test_verify_session_jwt_expired():
+    """Test that expired session tokens raise ValueError."""
+
+    test_token = create_jwt_from_payload(get_test_session_jwt_payload())
+
+    decoder = OAuthSessionTokenDecoder()
+
+    with (
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
+        patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
+    ):
         mock_decode.side_effect = jwt.ExpiredSignatureError("Token has expired")
 
         with pytest.raises(jwt.ExpiredSignatureError, match="Token has expired"):
             decoder.decode(test_token)
 
 
-def test_verify_session_access_token_with_2fa_enabled_and_valid_aal(
+def test_verify_session_jwt_with_2fa_enabled_and_two_factors(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Test successful verification when 2FA is enabled and account has aal2."""
-    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
     monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE_ID",
-        TEST_CLIENT_ID,
-    )
-    monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_SESSION_LOGIN_REQUIRE_2FA", True
+        "zimfarm_backend.api.token.OAUTH_SESSION_LOGIN_REQUIRE_2FA",
+        True,
     )
 
-    test_token = create_test_session_jwt_token(aal="aal2")
-
-    # Mock the PyJWKClient and jwt.decode
-    mock_signing_key = MagicMock()
-    mock_signing_key.key = "test-key"
-
-    decoded_payload = {
-        "iss": TEST_ISSUER,
-        "sub": str(UUID(int=0)),
-        "aud": [TEST_CLIENT_ID],
-        "name": "Test Account",
-        "iat": int(getnow().timestamp()),
-        "exp": int((getnow() + datetime.timedelta(hours=1)).timestamp()),
-        "aal": "aal2",  # Authenticator Assurance Level 2 (2FA)
-    }
+    test_payload = get_test_session_jwt_payload()
+    test_token = create_jwt_from_payload(test_payload)
 
     decoder = OAuthSessionTokenDecoder()
 
     with (
-        patch.object(
-            decoder._jwks_client,
-            "get_signing_key_from_jwt",
-        ) as mock_get_key,
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
         patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
     ):
-        mock_get_key.return_value = mock_signing_key
-        mock_decode.return_value = decoded_payload
+        mock_decode.return_value = test_payload
 
         result = decoder.decode(test_token)
 
-        assert result.iss == decoded_payload["iss"]
-        assert str(result.sub) == decoded_payload["sub"]
-        assert result.name == decoded_payload["name"]
+        assert result.iss == test_payload["iss"]
+        assert str(result.sub) == test_payload["sub"]
+        assert result.name == test_payload["name"]
 
 
-def test_verify_session_access_token_with_2fa_enabled_only_aal1(
+def test_verify_session_jwt_with_2fa_enabled_and_only_first_factor(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """Test verification fails when 2FA is enabled but only aal1 is present."""
-    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
-    monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE_ID",
-        TEST_CLIENT_ID,
-    )
     monkeypatch.setattr(
         "zimfarm_backend.api.token.OAUTH_SESSION_LOGIN_REQUIRE_2FA", True
     )
 
-    test_token = create_test_session_jwt_token(aal="aal1")
-
-    mock_signing_key = MagicMock()
-    mock_signing_key.key = "test-key"
-
-    decoded_payload = {
-        "iss": TEST_ISSUER,
-        "sub": str(UUID(int=0)),
-        "aud": [TEST_CLIENT_ID],
-        "name": "Test Account",
-        "iat": int(getnow().timestamp()),
-        "exp": int((getnow() + datetime.timedelta(hours=1)).timestamp()),
-        "aal": "aal1",  # Only first factor (aal1)
-    }
+    test_payload = get_test_session_jwt_payload(aal="aal1")
+    test_token = create_jwt_from_payload(test_payload)
 
     decoder = OAuthSessionTokenDecoder()
 
     with (
-        patch.object(
-            decoder._jwks_client,
-            "get_signing_key_from_jwt",
-        ) as mock_get_key,
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
         patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
     ):
-        mock_get_key.return_value = mock_signing_key
-        mock_decode.return_value = decoded_payload
+        mock_decode.return_value = test_payload
 
         with pytest.raises(
             ValueError, match="2FA authentication is mandatory on Zimfarm"
@@ -373,149 +397,148 @@ def test_verify_session_access_token_with_2fa_enabled_only_aal1(
             decoder.decode(test_token)
 
 
-def test_verify_session_access_token_with_2fa_disabled_only_aal1(
+def test_verify_session_jwt_with_2fa_enabled_and_missing_aal(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Test verification fails when 2FA is enabled but aal info is missing."""
+    monkeypatch.setattr(
+        "zimfarm_backend.api.token.OAUTH_SESSION_LOGIN_REQUIRE_2FA", True
+    )
+
+    test_payload = get_test_session_jwt_payload(aal=None)
+    test_token = create_jwt_from_payload(test_payload)
+
+    decoder = OAuthSessionTokenDecoder()
+
+    with (
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
+        patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
+    ):
+        mock_decode.return_value = test_payload
+
+        with pytest.raises(
+            ValueError, match="2FA authentication is mandatory on Zimfarm"
+        ):
+            decoder.decode(test_token)
+
+
+def test_verify_session_jwt_with_2fa_disabled_and_only_aal1(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """
     Test that verification succeeds when 2FA is disabled even with only aal1
     """
-    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
-    monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE_ID",
-        TEST_CLIENT_ID,
-    )
     monkeypatch.setattr(
         "zimfarm_backend.api.token.OAUTH_SESSION_LOGIN_REQUIRE_2FA", False
     )
 
-    test_token = create_test_session_jwt_token(aal="aal1")
-
-    mock_signing_key = MagicMock()
-    mock_signing_key.key = "test-key"
-
-    decoded_payload = {
-        "iss": TEST_ISSUER,
-        "sub": str(UUID(int=0)),
-        "aud": [TEST_CLIENT_ID],
-        "name": "Test Account",
-        "iat": int(getnow().timestamp()),
-        "exp": int((getnow() + datetime.timedelta(hours=1)).timestamp()),
-        "aal": "aal1",  # Only first factor (aal1), but 2FA is disabled
-    }
+    test_payload = get_test_session_jwt_payload(aal="aal1")
+    test_token = create_jwt_from_payload(test_payload)
 
     decoder = OAuthSessionTokenDecoder()
 
     with (
-        patch.object(
-            decoder._jwks_client,
-            "get_signing_key_from_jwt",
-        ) as mock_get_key,
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
         patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
     ):
-        mock_get_key.return_value = mock_signing_key
-        mock_decode.return_value = decoded_payload
+        mock_decode.return_value = test_payload
 
         result = decoder.decode(test_token)
 
         # The decoder returns a JWTClaims object, not the raw payload
-        assert result.iss == decoded_payload["iss"]
-        assert str(result.sub) == decoded_payload["sub"]
-        assert result.name == decoded_payload["name"]
+        assert result.iss == test_payload["iss"]
+        assert str(result.sub) == test_payload["sub"]
+        assert result.name == test_payload["name"]
 
 
-def test_verify_session_access_token_with_client_id_requires_no_2fa(
+def test_verify_session_jwt_with_2fa_disabled_and_missing_aal(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """
-    Test that verification succeeds when 2FA is enabled but token contains client_id
+    Test that verification succeeds when 2FA is disabled even when aal is missing
     """
-    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
     monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE_ID",
-        TEST_CLIENT_ID,
-    )
-    monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_SESSION_LOGIN_REQUIRE_2FA", True
+        "zimfarm_backend.api.token.OAUTH_SESSION_LOGIN_REQUIRE_2FA", False
     )
 
-    test_token = create_test_session_jwt_token(aal=None)
-
-    mock_signing_key = MagicMock()
-    mock_signing_key.key = "test-key"
-    sub = str(UUID(int=0))
-
-    decoded_payload = {
-        "iss": TEST_ISSUER,
-        "aud": [TEST_CLIENT_ID],
-        "sub": sub,
-        "client_id": sub,
-        "name": "Test Account",
-        "iat": int(getnow().timestamp()),
-        "exp": int((getnow() + datetime.timedelta(hours=1)).timestamp()),
-    }
+    test_payload = get_test_session_jwt_payload(aal=None)
+    test_token = create_jwt_from_payload(test_payload)
 
     decoder = OAuthSessionTokenDecoder()
 
     with (
-        patch.object(
-            decoder._jwks_client,
-            "get_signing_key_from_jwt",
-        ) as mock_get_key,
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
         patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
     ):
-        mock_get_key.return_value = mock_signing_key
-        mock_decode.return_value = decoded_payload
+        mock_decode.return_value = test_payload
 
         result = decoder.decode(test_token)
 
         # The decoder returns a JWTClaims object, not the raw payload
-        assert result.iss == decoded_payload["iss"]
-        assert str(result.sub) == decoded_payload["sub"]
+        assert result.iss == test_payload["iss"]
+        assert str(result.sub) == test_payload["sub"]
+        assert result.name == test_payload["name"]
 
 
-def test_verify_session_access_token_verify_client_id_matches_sub(
+def test_verify_session_jwt_from_machine_requires_no_2fa(
     monkeypatch: pytest.MonkeyPatch,
 ):
     """
-    Test that verification succeeds when 2FA is enabled but token contains client_id
+    Test that verification succeeds when 2FA is enabled but token comes from a machine
     """
-    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
-    monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE_ID",
-        TEST_CLIENT_ID,
-    )
     monkeypatch.setattr(
         "zimfarm_backend.api.token.OAUTH_SESSION_LOGIN_REQUIRE_2FA", True
     )
 
-    test_token = create_test_session_jwt_token(aal=None)
-
-    mock_signing_key = MagicMock()
-    mock_signing_key.key = "test-key"
-
-    decoded_payload = {
-        "iss": TEST_ISSUER,
-        "aud": [TEST_CLIENT_ID],
-        "sub": str(UUID(int=0)),
-        "client_id": str(UUID(int=1)),
-        "name": "Test Account",
-        "iat": int(getnow().timestamp()),
-        "exp": int((getnow() + datetime.timedelta(hours=1)).timestamp()),
-    }
+    test_payload = get_test_session_jwt_payload(
+        aal=None, name=None, client_id=TEST_CLIENT_ID, subject=TEST_CLIENT_ID
+    )
+    test_token = create_jwt_from_payload(test_payload)
 
     decoder = OAuthSessionTokenDecoder()
 
     with (
-        patch.object(
-            decoder._jwks_client,
-            "get_signing_key_from_jwt",
-        ) as mock_get_key,
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
         patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
     ):
-        mock_get_key.return_value = mock_signing_key
-        mock_decode.return_value = decoded_payload
+        mock_decode.return_value = test_payload
 
-        with pytest.raises(ValueError, match="Oauth client ID does not match"):
+        result = decoder.decode(test_token)
+
+        # The decoder returns a JWTClaims object, not the raw payload
+        assert result.iss == test_payload["iss"]
+        assert str(result.sub) == test_payload["sub"]
+        assert not result.name
+
+
+def test_verify_session_jwt_from_machine_matches_sub(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """
+    Test that verification fails when token comes from a machine and client_id doesn't
+    match sub
+    """
+    monkeypatch.setattr(
+        "zimfarm_backend.api.token.OAUTH_SESSION_LOGIN_REQUIRE_2FA", False
+    )
+
+    test_payload = get_test_session_jwt_payload(
+        aal=None, name=None, client_id=TEST_CLIENT_ID, subject=str(uuid4())
+    )
+    test_token = create_jwt_from_payload(test_payload)
+
+    decoder = OAuthSessionTokenDecoder()
+
+    with (
+        patch.object(decoder._jwks_client, "get_signing_key_from_jwt"),
+        patch("zimfarm_backend.api.token.jwt.decode") as mock_decode,
+    ):
+        mock_decode.return_value = test_payload
+
+        with pytest.raises(
+            ValueError,
+            match="Oauth client ID does not match sub, while it should for a machine",
+        ):
             decoder.decode(test_token)
 
 
@@ -562,7 +585,7 @@ def test_local_token_decoder_can_decode_with_auth_mode_disabled(
     monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["oauth-oidc"])
 
     decoder = LocalTokenDecoder()
-    token = create_test_jwt_token(issuer="zimfarm_backend")
+    token = create_test_jwt(issuer="zimfarm_backend")
     assert decoder.can_decode(token) is False
 
 
@@ -574,7 +597,7 @@ def test_local_token_decoder_can_decode_with_correct_issuer(
     monkeypatch.setattr("zimfarm_backend.api.token.JWT_TOKEN_ISSUER", "zimfarm_backend")
 
     decoder = LocalTokenDecoder()
-    token = create_test_jwt_token(issuer="zimfarm_backend")
+    token = create_test_jwt(issuer="zimfarm_backend")
     assert decoder.can_decode(token) is True
 
 
@@ -586,7 +609,7 @@ def test_local_token_decoder_can_decode_with_wrong_issuer(
     monkeypatch.setattr("zimfarm_backend.api.token.JWT_TOKEN_ISSUER", "zimfarm_backend")
 
     decoder = LocalTokenDecoder()
-    token = create_test_jwt_token(issuer="wrong-issuer")
+    token = create_test_jwt(issuer="wrong-issuer")
     assert decoder.can_decode(token) is False
 
 
@@ -597,7 +620,7 @@ def test_oauth_oidc_token_decoder_can_decode_with_auth_mode_disabled(
     monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["local"])
 
     decoder = OAuthOIDCTokenDecoder()
-    token = create_test_jwt_token()
+    token = create_test_jwt()
     assert decoder.can_decode(token) is False
 
 
@@ -607,22 +630,11 @@ def test_oauth_oidc_token_decoder_can_decode_with_correct_issuer_and_audience(
     """Test OAuth OIDC token decoder can_decode with correct issuer and audience."""
     monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["oauth-oidc"])
     monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
-    monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_OIDC_CLIENT_ID", TEST_CLIENT_ID
-    )
+    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_OIDC_AUDIENCE", TEST_AUDIENCE)
 
     decoder = OAuthOIDCTokenDecoder()
 
-    now = getnow()
-    payload = {
-        "iss": TEST_ISSUER,
-        "sub": str(UUID(int=0)),
-        "iat": int(now.timestamp()),
-        "exp": int((now + datetime.timedelta(hours=1)).timestamp()),
-        "aud": [TEST_CLIENT_ID],
-    }
-    token = jwt.encode(payload, "test-secret", algorithm="HS256")
-
+    token = create_jwt_from_payload(get_test_oidc_jwt_payload())
     assert decoder.can_decode(token) is True
 
 
@@ -632,22 +644,11 @@ def test_oauth_oidc_token_decoder_can_decode_with_wrong_issuer(
     """Test OAuth OIDC token decoder can_decode with wrong issuer."""
     monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["oauth-oidc"])
     monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
-    monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_OIDC_CLIENT_ID", TEST_CLIENT_ID
-    )
+    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_OIDC_AUDIENCE", TEST_AUDIENCE)
 
     decoder = OAuthOIDCTokenDecoder()
 
-    now = getnow()
-    payload = {
-        "iss": "wrong-issuer",
-        "sub": str(UUID(int=0)),
-        "iat": int(now.timestamp()),
-        "exp": int((now + datetime.timedelta(hours=1)).timestamp()),
-        "aud": [TEST_CLIENT_ID],
-    }
-    token = jwt.encode(payload, "test-secret", algorithm="HS256")
-
+    token = create_jwt_from_payload(get_test_oidc_jwt_payload(issuer="wrong-issuer"))
     assert decoder.can_decode(token) is False
 
 
@@ -657,21 +658,12 @@ def test_oauth_oidc_token_decoder_can_decode_with_wrong_audience(
     """Test OAuth OIDC token decoder can_decode with wrong audience."""
     monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["oauth-oidc"])
     monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
-    monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_OIDC_CLIENT_ID", TEST_CLIENT_ID
-    )
+    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_OIDC_AUDIENCE", TEST_AUDIENCE)
 
     decoder = OAuthOIDCTokenDecoder()
-
-    now = getnow()
-    payload = {
-        "iss": TEST_ISSUER,
-        "sub": str(UUID(int=0)),
-        "iat": int(now.timestamp()),
-        "exp": int((now + datetime.timedelta(hours=1)).timestamp()),
-        "aud": ["wrong-audience"],
-    }
-    token = jwt.encode(payload, "test-secret", algorithm="HS256")
+    token = create_jwt_from_payload(
+        get_test_oidc_jwt_payload(audience="wrong-audience")
+    )
 
     assert decoder.can_decode(token) is False
 
@@ -683,7 +675,7 @@ def test_oauth_session_token_decoder_can_decode_with_auth_mode_disabled(
     monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["local"])
 
     decoder = OAuthSessionTokenDecoder()
-    token = create_test_session_jwt_token()
+    token = create_jwt_from_payload(get_test_session_jwt_payload())
     assert decoder.can_decode(token) is False
 
 
@@ -694,13 +686,11 @@ def test_oauth_session_token_decoder_can_decode_with_correct_issuer_and_audience
     monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["oauth-session"])
     monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
     monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE_ID", TEST_CLIENT_ID
+        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE", TEST_AUDIENCE
     )
 
     decoder = OAuthSessionTokenDecoder()
-    token = create_test_session_jwt_token(
-        issuer=TEST_ISSUER, audience_id=TEST_CLIENT_ID
-    )
+    token = create_jwt_from_payload(get_test_session_jwt_payload())
     assert decoder.can_decode(token) is True
 
 
@@ -711,13 +701,11 @@ def test_oauth_session_token_decoder_can_decode_with_wrong_issuer(
     monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["oauth-session"])
     monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
     monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE_ID", TEST_CLIENT_ID
+        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE", TEST_AUDIENCE
     )
 
     decoder = OAuthSessionTokenDecoder()
-    token = create_test_session_jwt_token(
-        issuer="wrong-issuer", audience_id=TEST_CLIENT_ID
-    )
+    token = create_jwt_from_payload(get_test_session_jwt_payload(issuer="wrong-issuer"))
     assert decoder.can_decode(token) is False
 
 
@@ -726,14 +714,14 @@ def test_oauth_session_token_decoder_can_decode_with_wrong_audience(
 ):
     """Test OAuth Session token decoder can_decode with wrong audience."""
     monkeypatch.setattr("zimfarm_backend.api.token.AUTH_MODES", ["oauth-session"])
-    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_ISSUER)
+    monkeypatch.setattr("zimfarm_backend.api.token.OAUTH_ISSUER", TEST_AUDIENCE)
     monkeypatch.setattr(
-        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE_ID", TEST_CLIENT_ID
+        "zimfarm_backend.api.token.OAUTH_SESSION_AUDIENCE", TEST_AUDIENCE
     )
 
     decoder = OAuthSessionTokenDecoder()
-    token = create_test_session_jwt_token(
-        issuer=TEST_ISSUER, audience_id="wrong-audience"
+    token = create_jwt_from_payload(
+        get_test_session_jwt_payload(audience="wrong-audience")
     )
     assert decoder.can_decode(token) is False
 

--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -48,11 +48,11 @@ services:
       API_ENDPOINT: http://localhost:8000/v2
       OAUTH_JWKS_URI: https://ory.login-staging.kiwix.org/.well-known/jwks.json
       OAUTH_ISSUER: https://ory.login-staging.kiwix.org
-      OAUTH_OIDC_CLIENT_ID: 38302485-7f3d-4e88-b1b3-ec02fb92ec8c
+      OAUTH_OIDC_AUDIENCE: c688aac9-df70-400b-9c1c-a08d6ae3d287
       OAUTH_OIDC_LOGIN_REQUIRE_2FA: true
-      OAUTH_SESSION_AUDIENCE_ID: 309693e7-ad5e-4379-bf93-ba89314230fd
+      OAUTH_SESSION_AUDIENCE: 309693e7-ad5e-4379-bf93-ba89314230fd
       OAUTH_SESSION_LOGIN_REQUIRE_2FA: true
-      CREATE_NEW_OAUTH_ACCOUNT: true
+      OAUTH_CREATE_NEW_ACCOUNT: true
       AUTH_MODES: local
 
     command:

--- a/dev/frontend-ui-dev/config-oidc.json
+++ b/dev/frontend-ui-dev/config-oidc.json
@@ -1,0 +1,11 @@
+{
+  "ZIMFARM_WEBAPI": "http://localhost:8000/v2",
+  "MONITORING_URL": "http://localhost:8004/v3",
+  "BLOB_MAX_SIZE": 1048576,
+  "DISABLE_WAREHOUSE_PATH": true,
+  "LOGIN_MODES": ["oauth"],
+  "OAUTH_MODE": "oidc",
+  "OAUTH_BASE_URL": "https://ory.login-staging.kiwix.org",
+  "OAUTH_CLIENT_ID": "1fec40e6-df3b-4633-9545-7a41612cb0d0",
+  "OAUTH_AUDIENCE": "c688aac9-df70-400b-9c1c-a08d6ae3d287"
+}

--- a/dev/frontend-ui-dev/config-session.json
+++ b/dev/frontend-ui-dev/config-session.json
@@ -3,5 +3,7 @@
   "MONITORING_URL": "http://localhost:8004/v3",
   "BLOB_MAX_SIZE": 1048576,
   "DISABLE_WAREHOUSE_PATH": true,
-  "LOGIN_MODES": ["local"]
+  "LOGIN_MODES": ["oauth"],
+  "OAUTH_MODE": "session",
+  "OAUTH_BASE_URL": "https://ory.login-staging.kiwix.org"
 }

--- a/frontend-ui/src/config.ts
+++ b/frontend-ui/src/config.ts
@@ -13,6 +13,7 @@ export interface Config {
   MONITORING_URL: string
   BLOB_MAX_SIZE: number
   OAUTH_CLIENT_ID: string
+  OAUTH_AUDIENCE: string
   OAUTH_BASE_URL: string
   OAUTH_MODE: 'oidc' | 'session'
   LOGIN_MODES: Array<string>

--- a/frontend-ui/src/services/auth/OAuthOIDCProvider.ts
+++ b/frontend-ui/src/services/auth/OAuthOIDCProvider.ts
@@ -36,8 +36,6 @@ export class OAuthOIDCProvider extends AuthProvider {
     this.storePKCEParams(codeVerifier, state)
 
     // Build authorization URL with all required OAuth2 parameters
-    // Note: Only requesting 'openid' and 'offline_access' as these are the only
-    // scopes supported by this Kiwix auth instance (profile and email are not available)
     const params = new URLSearchParams({
       client_id: this.config.clientId,
       response_type: 'code',
@@ -46,6 +44,7 @@ export class OAuthOIDCProvider extends AuthProvider {
       code_challenge: codeChallenge,
       code_challenge_method: 'S256',
       scope: 'openid profile offline_access',
+      audience: this.config.audience,
     })
 
     const authUrl = `${this.config.authorizeUrl}?${params.toString()}`
@@ -153,7 +152,7 @@ export class OAuthOIDCProvider extends AuthProvider {
     const response = await this.exchangeCodeForToken(code, pkceParams.verifier)
     const expiresTime = new Date(Date.now() + response.expires_in * 1000).toISOString()
     return {
-      access_token: response.id_token,
+      access_token: response.access_token,
       refresh_token: response.refresh_token,
       token_type: 'oauth',
       expires_time: expiresTime,

--- a/frontend-ui/src/services/auth/base.ts
+++ b/frontend-ui/src/services/auth/base.ts
@@ -3,6 +3,7 @@ import type { StoredToken } from '@/types/auth'
 
 export interface OAuthConfig {
   clientId: string
+  audience: string
   authorizeUrl: string
   tokenUrl: string
   userInfoUrl: string
@@ -17,6 +18,7 @@ export function getOAuthConfig(config: Config): OAuthConfig {
   const basePath = config.OAUTH_BASE_URL
   return {
     clientId: config.OAUTH_CLIENT_ID,
+    audience: config.OAUTH_AUDIENCE,
     authorizeUrl: `${basePath}/oauth2/auth`,
     tokenUrl: `${basePath}/oauth2/token`,
     userInfoUrl: `${basePath}/userinfo`,


### PR DESCRIPTION
## Rationale

Adapt many details to our new understanding and configuration of OAuth OIDC flows.

## Changes

- see https://github.com/kiwix/overview/issues/175
- backend:
  - always create an account when a JWT arrives with an unknown `sub` (even for machines): when `name` is unknown, simply use `sub` as display name until it gets updated by a Zimfarm admin
  - clarify variable namings
    - `OAUTH_OIDC_CLIENT_ID` => `OAUTH_OIDC_AUDIENCE` (we use it only to check audience in the JWT)
    - `OAUTH_SESSION_AUDIENCE_ID` => `OAUTH_SESSION_AUDIENCE` (audience ID is meaningless, it is an audience and a client ID ; choosing audience for clarity)
    - `CREATE_NEW_OAUTH_ACCOUNT` => `OAUTH_CREATE_NEW_ACCOUNT`
  - share code in both OAuth kinds to detect humans vs machine when receiving a JWT
  - OIDC: source aal and name from new `ext.kiwix-aal` and `ext.kiwix-name` claims
- frontend: 
  - OIDC: 
    - use the `access_token` instead of the `id_token` (save it in local storage + send it to the API)
    - when initiating the auth flow at `/oauth2/auth`, specify the `audience` (backend client ID) the access_token is intended for
    - add a new setting to allow the distinction between `OAUTH_CLIENT_ID`(the UI client ID) from `OAUTH_AUDIENCE` (the backend client ID)
- update integrator guide to clarify what needs to be configured in backend/frontend regarding OAuth
